### PR TITLE
feat(dictionary): add Fast Generate (Experimental) - parallel dictionary generation

### DIFF
--- a/.memory-bank/20251121-1530-abort-signal-infrastructure.md
+++ b/.memory-bank/20251121-1530-abort-signal-infrastructure.md
@@ -1,0 +1,265 @@
+# Abort Signal Infrastructure Implementation
+
+**Date**: 2025-11-21, 15:30
+**Context**: PR-31 Review Response (Fast Dictionary Generation)
+**Branch**: `epic/parallel-dictionary-generation-2025-11-20`
+**Status**: Backend infrastructure complete, UI exposure deferred
+
+---
+
+## Summary
+
+Implemented comprehensive request cancellation infrastructure in response to PR-31 review findings. Backend wiring is complete; UI exposure deferred to future epic.
+
+---
+
+## Problem Statement (from PR-31 Review)
+
+**Priority**: High
+**Finding**: "Fast gen block timeouts don't cancel real requests"
+
+> `DictionaryService.generateSingleBlock` races a timeout against `executeWithoutCapabilities`, but the underlying OpenRouter call is not aborted. A timed-out block will keep burning tokens while the retry runs, so concurrency and cost can double. The stack (`AIResourceOrchestrator.executeWithoutCapabilities` → `OpenRouterClient.createChatCompletion`) does not accept a `signal` or `timeoutMs`, so there's no cancellation support yet.
+
+**Codex Recommendation**:
+- Extend `AIOptions` and `OpenRouterClient.createChatCompletion` to accept `signal?: AbortSignal` (and optionally `timeoutMs?: number`)
+- Pass `signal` through `executeWithoutCapabilities`
+- Use an `AbortController` in `DictionaryService.generateSingleBlock`
+
+---
+
+## Implementation
+
+### 1. AIResourceOrchestrator - Unified Termination Context
+
+**File**: [src/application/services/AIResourceOrchestrator.ts](../src/application/services/AIResourceOrchestrator.ts)
+
+**Changes**:
+- Added `signal?: AbortSignal` and `timeoutMs?: number` to `AIOptions` interface
+- Implemented `createTerminationContext()` pattern for unified signal management
+- Handles both external signals (passed by caller) and internal timeouts
+- Proper cleanup via `termination.dispose()` (clears timers, removes event listeners)
+
+**Key Pattern** - `TerminationContext`:
+```typescript
+interface TerminationContext {
+  signal?: AbortSignal;
+  dispose: () => void;
+}
+
+private createTerminationContext(options: AIOptions): TerminationContext {
+  // If no signal or timeout, return no-op
+  if (!options.timeoutMs && !options.signal) {
+    return { signal: undefined, dispose: () => {} };
+  }
+
+  const controller = new AbortController();
+  let timeoutId: NodeJS.Timeout | undefined;
+  let externalAbortListener: (() => void) | undefined;
+
+  // Handle external signal (if provided)
+  if (options.signal) {
+    if (options.signal.aborted) {
+      abortWithReason(options.signal.reason ?? new Error('Aborted'));
+    } else {
+      externalAbortListener = () => abortWithReason(options.signal?.reason ?? new Error('Aborted'));
+      options.signal.addEventListener('abort', externalAbortListener, { once: true });
+    }
+  }
+
+  // Handle internal timeout (if specified)
+  if (options.timeoutMs) {
+    timeoutId = setTimeout(
+      () => abortWithReason(new Error(`Request timed out after ${options.timeoutMs}ms`)),
+      options.timeoutMs
+    );
+  }
+
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      if (externalAbortListener && options.signal) {
+        options.signal.removeEventListener('abort', externalAbortListener);
+      }
+    }
+  };
+}
+```
+
+**Applied to All Execution Modes**:
+- `executeWithCapabilities()` (multi-turn with guide requests)
+- `executeWithoutCapabilities()` (single-turn)
+- `executeContextWithResources()` (context generation with multi-file resources)
+
+Each mode:
+1. Creates termination context at start
+2. Passes signal through to `OpenRouterClient`
+3. Calls `termination.dispose()` in `finally` block
+
+### 2. OpenRouterClient - Native Fetch Abort
+
+**File**: [src/infrastructure/api/OpenRouterClient.ts](../src/infrastructure/api/OpenRouterClient.ts)
+
+**Changes**:
+- Added `signal?: AbortSignal` parameter to `createChatCompletion()` options
+- Passes signal to `fetch()` for native HTTP request abort
+- Fixed import order (moved `TokenUsage` import to top)
+
+**Before**:
+```typescript
+createChatCompletion(messages, { temperature, maxTokens })
+```
+
+**After**:
+```typescript
+createChatCompletion(messages, { temperature, maxTokens, signal })
+// Signal passed to fetch(): fetch(url, { ..., signal })
+```
+
+### 3. DictionaryService - Using timeoutMs
+
+**File**: [src/infrastructure/api/services/dictionary/DictionaryService.ts](../src/infrastructure/api/services/dictionary/DictionaryService.ts)
+
+**Changes**:
+- Removed manual `Promise.race()` pattern with `createTimeout()`
+- Uses `timeoutMs` option in `AIOptions` (surfaced through orchestrator)
+- Removed `createTimeout()` helper method (no longer needed)
+
+**Before**:
+```typescript
+const result = await Promise.race([
+  orchestrator.executeWithoutCapabilities(toolName, systemMessage, userMessage, {
+    temperature: 0.4,
+    maxTokens: 3500
+  }),
+  this.createTimeout(this.BLOCK_TIMEOUT)
+]);
+```
+
+**After**:
+```typescript
+const result = await orchestrator.executeWithoutCapabilities(
+  toolName,
+  systemMessage,
+  userMessage,
+  {
+    temperature: 0.4,
+    maxTokens: 3500,
+    timeoutMs: this.BLOCK_TIMEOUT // Orchestrator handles abort
+  }
+);
+```
+
+**Benefits**:
+- ✅ Cleaner code (no manual race conditions)
+- ✅ Proper abort handling (request actually cancelled, not orphaned)
+- ✅ Consistent pattern across all services
+
+---
+
+## Architectural Benefits
+
+### 1. Proper Separation of Concerns
+- **AIResourceOrchestrator**: Owns timeout logic and signal management
+- **OpenRouterClient**: Passes signal to fetch (no business logic)
+- **Services**: Use `timeoutMs` option (declarative, no manual racing)
+
+### 2. Composable Signals
+- External callers can pass their own `AbortSignal`
+- Internal `timeoutMs` creates a managed signal
+- Both can be combined (first to fire wins)
+- Proper cleanup prevents memory leaks
+
+### 3. Consistent Pattern
+- All three execution modes use same `createTerminationContext()` pattern
+- Easy to add cancellation to any AI request
+- Future UI cancel buttons can pass signals through
+
+### 4. Cost Control
+- Timed-out requests no longer burn tokens
+- Faster retry cycles (no orphaned requests)
+- Concurrency doesn't double during timeouts
+
+---
+
+## Testing
+
+**Manual Testing** (Fast Dictionary Generation):
+- ✅ Block timeouts abort OpenRouter request (verified in Output Channel logs)
+- ✅ Retry logic works correctly after abort
+- ✅ No orphaned requests consuming tokens
+- ✅ Error messages surface timeout reason
+
+**Edge Cases Handled**:
+- ✅ External signal already aborted when passed
+- ✅ Timeout fires before external signal
+- ✅ External signal fires before timeout
+- ✅ No signal or timeout (no-op path)
+- ✅ Cleanup in all code paths (try/finally)
+
+---
+
+## Documentation Updates
+
+**Also Fixed** (from PR-31 Low/Medium findings):
+- ✅ `CHANGELOG-DETAILED.md`: Fixed prompt path `dictionary-parallel/` → `dictionary-fast/`
+- ✅ `CHANGELOG-DETAILED.md`: Improved model recommendations wording
+- ✅ `README.md`: Polished feature description, consistent button label
+
+---
+
+## Future Work
+
+**Architecture Debt Created**: [2025-11-21-request-cancellation-ui-exposure.md](../.todo/architecture-debt/2025-11-21-request-cancellation-ui-exposure.md)
+
+**UI Layer Exposure** (deferred to v1.1+):
+1. Domain hooks: Add `cancelAnalysis()` / `cancelDictionary()` actions
+2. Backend handlers: Track `AbortController` per request ID
+3. Message contracts: Add `CANCEL_REQUEST` message type
+4. UI components: Add cancel buttons to loading indicators
+
+**Why Deferred**:
+- Backend infrastructure complete and working
+- UI exposure requires significant message contract changes
+- Not critical for v1.0 release (feature works with timeouts)
+- Better UX, but lower priority than testing/polish work
+
+---
+
+## PR-31 Review Status
+
+| Finding | Priority | Status |
+|---------|----------|--------|
+| Fast gen block timeouts don't cancel real requests | **High** | ✅ **RESOLVED** |
+| Docs path + wording mismatch | **Medium** | ✅ **RESOLVED** |
+| README copy inconsistency | **Low** | ✅ **RESOLVED** |
+
+**All findings addressed** in this commit batch.
+
+---
+
+## Related Files
+
+**Modified** (this commit):
+- [src/application/services/AIResourceOrchestrator.ts](../src/application/services/AIResourceOrchestrator.ts) - Termination context infrastructure
+- [src/infrastructure/api/OpenRouterClient.ts](../src/infrastructure/api/OpenRouterClient.ts) - Signal pass-through
+- [src/infrastructure/api/services/dictionary/DictionaryService.ts](../src/infrastructure/api/services/dictionary/DictionaryService.ts) - Use `timeoutMs`
+- [README.md](../README.md) - Documentation fixes
+- [docs/CHANGELOG-DETAILED.md](../docs/CHANGELOG-DETAILED.md) - Documentation fixes
+
+**Created** (this commit):
+- [.todo/architecture-debt/2025-11-21-request-cancellation-ui-exposure.md](../.todo/architecture-debt/2025-11-21-request-cancellation-ui-exposure.md) - Future work tracker
+- [.memory-bank/20251121-1530-abort-signal-infrastructure.md](20251121-1530-abort-signal-infrastructure.md) - This document
+
+---
+
+## Configuration Note
+
+**Concurrency Limit**: Reverted to `CONCURRENCY_LIMIT = 7` (from 14)
+- Conservative limit reduces OpenRouter rate limiting risk
+- Still achieves 2-4× speedup over sequential generation
+- Can be increased after more production testing
+
+---
+
+**Status**: ✅ Ready to commit and push

--- a/.todo/architecture-debt/2025-11-21-request-cancellation-ui-exposure.md
+++ b/.todo/architecture-debt/2025-11-21-request-cancellation-ui-exposure.md
@@ -1,0 +1,220 @@
+# Request Cancellation - UI Exposure
+
+**Date Identified**: 2025-11-21
+**Identified During**: PR-31 Review (Fast Dictionary Generation)
+**Priority**: Medium
+**Estimated Effort**: 4-6 hours
+
+## Problem
+
+Backend infrastructure for request cancellation is now implemented, but not exposed to the UI layer. Users cannot cancel long-running AI requests (analysis, dictionary generation, context generation, etc.).
+
+## Current Implementation (Infrastructure Complete)
+
+### ✅ Backend Wiring (PR-31 Changes)
+
+**AIResourceOrchestrator** ([src/application/services/AIResourceOrchestrator.ts](../../src/application/services/AIResourceOrchestrator.ts)):
+- Added `signal?: AbortSignal` and `timeoutMs?: number` to `AIOptions` interface
+- Implemented `createTerminationContext()` for unified signal management
+- Handles both external signals (passed in) and internal timeouts
+- Proper cleanup via `termination.dispose()` in all execution paths
+- Supports all three execution modes:
+  - `executeWithCapabilities()` (multi-turn with guides)
+  - `executeWithoutCapabilities()` (single-turn)
+  - `executeContextWithResources()` (context with multi-file resources)
+
+**OpenRouterClient** ([src/infrastructure/api/OpenRouterClient.ts](../../src/infrastructure/api/OpenRouterClient.ts)):
+- Added `signal?: AbortSignal` parameter to `createChatCompletion()`
+- Passes signal to `fetch()` for native HTTP abort
+
+**DictionaryService** ([src/infrastructure/api/services/dictionary/DictionaryService.ts](../../src/infrastructure/api/services/dictionary/DictionaryService.ts)):
+- Uses `timeoutMs` option for per-block timeouts (15s) in fast generation
+- No longer uses manual `Promise.race()` pattern
+
+### ❌ Missing: UI Layer Exposure
+
+Users have no way to:
+- Cancel an in-progress analysis
+- Stop a long-running dictionary generation
+- Abort a context generation request
+- Cancel a word search
+
+## Recommendation
+
+### Phase 1: Domain Hooks State Management
+
+Add cancellation state to domain hooks:
+
+```typescript
+// Example: useAnalysis.ts
+export interface AnalysisActions {
+  // ... existing actions
+  cancelAnalysis: () => void;
+}
+
+const useDictionaryReturn = () => {
+  const [abortController, setAbortController] = useState<AbortController | null>(null);
+
+  const cancelAnalysis = useCallback(() => {
+    if (abortController) {
+      abortController.abort(new Error('User cancelled'));
+      setAbortController(null);
+    }
+  }, [abortController]);
+
+  const handleAnalyzeRequest = useCallback((msg: MessageEnvelope<AnalyzeRequest>) => {
+    const controller = new AbortController();
+    setAbortController(controller);
+
+    // Send to backend with signal metadata
+    postMessage({
+      type: MessageType.ANALYZE,
+      payload: {
+        ...msg.payload,
+        abortSignalId: generateId() // backend tracks this
+      }
+    });
+  }, []);
+
+  return {
+    // ... state
+    cancelAnalysis,
+    // ... other actions
+  };
+};
+```
+
+### Phase 2: Backend Signal Registry
+
+Message handlers need to track signals by request ID:
+
+```typescript
+// MessageHandler or domain handlers
+private abortControllers = new Map<string, AbortController>();
+
+private handleAnalyzeRequest(message: MessageEnvelope<AnalyzeRequest>) {
+  const controller = new AbortController();
+  const requestId = message.payload.abortSignalId || generateId();
+
+  this.abortControllers.set(requestId, controller);
+
+  // Pass signal to orchestrator
+  orchestrator.executeWithCapabilities(toolName, systemPrompt, userMessage, {
+    signal: controller.signal,
+    // ... other options
+  }).finally(() => {
+    this.abortControllers.delete(requestId);
+  });
+}
+
+private handleCancelRequest(message: MessageEnvelope<CancelRequest>) {
+  const controller = this.abortControllers.get(message.payload.requestId);
+  if (controller) {
+    controller.abort(new Error('User cancelled'));
+  }
+}
+```
+
+### Phase 3: UI Components
+
+Add cancel buttons to loading indicators:
+
+```tsx
+// LoadingIndicator.tsx (or inline in tabs)
+<div className="loading-indicator">
+  <div className="loading-header">
+    <div className="spinner"></div>
+    <div className="loading-text">
+      <div>{statusMessage || defaultMessage}</div>
+    </div>
+    {onCancel && (
+      <button onClick={onCancel} className="cancel-button">
+        Cancel
+      </button>
+    )}
+  </div>
+  <LoadingWidget />
+</div>
+```
+
+### Phase 4: Message Contracts
+
+Add cancellation message types:
+
+```typescript
+// src/shared/types/messages/base.ts or domain-specific files
+export interface CancelRequest {
+  requestId: string;
+  domain: 'analysis' | 'dictionary' | 'context' | 'search' | 'metrics';
+}
+
+// Add to MessageType enum
+export enum MessageType {
+  // ... existing types
+  CANCEL_REQUEST = 'cancelRequest',
+}
+```
+
+## Impact
+
+### Benefits
+- ✅ Better UX: users can stop expensive/long requests
+- ✅ Cost control: avoid burning tokens on unwanted requests
+- ✅ Infrastructure ready: backend wiring complete
+- ✅ Clean architecture: proper signal propagation through layers
+
+### Risks
+- ⚠️ Complexity: need to track request IDs across webview ↔ extension boundary
+- ⚠️ State management: ensure cleanup on abort (no orphaned promises)
+- ⚠️ Race conditions: cancel arriving after completion
+
+## Related Work
+
+- **PR-31 Review** ([docs/pr/pr-31-review-codex.md](../../docs/pr/pr-31-review-codex.md)): Identified missing cancellation support
+- **Loading Widget Status Integration** ([2025-11-19-loading-widget-status-integration.md](2025-11-19-loading-widget-status-integration.md)): Proposes extracting `LoadingIndicator` component (good place for cancel button)
+- **ADR: Cross-Cutting UI Improvements** (if exists): May cover cancellation UX patterns
+
+## Files to Update
+
+### Domain Hooks (add cancellation actions)
+- `src/presentation/webview/hooks/domain/useAnalysis.ts`
+- `src/presentation/webview/hooks/domain/useDictionary.ts`
+- `src/presentation/webview/hooks/domain/useContext.ts`
+- `src/presentation/webview/hooks/domain/useSearch.ts`
+- `src/presentation/webview/hooks/domain/useMetrics.ts`
+
+### Backend Handlers (add signal registry + cancel handler)
+- `src/application/handlers/domain/AnalysisHandler.ts`
+- `src/application/handlers/domain/DictionaryHandler.ts`
+- `src/application/handlers/domain/ContextHandler.ts`
+- `src/application/handlers/domain/SearchHandler.ts`
+- `src/application/handlers/domain/MetricsHandler.ts`
+
+### Message Contracts
+- `src/shared/types/messages/base.ts` (add `CANCEL_REQUEST` type)
+- Create `CancelRequest` interface in appropriate domain file
+
+### UI Components
+- `src/presentation/webview/components/AnalysisTab.tsx`
+- `src/presentation/webview/components/UtilitiesTab.tsx`
+- `src/presentation/webview/components/SearchTab.tsx`
+- `src/presentation/webview/components/MetricsTab.tsx`
+
+## When to Fix
+
+**Medium priority** - Nice UX improvement, infrastructure ready, but not critical for v1.0.
+
+**Suggested Timing**: v1.1 or v1.2 after higher-priority items (Settings Hooks Unit Tests, StandardsService refactor).
+
+---
+
+## Implementation Notes
+
+**Backend Infrastructure Complete** (2025-11-21):
+- ✅ `AIOptions` supports `signal` and `timeoutMs`
+- ✅ `AIResourceOrchestrator.createTerminationContext()` handles both external signals and timeouts
+- ✅ `OpenRouterClient.createChatCompletion()` passes signal to fetch
+- ✅ Proper cleanup with `termination.dispose()` in all execution paths
+- ✅ DictionaryService uses `timeoutMs` for fast generation block timeouts
+
+**Remaining Work**: UI layer exposure only (Phases 1-4 above).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 For detailed technical documentation, see [docs/CHANGELOG-DETAILED.md](docs/CHANGELOG-DETAILED.md).
 
+## [1.1.1] - 2025-11-20
+
+### Added
+
+- **⚡ Fast Generate (Experimental)**: Parallel dictionary generation using concurrent API calls (2-4× faster)
+  - 14 dictionary blocks generated in parallel with 7-thread concurrency
+  - Progress bar UI with real-time updates
+  - Token usage aggregation across all API calls
+  - Fan-out pattern using `p-limit` for rate limiting
+
+### Fixed
+
+- Error recovery for fast generation loading state (UI no longer gets stuck on API errors)
+- Added loading widget consistency for fast generation loading indicator
+
+---
+
 ## [1.1.0] - 2025-11-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@
 
 ---
 
-## 🎉 What's New in v1.1.0
-
-> **✨ Context Search** - NEW AI-powered semantic word discovery! Search your manuscript by category or concept instead of exact words.
+## 🎉 What's New in v1.1.0 & v1.1.1
+> **✨ Context Search** - AI-powered semantic word discovery! Search your manuscript by category or concept instead of exact words. 
 >
-> Try queries like `[clothing]`, `[emotions]`, or `[color red]` to discover all related words you've used. [Learn more →](#context-search-ai-powered)
+> Try queries like `[clothing]`, `[emotions]`, or `[color red]`. 
+> [Learn more →](#context-search-ai-powered)
 >
-> **📋 Full Changelog** - See [CHANGELOG.md](CHANGELOG.md) for complete v1.1.0 release notes including testing framework, custom model support, and bug fixes.
+> **⚡ Fast Dictionary Generate (Experimental)** - NEW parallel dictionary generation! Generate dictionary entries 2-4× faster using concurrent API calls. Look for the "Fast Generate (Experimental)" button in the Dictionary tab. Works best with Newest Models ( Haiku 4.5, Sonnet 4.5, Gemini Flash 2.5, GPT **5.1**)
+>
+> **📋 Full Changelog** - See [CHANGELOG.md](CHANGELOG.md) for complete release notes including testing framework, custom model support, and bug fixes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 > Try queries like `[clothing]`, `[emotions]`, or `[color red]`. 
 > [Learn more →](#context-search-ai-powered)
 >
-> **⚡ Fast Dictionary Generate (Experimental)** - NEW parallel dictionary generation! Generate dictionary entries 2-4× faster using concurrent API calls. Look for the "Fast Generate (Experimental)" button in the Dictionary tab. Works best with Newest Models ( Haiku 4.5, Sonnet 4.5, Gemini Flash 2.5, GPT **5.1**)
+> **⚡ Fast Generate (Experimental)** - NEW parallel dictionary generation! Generate dictionary entries 2-4× faster using concurrent API calls. Look for the "Fast Generate (Experimental)" button in the Dictionary tab. Works best with newer models such as Haiku 4.5, Sonnet 4.5, Gemini Flash 2.5, GPT **5.1**.
 >
 > **📋 Full Changelog** - See [CHANGELOG.md](CHANGELOG.md) for complete release notes including testing framework, custom model support, and bug fixes.
 

--- a/docs/CHANGELOG-DETAILED.md
+++ b/docs/CHANGELOG-DETAILED.md
@@ -31,7 +31,7 @@ Generate dictionary entries 2-4× faster by running multiple API calls in parall
 - **Token Aggregation**: Total token usage calculated across all parallel API calls
 
 **Technical Implementation:**
-- Fan-out pattern: Single request spawns 14 parallel API calls
+- Fan-out pattern: Single request spawns 7 parallel API calls
 - Each block has its own focused prompt for better quality
 - Results assembled in deterministic order regardless of completion order
 - Graceful error handling: Partial failures don't crash the entire generation
@@ -51,7 +51,7 @@ Generate dictionary entries 2-4× faster by running multiple API calls in parall
 
 **User Notes:**
 - Marked as "Experimental" - some models may struggle with high concurrency
-- Works best with fast models (Claude Haiku, GPT-4o-mini)
+- Works best with fast models Works best with Newest Models ( Haiku 4.5, Sonnet 4.5, Gemini Flash 2.5, GPT **5.1**)
 - Uses same API key and model as regular dictionary lookup
 
 ---

--- a/docs/CHANGELOG-DETAILED.md
+++ b/docs/CHANGELOG-DETAILED.md
@@ -47,11 +47,11 @@ Generate dictionary entries 2-4× faster by running multiple API calls in parall
 - `src/shared/types/messages/dictionary.ts` - Added fast generation message types
 - `src/presentation/webview/hooks/domain/useDictionary.ts` - Added fast generation state
 - `src/presentation/webview/components/UtilitiesTab.tsx` - Added Fast Generate button and progress UI
-- `resources/system-prompts/dictionary-parallel/` - 14 block-specific prompt files
+- `resources/system-prompts/dictionary-fast/` - 14 block-specific prompt files
 
 **User Notes:**
 - Marked as "Experimental" - some models may struggle with high concurrency
-- Works best with fast models Works best with Newest Models ( Haiku 4.5, Sonnet 4.5, Gemini Flash 2.5, GPT **5.1**)
+- Works best with newer fast models (Haiku 4.5, Sonnet 4.5, Gemini Flash 2.5, GPT **5.1**)
 - Uses same API key and model as regular dictionary lookup
 
 ---

--- a/docs/CHANGELOG-DETAILED.md
+++ b/docs/CHANGELOG-DETAILED.md
@@ -5,6 +5,78 @@ All notable changes to the Prose Minion VSCode extension will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2025-11-20
+
+### Overview
+
+This patch release introduces **Fast Generate (Experimental)**, a new parallel dictionary generation feature that generates dictionary entries 2-4× faster using concurrent API calls.
+
+**Key Highlights:**
+- ⚡ **Fast Generate** - Experimental parallel dictionary generation
+- 🔧 **Bug Fixes** - Error recovery and loading state improvements
+
+---
+
+### Features
+
+#### ⚡ Fast Generate - Parallel Dictionary Generation (Experimental)
+
+**What It Does:**
+Generate dictionary entries 2-4× faster by running multiple API calls in parallel.
+
+**How It Works:**
+- **14 Dictionary Blocks**: Definition, pronunciation, parts of speech, etymology, synonyms, antonyms, usage examples, collocations, register notes, common mistakes, idioms, word family, mnemonic, and summary
+- **Parallel Execution**: 7-thread concurrency limit (configurable) using `p-limit`
+- **Progress Bar**: Real-time progress indicator showing completed blocks
+- **Token Aggregation**: Total token usage calculated across all parallel API calls
+
+**Technical Implementation:**
+- Fan-out pattern: Single request spawns 14 parallel API calls
+- Each block has its own focused prompt for better quality
+- Results assembled in deterministic order regardless of completion order
+- Graceful error handling: Partial failures don't crash the entire generation
+
+**UI Changes:**
+- New "⚡ Fast Generate (Experimental)" button in Dictionary tab
+- Progress bar shows `X / 14 blocks` completion
+- Loading widget displays during generation
+
+**Files Added/Modified:**
+- `src/infrastructure/api/services/dictionary/DictionaryService.ts` - Added `generateParallelDictionary()` method
+- `src/application/handlers/domain/DictionaryHandler.ts` - Added fast generation message handler
+- `src/shared/types/messages/dictionary.ts` - Added fast generation message types
+- `src/presentation/webview/hooks/domain/useDictionary.ts` - Added fast generation state
+- `src/presentation/webview/components/UtilitiesTab.tsx` - Added Fast Generate button and progress UI
+- `resources/system-prompts/dictionary-parallel/` - 14 block-specific prompt files
+
+**User Notes:**
+- Marked as "Experimental" - some models may struggle with high concurrency
+- Works best with fast models (Claude Haiku, GPT-4o-mini)
+- Uses same API key and model as regular dictionary lookup
+
+---
+
+### Fixed
+
+#### Error Recovery for Fast Generation
+- **Issue**: When fast generation encountered an API error, the `isFastGenerating` state wasn't being reset, leaving the UI stuck in loading state
+- **Fix**: Added `setFastGenerating(false)` to error handler in App.tsx
+- **Impact**: UI now correctly recovers from errors during fast generation
+
+#### Loading Widget Consistency
+- **Issue**: Fast generation loading indicator was missing the animated LoadingWidget that regular dictionary lookup has
+- **Fix**: Added `<LoadingWidget />` component to fast generation loading section
+- **Impact**: Consistent visual feedback during all dictionary operations
+
+---
+
+### References
+
+- ADR: [docs/adr/2025-11-20-parallel-dictionary-generation.md](docs/adr/2025-11-20-parallel-dictionary-generation.md)
+- Epic: [.todo/epics/epic-parallel-dictionary-generation-2025-11-20/](.todo/epics/epic-parallel-dictionary-generation-2025-11-20/)
+
+---
+
 ## [1.1.0] - 2025-11-20
 
 ### Overview

--- a/docs/pr/pr-31-review-codex.md
+++ b/docs/pr/pr-31-review-codex.md
@@ -1,0 +1,13 @@
+# PR-31 Review (Codex)
+
+Date: 2025-11-20
+Reviewer: Codex (GPT-5)
+
+## Findings
+- **High – Fast gen block timeouts don’t cancel real requests**: `DictionaryService.generateSingleBlock` races a timeout against `executeWithoutCapabilities`, but the underlying OpenRouter call is not aborted. A timed-out block will keep burning tokens while the retry runs, so concurrency and cost can double. The stack (`AIResourceOrchestrator.executeWithoutCapabilities` → `OpenRouterClient.createChatCompletion`) does not accept a `signal` or `timeoutMs`, so there’s no cancellation support yet.
+- **Medium – Docs path + wording mismatch**: `docs/CHANGELOG-DETAILED.md` claims prompts live under `resources/system-prompts/dictionary-parallel/` and repeats the “Works best…” line. Actual code uses `resources/system-prompts/dictionary-fast/…`, so the doc misleads contributors.
+- **Low – README copy inconsistency**: The “Fast Dictionary Generate” blurb doesn’t match the UI label (“Fast Generate (Experimental)”) and crams model guidance into the same line. Worth polishing for clarity but not blocking.
+
+## Recommendations
+- Add abortable requests: extend `AIOptions` and `OpenRouterClient.createChatCompletion` to accept `signal?: AbortSignal` (and optionally `timeoutMs?: number`), pass `signal` through `executeWithoutCapabilities`, and use an `AbortController` in `DictionaryService.generateSingleBlock` (new controller per attempt, clear timer, abort on timeout). If you add `timeoutMs`, set a timer to call `abort`.
+- Update docs: point the prompt path to `resources/system-prompts/dictionary-fast/` and fix the duplicated “Works best…” sentence. Optionally align README wording to the button label and move model advice to its own sentence.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/marked": "^6.0.0",
         "marked": "^16.4.1",
+        "p-limit": "^7.2.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "wink-pos-tagger": "^2.2.2"
@@ -19,6 +20,7 @@
         "@testing-library/react-hooks": "^8.0.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^18.0.0",
+        "@types/p-limit": "^2.1.0",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
         "@types/vscode": "^1.75.0",
@@ -2013,6 +2015,13 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/p-limit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/p-limit/-/p-limit-2.1.0.tgz",
+      "integrity": "sha512-qorhClbttP1axgmbMP3rozj6WF6TPAOeKmW3qyC3I7hAgPMvH76Avt/F3seqEciacgLWk8pQxP9Rtde4BnBEpA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -4881,6 +4890,35 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
@@ -4997,6 +5035,22 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus/node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5010,6 +5064,19 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-cli": {
@@ -5800,6 +5867,22 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-runner/node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5850,6 +5933,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-runtime": {
@@ -6860,14 +6956,15 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.2.0.tgz",
+      "integrity": "sha512-ATHLtwoTNDloHRFFxFJdHnG6n2WUeFjaR8XQMFdKIv0xkXjrER8/iG9iu265jOM95zXHAfv9oTkqhrfbIzosrQ==",
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "yocto-queue": "^1.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6880,6 +6977,35 @@
       "dependencies": {
         "p-limit": "^3.0.2"
       },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -9092,11 +9218,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prose-minion",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prose-minion",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@types/marked": "^6.0.0",
@@ -20,7 +20,6 @@
         "@testing-library/react-hooks": "^8.0.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^18.0.0",
-        "@types/p-limit": "^2.1.0",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
         "@types/vscode": "^1.75.0",
@@ -2015,13 +2014,6 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
-    },
-    "node_modules/@types/p-limit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/p-limit/-/p-limit-2.1.0.tgz",
-      "integrity": "sha512-qorhClbttP1axgmbMP3rozj6WF6TPAOeKmW3qyC3I7hAgPMvH76Avt/F3seqEciacgLWk8pQxP9Rtde4BnBEpA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",

--- a/package.json
+++ b/package.json
@@ -449,6 +449,7 @@
     "@testing-library/react-hooks": "^8.0.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^18.0.0",
+    "@types/p-limit": "^2.1.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/vscode": "^1.75.0",
@@ -472,6 +473,7 @@
   "dependencies": {
     "@types/marked": "^6.0.0",
     "marked": "^16.4.1",
+    "p-limit": "^7.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "wink-pos-tagger": "^2.2.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prose-minion",
   "displayName": "Prose Minion: Writing Toolkit",
   "description": "AI prose analysis and writing assistant for fiction authors. Dialogue suggestions, context-aware dictionary, comprehensive prose metrics, style flags, word frequency, and manuscript search. Metrics/search work offline—no API key needed.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "OkeyLanders",
   "repository": {
@@ -449,7 +449,6 @@
     "@testing-library/react-hooks": "^8.0.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^18.0.0",
-    "@types/p-limit": "^2.1.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/vscode": "^1.75.0",

--- a/resources/system-prompts/dictionary-fast/00-base-instructions.md
+++ b/resources/system-prompts/dictionary-fast/00-base-instructions.md
@@ -1,0 +1,21 @@
+# Dictionary Utility — Block Generation Base Instructions
+
+You are the `dictionary-utility` generating a SINGLE SECTION of a dictionary entry for creative writers.
+
+## Critical Rules
+1. Generate ONLY the section specified in the task instruction
+2. Do NOT include preambles, closings, or other sections
+3. Preserve the section icon and heading exactly as shown
+4. Output markdown format matching the reference style
+5. Stay under ~150 words unless the section requires more detail
+
+## Style Guidelines
+- Keep content scannable with bullets or compact paragraphs
+- When listing words, avoid duplicates and order by usefulness
+- Use italics for example sentences and register labels
+- Assume the audience is a novelist seeking nuance, tonal control, and sensory precision
+
+## Safety & Accuracy
+- If information is uncertain, mark it with "(verify)" or similar
+- Do not invent faux citations
+- Clearly attribute when referencing well-known sources

--- a/resources/system-prompts/dictionary-fast/01-definition-block.md
+++ b/resources/system-prompts/dictionary-fast/01-definition-block.md
@@ -1,0 +1,17 @@
+# Block: Definition
+
+Generate ONLY the **📕 Definition** section.
+
+## Output Format
+```
+# 📕 Definition
+[Canonical definition(s) in elegant but concise prose. 2-4 definitions ordered by relevance to creative writing.]
+```
+
+## Reference Example
+```
+# 📕 Definition
+To compress or crush something with force, producing a sharp, brittle sound; to grind or chew with a noisy crushing action; to process data or numbers intensively; to experience severe pressure or constraint.
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 📕 Definition".

--- a/resources/system-prompts/dictionary-fast/02-pronunciation-block.md
+++ b/resources/system-prompts/dictionary-fast/02-pronunciation-block.md
@@ -1,0 +1,25 @@
+# Block: Pronunciation
+
+Generate ONLY the **🔈 Pronunciation** section.
+
+## Output Format
+```
+# 🔈 Pronunciation
+- IPA: `/[phonetic]/`
+- Phonetic: *[RESPELLING]*
+- Syllables: [count] (*[broken-down]*)
+- Stress: [stress pattern]
+- Audio cues: [description of sound qualities]
+```
+
+## Reference Example
+```
+# 🔈 Pronunciation
+- IPA: `/krʌntʃt/`
+- Phonetic: *KRUNCHT*
+- Syllables: 1 (*crunched*)
+- Stress: Single stressed syllable
+- Audio cues: Hard consonant cluster opening, brief vowel, terminal affricate
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🔈 Pronunciation".

--- a/resources/system-prompts/dictionary-fast/03-parts-of-speech-block.md
+++ b/resources/system-prompts/dictionary-fast/03-parts-of-speech-block.md
@@ -1,0 +1,19 @@
+# Block: Parts of Speech
+
+Generate ONLY the **🧩 Parts of Speech** section.
+
+## Output Format
+```
+# 🧩 Parts of Speech
+- **[Part of speech]** ([descriptor]): [brief explanation]
+- **[Part of speech]** ([descriptor]): [brief explanation]
+```
+
+## Reference Example
+```
+# 🧩 Parts of Speech
+- **Verb** (past tense/past participle): primary inflection of "crunch"
+- **Adjective** (informal): denotes a compressed, processed, or heavily analyzed state
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🧩 Parts of Speech".

--- a/resources/system-prompts/dictionary-fast/04-sense-explorer-block.md
+++ b/resources/system-prompts/dictionary-fast/04-sense-explorer-block.md
@@ -1,0 +1,30 @@
+# Block: Sense Explorer
+
+Generate ONLY the **🔍 Sense Explorer** section.
+
+## Output Format
+For each sense (2-4 senses typically):
+```
+# 🔍 Sense Explorer
+1. **[Sense label]**
+   - *Definition*: [Clear definition]
+   - *Example*: *[Example sentence in italics]*
+   - *Synonyms*: [8-12 synonyms, comma-separated]
+   - *Antonyms*: [4-6 antonyms, comma-separated]
+   - *Nuance*: [Brief note on usage nuance]
+
+2. **[Next sense]**
+   ...
+```
+
+## Reference Example (first sense only)
+```
+1. **Physical crushing with sound**
+   - *Definition*: Compressed or crushed something brittle, producing characteristic breaking sounds.
+   - *Example*: *The frost-hardened grass crunched beneath their boots like breaking glass.*
+   - *Synonyms*: crushed, ground, pulverized, shattered, splintered, fractured, crackled, snapped, broke, fragmented, crumbled, mashed
+   - *Antonyms*: cushioned, muffled, silenced, padded, softened, absorbed
+   - *Nuance*: Highlights action plus acoustics; implies brittleness or dryness.
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🔍 Sense Explorer".

--- a/resources/system-prompts/dictionary-fast/05-register-connotation-block.md
+++ b/resources/system-prompts/dictionary-fast/05-register-connotation-block.md
@@ -1,0 +1,27 @@
+# Block: Register & Connotation
+
+Generate ONLY the **🗣️ Register & Connotation** section.
+
+## Output Format
+```
+# 🗣️ Register & Connotation
+- Registers: [List registers: formal, informal, archaic, technical, etc.]
+- Emotional valence: [Positive, negative, neutral, mixed - with explanation]
+- Tonal sliders:
+  - [Dimension 1]: [visual bar] ([percentage])
+  - [Dimension 2]: [visual bar] ([percentage])
+  - [Dimension 3]: [visual bar] ([percentage])
+```
+
+## Reference Example
+```
+# 🗣️ Register & Connotation
+- Registers: Neutral to informal; technical in analytics contexts.
+- Emotional valence: Neutral-to-negative (destruction, pressure) or positive (satisfying crunch).
+- Tonal sliders:
+  - Harshness: ████████░░ (80%)
+  - Finality: ██████░░░░ (60%)
+  - Intensity: ███████░░░ (70%)
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🗣️ Register & Connotation".

--- a/resources/system-prompts/dictionary-fast/06-narrative-texture-block.md
+++ b/resources/system-prompts/dictionary-fast/06-narrative-texture-block.md
@@ -1,0 +1,21 @@
+# Block: Narrative Texture
+
+Generate ONLY the **🪶 Narrative Texture** section.
+
+## Output Format
+```
+# 🪶 Narrative Texture
+- Sensory tags: [primary sense], [secondary senses].
+- Mood levers: [list of moods/atmospheres this word evokes].
+- Symbolism: [Thematic associations useful for fiction].
+```
+
+## Reference Example
+```
+# 🪶 Narrative Texture
+- Sensory tags: auditory (primary), tactile, kinesthetic.
+- Mood levers: tension, fragility, destruction, wintry atmosphere, anxious urgency.
+- Symbolism: Breaking points, irreversible change, deadlines, mortality, revelation.
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🪶 Narrative Texture".

--- a/resources/system-prompts/dictionary-fast/07-collocations-idioms-block.md
+++ b/resources/system-prompts/dictionary-fast/07-collocations-idioms-block.md
@@ -1,0 +1,21 @@
+# Block: Collocations & Idioms
+
+Generate ONLY the **📚 Collocations & Idioms** section.
+
+## Output Format
+```
+# 📚 Collocations & Idioms
+- Collocations: *[list of common collocations, italicized]*.
+- Idioms: "[idiom 1]" ([meaning]), "[idiom 2]" ([meaning]).
+- Cliché refreshers: swap "[cliché]" for "[fresher alternatives]."
+```
+
+## Reference Example
+```
+# 📚 Collocations & Idioms
+- Collocations: *crunched numbers*, *crunched underfoot*, *crunched leaves*, *crunched data*, *crunched for time*.
+- Idioms: "when it comes to the crunch" (critical juncture), "credit crunch" (financial squeeze).
+- Cliché refreshers: swap "crunched the numbers" for "interrogated the spreadsheets," "parsed the figures."
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 📚 Collocations & Idioms".

--- a/resources/system-prompts/dictionary-fast/08-morphology-family-block.md
+++ b/resources/system-prompts/dictionary-fast/08-morphology-family-block.md
@@ -1,0 +1,25 @@
+# Block: Morphology & Family
+
+Generate ONLY the **🧬 Morphology & Family** section.
+
+## Output Format
+```
+# 🧬 Morphology & Family
+- Base: *[root word]*
+- Inflections: [list of inflected forms]
+- Derivatives: [derived words]
+- Compounds: [compound words]
+- Affix play: [prefix/suffix variations]
+```
+
+## Reference Example
+```
+# 🧬 Morphology & Family
+- Base: *crunch*
+- Inflections: crunch, crunches, crunching, crunched
+- Derivatives: crunchy, crunchiness, crunchable, cruncher
+- Compounds: crunch-time, number-crunching, ab-crunches
+- Affix play: re-crunched, pre-crunched, over-crunched
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🧬 Morphology & Family".

--- a/resources/system-prompts/dictionary-fast/09-character-voice-block.md
+++ b/resources/system-prompts/dictionary-fast/09-character-voice-block.md
@@ -1,0 +1,27 @@
+# Block: Character Voice Variations
+
+Generate ONLY the **🎭 Character Voice Variations** section.
+
+## Output Format
+```
+# 🎭 Character Voice Variations
+- **[Archetype 1]**: "[alternative phrasing or usage]"
+- **[Archetype 2]**: "[alternative phrasing or usage]"
+- **[Archetype 3]**: "[alternative phrasing or usage]"
+[... at least 6-8 archetypes]
+```
+
+## Reference Example
+```
+# 🎭 Character Voice Variations
+- **Academic theorist**: "The substrate fragmented beneath applied pressure differentials."
+- **Hardboiled detective**: "Dead leaves cracked like old bones under my boots."
+- **Teen slangster**: "I crunched through those chips in, like, two seconds flat."
+- **Lyrical poet**: "Autumn's brittle symphony crackled beneath wandering soles."
+- **Battlefield commander**: "Armor crunched together as the line braced for impact."
+- **Whimsical fae guide**: "Each leaf crunched a spark of woodland laughter underfoot."
+- **Villainous mastermind**: "Our rivals' defenses? Already crunched to dust."
+- **AI concierge**: "Data ingested. Figures crunched. Insights ready for review."
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🎭 Character Voice Variations".

--- a/resources/system-prompts/dictionary-fast/10-soundplay-rhyme-block.md
+++ b/resources/system-prompts/dictionary-fast/10-soundplay-rhyme-block.md
@@ -1,0 +1,23 @@
+# Block: Soundplay & Rhyme
+
+Generate ONLY the **🎵 Soundplay & Rhyme** section.
+
+## Output Format
+```
+# 🎵 Soundplay & Rhyme
+- Perfect rhymes: [list of perfect rhymes]
+- Slant rhymes: [list of slant/near rhymes]
+- Alliterative partners: [words that alliterate well]
+- Meter note: [guidance for rhythm/meter usage]
+```
+
+## Reference Example
+```
+# 🎵 Soundplay & Rhyme
+- Perfect rhymes: bunched, hunched, lunched, munched, punched, scrunched
+- Slant rhymes: clutched, launched, staunch, crutched
+- Alliterative partners: crackled, crashed, crumbled, crushed, crisp
+- Meter note: Strong stressed monosyllable—great for emphatic closings or percussive beats.
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🎵 Soundplay & Rhyme".

--- a/resources/system-prompts/dictionary-fast/11-translations-cognates-block.md
+++ b/resources/system-prompts/dictionary-fast/11-translations-cognates-block.md
@@ -1,0 +1,25 @@
+# Block: Translations & Cognates
+
+Generate ONLY the **🌐 Translations & Cognates** section.
+
+## Output Format
+```
+# 🌐 Translations & Cognates
+- French: *[translation]* ([nuance])
+- Spanish: *[translation]* ([nuance])
+- German: *[translation]* ([nuance])
+- Japanese: [characters] (*[romanization]*, [nuance])
+- Nuance: [General note about cross-language considerations]
+```
+
+## Reference Example
+```
+# 🌐 Translations & Cognates
+- French: *écrasé* (crushed), *croqué* (crunching food)
+- Spanish: *crujió* (sound), *triturado* (action)
+- German: *knirschte*, *zerknirscht* (onomatopoeic focus)
+- Japanese: カリカリ (*kari-kari*, sound), 砕いた (*kudaita*, action)
+- Nuance: Many languages separate sound from action; choose the variant that matches intent.
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# 🌐 Translations & Cognates".

--- a/resources/system-prompts/dictionary-fast/12-usage-watchpoints-block.md
+++ b/resources/system-prompts/dictionary-fast/12-usage-watchpoints-block.md
@@ -1,0 +1,23 @@
+# Block: Usage Watchpoints
+
+Generate ONLY the **⚠️ Usage Watchpoints** section.
+
+## Output Format
+```
+# ⚠️ Usage Watchpoints
+- Ambiguity: [Potential confusion points]
+- Overuse: [Alternatives to rotate with]
+- Regional: [Regional usage differences]
+- Clichés: [Common clichés to avoid or refresh]
+```
+
+## Reference Example
+```
+# ⚠️ Usage Watchpoints
+- Ambiguity: Specify context to avoid confusion between physical and data senses.
+- Overuse: Rotate with "crackled," "splintered," "fractured" in action scenes.
+- Regional: "Crunched" for financial pressure is more common in British usage.
+- Clichés: "Crunched leaves" in autumn—refresh with "brittle carpet" or "crackling understory."
+```
+
+Generate this section for the word provided. Output ONLY the section content, starting with "# ⚠️ Usage Watchpoints".

--- a/resources/system-prompts/dictionary-fast/13-semantic-gradient-block.md
+++ b/resources/system-prompts/dictionary-fast/13-semantic-gradient-block.md
@@ -1,0 +1,17 @@
+# Block: Semantic Gradient
+
+Generate ONLY the **🧭 Semantic Gradient** section.
+
+## Output Format
+```
+# 🧭 Semantic Gradient
+[weakest] → [less weak] → [moderate] → [stronger] → **[target word]** → [stronger still] → [strongest]
+```
+
+## Reference Example
+```
+# 🧭 Semantic Gradient
+pressed → compressed → squeezed → crushed → **crunched** → pulverized → shattered → obliterated → annihilated
+```
+
+Generate this section for the word provided. Show an ordered ladder of near-synonyms from weakest to strongest intensity, with the target word in bold. Output ONLY the section content, starting with "# 🧭 Semantic Gradient".

--- a/resources/system-prompts/dictionary-fast/14-ai-advisory-notes-block.md
+++ b/resources/system-prompts/dictionary-fast/14-ai-advisory-notes-block.md
@@ -1,0 +1,22 @@
+# Block: AI Advisory Notes
+
+Generate ONLY the **🧠 AI Advisory Notes** section.
+
+## Output Format
+```
+# 🧠 AI Advisory Notes
+- [Note about any uncertain information in the entry]
+- [Suggestions for verification if needed]
+- [Creative tips or connections worth exploring]
+```
+
+## Reference Example
+```
+# 🧠 AI Advisory Notes
+- Onomatopoetic origin is well-attested.
+- Japanese equivalents simplified; verify nuance when stakes are high.
+- If the source passage leans on percussive consonants (e.g., "percussive pops"), explore alternates like "clattered," "rattled," "stuttered" for variety.
+- Synesthetic pairings (e.g., "bitter-brown-black") resonate with the harsh consonant cluster—lean into that alignment when helpful.
+```
+
+Generate this section for the word provided. Flag which insights derive from creative inference or limited certainty. Output ONLY the section content, starting with "# 🧠 AI Advisory Notes".

--- a/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts
+++ b/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts
@@ -18,7 +18,10 @@ describe('useDictionary - Type Contracts', () => {
         wordEdited: false,
         sourceUri: '',
         relativePath: '',
-        statusMessage: ''
+        statusMessage: '',
+        isFastGenerating: false,
+        fastGenerationProgress: null,
+        lastFastGenerationMetadata: null
       };
 
       expect(state).toHaveProperty('result');
@@ -27,6 +30,8 @@ describe('useDictionary - Type Contracts', () => {
       expect(state).toHaveProperty('context');
       expect(state).toHaveProperty('wordEdited');
       expect(state).toHaveProperty('sourceUri');
+      expect(state).toHaveProperty('isFastGenerating');
+      expect(state).toHaveProperty('fastGenerationProgress');
     });
 
     it('should define Actions interface', () => {
@@ -38,12 +43,17 @@ describe('useDictionary - Type Contracts', () => {
         setContext: jest.fn(),
         setWordEdited: jest.fn(),
         setSource: jest.fn(),
-        clearResult: jest.fn()
+        clearResult: jest.fn(),
+        handleFastGenerateResult: jest.fn(),
+        handleProgress: jest.fn(),
+        setFastGenerating: jest.fn()
       };
 
       expect(typeof actions.handleDictionaryResult).toBe('function');
       expect(typeof actions.setWord).toBe('function');
       expect(typeof actions.clearResult).toBe('function');
+      expect(typeof actions.handleFastGenerateResult).toBe('function');
+      expect(typeof actions.setFastGenerating).toBe('function');
     });
 
     it('should define Persistence interface', () => {

--- a/src/application/handlers/domain/DictionaryHandler.ts
+++ b/src/application/handlers/domain/DictionaryHandler.ts
@@ -140,6 +140,11 @@ export class DictionaryHandler {
       // Send result back to webview
       this.sendFastGenerateResult(result);
       this.sendStatus('');
+
+      // Apply aggregated token usage
+      if (result.usage) {
+        this.applyTokenUsage(result.usage);
+      }
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       this.sendError('dictionary', 'Failed to generate dictionary entry', msg);

--- a/src/application/handlers/domain/DictionaryHandler.ts
+++ b/src/application/handlers/domain/DictionaryHandler.ts
@@ -9,10 +9,13 @@ import * as vscode from 'vscode';
 import { DictionaryService } from '../../../infrastructure/api/services/dictionary/DictionaryService';
 import {
   LookupDictionaryMessage,
+  FastGenerateDictionaryMessage,
   MessageType,
   TokenUsage,
   ErrorSource,
   DictionaryResultMessage,
+  FastGenerateDictionaryResultMessage,
+  DictionaryGenerationProgressMessage,
   StatusMessage,
   ErrorMessage
 } from '../../../shared/types/messages';
@@ -30,6 +33,7 @@ export class DictionaryHandler {
    */
   registerRoutes(router: MessageRouter): void {
     router.register(MessageType.LOOKUP_DICTIONARY, this.handleLookupDictionary.bind(this));
+    router.register(MessageType.FAST_GENERATE_DICTIONARY, this.handleFastGenerate.bind(this));
   }
 
   // Helper methods (domain owns its message lifecycle)
@@ -101,5 +105,84 @@ export class DictionaryHandler {
       const msg = error instanceof Error ? error.message : String(error);
       this.sendError('dictionary', 'Failed to lookup dictionary entry', msg);
     }
+  }
+
+  /**
+   * Handle fast (parallel) dictionary generation request
+   */
+  async handleFastGenerate(message: FastGenerateDictionaryMessage): Promise<void> {
+    try {
+      const { word, context } = message.payload;
+
+      if (!word.trim()) {
+        this.sendError('dictionary', 'Fast dictionary generation requires a word');
+        return;
+      }
+
+      this.sendStatus(`🧪 Fast generating dictionary entry for "${word}"...`);
+
+      // Progress callback to send updates to webview
+      const onProgress = (progress: {
+        word: string;
+        completedBlocks: string[];
+        totalBlocks: number;
+      }): void => {
+        this.sendProgress(progress.word, progress.completedBlocks, progress.totalBlocks);
+      };
+
+      // Generate parallel dictionary
+      const result = await this.dictionaryService.generateParallelDictionary(
+        word,
+        context,
+        onProgress
+      );
+
+      // Send result back to webview
+      this.sendFastGenerateResult(result);
+      this.sendStatus('');
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.sendError('dictionary', 'Failed to generate dictionary entry', msg);
+    }
+  }
+
+  /**
+   * Send fast generate result to webview
+   */
+  private sendFastGenerateResult(result: {
+    word: string;
+    result: string;
+    metadata: {
+      totalDuration: number;
+      blockDurations: Record<string, number>;
+      partialFailures: string[];
+      successCount: number;
+      totalBlocks: number;
+    };
+  }): void {
+    const message: FastGenerateDictionaryResultMessage = {
+      type: MessageType.FAST_GENERATE_DICTIONARY_RESULT,
+      source: 'extension.dictionary',
+      payload: result,
+      timestamp: Date.now()
+    };
+    void this.postMessage(message);
+  }
+
+  /**
+   * Send generation progress update to webview
+   */
+  private sendProgress(word: string, completedBlocks: string[], totalBlocks: number): void {
+    const message: DictionaryGenerationProgressMessage = {
+      type: MessageType.DICTIONARY_GENERATION_PROGRESS,
+      source: 'extension.dictionary',
+      payload: {
+        word,
+        completedBlocks,
+        totalBlocks
+      },
+      timestamp: Date.now()
+    };
+    void this.postMessage(message);
   }
 }

--- a/src/infrastructure/api/OpenRouterClient.ts
+++ b/src/infrastructure/api/OpenRouterClient.ts
@@ -3,6 +3,8 @@
  * Handles communication with OpenRouter API for AI-powered analysis
  */
 
+import { TokenUsage } from '../../shared/types';
+
 export interface OpenRouterMessage {
   role: 'system' | 'user' | 'assistant';
   content: string;
@@ -57,6 +59,7 @@ export class OpenRouterClient {
     options?: {
       temperature?: number;
       maxTokens?: number;
+      signal?: AbortSignal;
     }
   ): Promise<{ content: string; finishReason?: string; usage?: TokenUsage; id?: string }> {
     const response = await fetch(`${this.baseUrl}/chat/completions`, {
@@ -67,6 +70,7 @@ export class OpenRouterClient {
         'HTTP-Referer': 'https://github.com/okeylanders/prose-minion-vscode',
         'X-Title': 'Prose Minion VS Code Extension'
       },
+      signal: options?.signal,
       body: JSON.stringify({
         model: this.model,
         messages,
@@ -116,4 +120,3 @@ export class OpenRouterClient {
     return Boolean(apiKey && apiKey.trim().length > 0);
   }
 }
-import { TokenUsage } from '../../shared/types';

--- a/src/infrastructure/api/services/dictionary/DictionaryService.ts
+++ b/src/infrastructure/api/services/dictionary/DictionaryService.ts
@@ -7,6 +7,7 @@
  * - Word definitions with contextual understanding
  * - Synonyms, antonyms, and usage examples
  * - Context-aware explanations
+ * - Parallel (fast) dictionary generation using fan-out pattern
  *
  * This wrapper:
  * - Centralizes dictionary tool orchestration
@@ -16,11 +17,17 @@
  */
 
 import * as vscode from 'vscode';
+import pLimit from 'p-limit';
 import { DictionaryUtility } from '../../../../tools/utility/dictionaryUtility';
 import { AIResourceManager } from '../resources/AIResourceManager';
 import { ResourceLoaderService } from '../resources/ResourceLoaderService';
 import { ToolOptionsProvider } from '../shared/ToolOptionsProvider';
 import { AnalysisResult, AnalysisResultFactory } from '../../../../domain/models/AnalysisResult';
+import {
+  DictionaryBlockResult,
+  FastGenerateDictionaryResultPayload
+} from '../../../../shared/types/messages/dictionary';
+import { TokenUsage } from '../../../../shared/types/messages/base';
 
 /**
  * Service wrapper for AI-powered dictionary lookups
@@ -31,8 +38,43 @@ import { AnalysisResult, AnalysisResultFactory } from '../../../../domain/models
  * - Usage examples and explanations
  * - Part-of-speech information
  */
+/**
+ * Block names for parallel dictionary generation
+ */
+const DICTIONARY_BLOCKS = [
+  'definition',
+  'pronunciation',
+  'parts-of-speech',
+  'sense-explorer',
+  'register-connotation',
+  'narrative-texture',
+  'collocations-idioms',
+  'morphology-family',
+  'character-voice',
+  'soundplay-rhyme',
+  'translations-cognates',
+  'usage-watchpoints',
+  'semantic-gradient',
+  'ai-advisory-notes'
+] as const;
+
+type DictionaryBlockName = typeof DICTIONARY_BLOCKS[number];
+
+/**
+ * Progress callback for parallel generation
+ */
+export type ParallelGenerationProgressCallback = (progress: {
+  word: string;
+  completedBlocks: string[];
+  totalBlocks: number;
+}) => void;
+
 export class DictionaryService {
   private dictionaryUtility?: DictionaryUtility;
+
+  // Parallel generation constants
+  private readonly CONCURRENCY_LIMIT = 5;
+  private readonly BLOCK_TIMEOUT = 15000; // 15 seconds per block
 
   constructor(
     private readonly aiResourceManager: AIResourceManager,
@@ -135,5 +177,270 @@ To use AI-powered dictionary tools, you need to configure your OpenRouter API ke
 5. Select your preferred models for assistants and utilities
 
 The measurement tools (Prose Statistics, Style Flags, Word Frequency) work without an API key.`;
+  }
+
+  // ============================================
+  // Parallel Dictionary Generation (Fast Generate)
+  // ============================================
+
+  /**
+   * Generate dictionary entry using parallel fan-out pattern
+   * Fires concurrent API calls for each block and reassembles results
+   *
+   * @param word - Word to look up
+   * @param context - Optional context text
+   * @param onProgress - Optional callback for progress updates
+   * @returns Combined dictionary result with metadata
+   */
+  async generateParallelDictionary(
+    word: string,
+    context?: string,
+    onProgress?: ParallelGenerationProgressCallback
+  ): Promise<FastGenerateDictionaryResultPayload> {
+    const startTime = Date.now();
+    this.outputChannel?.appendLine(`\n[DictionaryService] Starting parallel dictionary generation for "${word}"`);
+
+    // Get orchestrator
+    const orchestrator = this.aiResourceManager.getOrchestrator('dictionary');
+    if (!orchestrator) {
+      throw new Error('Dictionary service not initialized. Please configure your OpenRouter API key.');
+    }
+
+    // Load prompts
+    const baseInstructions = await this.loadBlockPrompt('00-base-instructions');
+    const completedBlocks: string[] = [];
+    const totalBlocks = DICTIONARY_BLOCKS.length;
+
+    // Create concurrency limiter
+    const limit = pLimit(this.CONCURRENCY_LIMIT);
+
+    // Create block generation promises
+    const blockPromises = DICTIONARY_BLOCKS.map((blockName, index) =>
+      limit(async () => {
+        const result = await this.generateSingleBlock(
+          orchestrator,
+          baseInstructions,
+          blockName,
+          index + 1,
+          word,
+          context
+        );
+
+        // Update progress
+        if (!result.error) {
+          completedBlocks.push(blockName);
+          onProgress?.({
+            word,
+            completedBlocks: [...completedBlocks],
+            totalBlocks
+          });
+        }
+
+        return result;
+      })
+    );
+
+    // Execute all blocks with concurrency limit
+    const blockResults = await Promise.all(blockPromises);
+
+    // Assemble and return result
+    return this.assembleParallelResult(word, blockResults, startTime);
+  }
+
+  /**
+   * Generate a single dictionary block
+   */
+  private async generateSingleBlock(
+    orchestrator: any,
+    baseInstructions: string,
+    blockName: DictionaryBlockName,
+    blockNumber: number,
+    word: string,
+    context?: string
+  ): Promise<DictionaryBlockResult> {
+    const startTime = Date.now();
+    const paddedNumber = String(blockNumber).padStart(2, '0');
+
+    try {
+      // Load block-specific prompt
+      const blockPrompt = await this.loadBlockPrompt(`${paddedNumber}-${blockName}-block`);
+
+      // Build system message
+      const systemMessage = `${baseInstructions}\n\n---\n\n${blockPrompt}`;
+
+      // Build user message
+      const userMessage = this.buildBlockUserMessage(word, context);
+
+      this.outputChannel?.appendLine(`[DictionaryService] Generating block: ${blockName}`);
+
+      // Execute with timeout
+      const result = await Promise.race([
+        orchestrator.executeWithoutCapabilities(
+          `dictionary-fast-${blockName}`,
+          systemMessage,
+          userMessage,
+          {
+            temperature: 0.4,
+            maxTokens: 1500 // Smaller max for individual blocks
+          }
+        ),
+        this.createTimeout(this.BLOCK_TIMEOUT)
+      ]);
+
+      const duration = Date.now() - startTime;
+      this.outputChannel?.appendLine(`[DictionaryService] Block "${blockName}" completed in ${duration}ms`);
+
+      return {
+        blockName,
+        content: result.content,
+        duration
+      };
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      this.outputChannel?.appendLine(`[DictionaryService] Block "${blockName}" failed: ${errorMessage}`);
+
+      // Retry once
+      try {
+        this.outputChannel?.appendLine(`[DictionaryService] Retrying block "${blockName}"...`);
+        const blockPrompt = await this.loadBlockPrompt(`${paddedNumber}-${blockName}-block`);
+        const systemMessage = `${baseInstructions}\n\n---\n\n${blockPrompt}`;
+        const userMessage = this.buildBlockUserMessage(word, context);
+
+        const result = await orchestrator.executeWithoutCapabilities(
+          `dictionary-fast-${blockName}-retry`,
+          systemMessage,
+          userMessage,
+          {
+            temperature: 0.4,
+            maxTokens: 1500
+          }
+        );
+
+        const retryDuration = Date.now() - startTime;
+        this.outputChannel?.appendLine(`[DictionaryService] Block "${blockName}" retry succeeded in ${retryDuration}ms`);
+
+        return {
+          blockName,
+          content: result.content,
+          duration: retryDuration
+        };
+      } catch (retryError) {
+        const retryDuration = Date.now() - startTime;
+        const retryErrorMessage = retryError instanceof Error ? retryError.message : String(retryError);
+
+        this.outputChannel?.appendLine(`[DictionaryService] Block "${blockName}" retry failed: ${retryErrorMessage}`);
+
+        return {
+          blockName,
+          content: '',
+          duration: retryDuration,
+          error: retryErrorMessage
+        };
+      }
+    }
+  }
+
+  /**
+   * Load a block-specific prompt from the dictionary-fast directory
+   */
+  private async loadBlockPrompt(promptName: string): Promise<string> {
+    const promptLoader = this.resourceLoader.getPromptLoader();
+    try {
+      return await promptLoader.loadPrompts([`dictionary-fast/${promptName}.md`]);
+    } catch (error) {
+      this.outputChannel?.appendLine(`[DictionaryService] Failed to load prompt ${promptName}: ${error}`);
+      return '';
+    }
+  }
+
+  /**
+   * Build user message for block generation
+   */
+  private buildBlockUserMessage(word: string, context?: string): string {
+    const lines = [
+      `Generate the dictionary section for the following word:`,
+      '',
+      `Word: ${word.trim()}`
+    ];
+
+    if (context?.trim()) {
+      lines.push('', 'Context (use to tailor examples and usage notes):', context.trim());
+    }
+
+    lines.push('', 'Output ONLY the section content as specified in the block instructions.');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Create a timeout promise
+   */
+  private createTimeout(ms: number): Promise<never> {
+    return new Promise((_, reject) => {
+      setTimeout(() => reject(new Error(`Block generation timed out after ${ms}ms`)), ms);
+    });
+  }
+
+  /**
+   * Assemble parallel block results into final dictionary entry
+   */
+  private assembleParallelResult(
+    word: string,
+    blockResults: DictionaryBlockResult[],
+    startTime: number
+  ): FastGenerateDictionaryResultPayload {
+    const totalDuration = Date.now() - startTime;
+
+    // Collect metadata
+    const blockDurations: Record<string, number> = {};
+    const partialFailures: string[] = [];
+    let successCount = 0;
+
+    // Sort blocks to maintain order and build result
+    const orderedContent: string[] = [];
+
+    for (const blockName of DICTIONARY_BLOCKS) {
+      const result = blockResults.find(r => r.blockName === blockName);
+      if (result) {
+        blockDurations[blockName] = result.duration;
+
+        if (result.error) {
+          partialFailures.push(blockName);
+        } else if (result.content.trim()) {
+          successCount++;
+          orderedContent.push(result.content.trim());
+        }
+      }
+    }
+
+    // Build header
+    const header = `# Prose Minion | Writer's Dictionary Lookup\n\n# Word: *${word}*\n`;
+
+    // Combine all successful blocks
+    const combinedResult = header + '\n' + orderedContent.join('\n\n');
+
+    this.outputChannel?.appendLine(
+      `[DictionaryService] Parallel generation completed: ${successCount}/${DICTIONARY_BLOCKS.length} blocks in ${totalDuration}ms`
+    );
+
+    if (partialFailures.length > 0) {
+      this.outputChannel?.appendLine(
+        `[DictionaryService] Partial failures: ${partialFailures.join(', ')}`
+      );
+    }
+
+    return {
+      word,
+      result: combinedResult,
+      metadata: {
+        totalDuration,
+        blockDurations,
+        partialFailures,
+        successCount,
+        totalBlocks: DICTIONARY_BLOCKS.length
+      }
+    };
   }
 }

--- a/src/infrastructure/api/services/dictionary/DictionaryService.ts
+++ b/src/infrastructure/api/services/dictionary/DictionaryService.ts
@@ -73,7 +73,7 @@ export class DictionaryService {
   private dictionaryUtility?: DictionaryUtility;
 
   // Parallel generation constants
-  private readonly CONCURRENCY_LIMIT = 14;
+  private readonly CONCURRENCY_LIMIT = 7;
   private readonly BLOCK_TIMEOUT = 15000; // 15 seconds per block
 
   constructor(

--- a/src/infrastructure/api/services/dictionary/DictionaryService.ts
+++ b/src/infrastructure/api/services/dictionary/DictionaryService.ts
@@ -73,7 +73,7 @@ export class DictionaryService {
   private dictionaryUtility?: DictionaryUtility;
 
   // Parallel generation constants
-  private readonly CONCURRENCY_LIMIT = 5;
+  private readonly CONCURRENCY_LIMIT = 14;
   private readonly BLOCK_TIMEOUT = 15000; // 15 seconds per block
 
   constructor(
@@ -281,7 +281,7 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
           userMessage,
           {
             temperature: 0.4,
-            maxTokens: 1500 // Smaller max for individual blocks
+            maxTokens: 3500 // Smaller max for individual blocks
           }
         ),
         this.createTimeout(this.BLOCK_TIMEOUT)
@@ -314,7 +314,7 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
           userMessage,
           {
             temperature: 0.4,
-            maxTokens: 1500
+            maxTokens: 3500
           }
         );
 

--- a/src/infrastructure/api/services/dictionary/DictionaryService.ts
+++ b/src/infrastructure/api/services/dictionary/DictionaryService.ts
@@ -273,19 +273,17 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
 
       this.outputChannel?.appendLine(`[DictionaryService] Generating block: ${blockName}`);
 
-      // Execute with timeout
-      const result = await Promise.race([
-        orchestrator.executeWithoutCapabilities(
-          `dictionary-fast-${blockName}`,
-          systemMessage,
-          userMessage,
-          {
-            temperature: 0.4,
-            maxTokens: 3500 // Smaller max for individual blocks
-          }
-        ),
-        this.createTimeout(this.BLOCK_TIMEOUT)
-      ]);
+      // Execute with timeout surfaced through the orchestrator
+      const result = await orchestrator.executeWithoutCapabilities(
+        `dictionary-fast-${blockName}`,
+        systemMessage,
+        userMessage,
+        {
+          temperature: 0.4,
+          maxTokens: 3500, // Smaller max for individual blocks
+          timeoutMs: this.BLOCK_TIMEOUT
+        }
+      );
 
       const duration = Date.now() - startTime;
       this.outputChannel?.appendLine(`[DictionaryService] Block "${blockName}" completed in ${duration}ms`);
@@ -315,7 +313,8 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
           userMessage,
           {
             temperature: 0.4,
-            maxTokens: 3500
+            maxTokens: 3500,
+            timeoutMs: this.BLOCK_TIMEOUT
           }
         );
 
@@ -374,15 +373,6 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
     lines.push('', 'Output ONLY the section content as specified in the block instructions.');
 
     return lines.join('\n');
-  }
-
-  /**
-   * Create a timeout promise
-   */
-  private createTimeout(ms: number): Promise<never> {
-    return new Promise((_, reject) => {
-      setTimeout(() => reject(new Error(`Block generation timed out after ${ms}ms`)), ms);
-    });
   }
 
   /**

--- a/src/presentation/webview/App.tsx
+++ b/src/presentation/webview/App.tsx
@@ -83,6 +83,13 @@ export const App: React.FC = () => {
       dictionary.handleDictionaryResult(msg);
       setError(''); // Clear error on success
     },
+    [MessageType.FAST_GENERATE_DICTIONARY_RESULT]: (msg) => {
+      dictionary.handleFastGenerateResult(msg);
+      setError(''); // Clear error on success
+    },
+    [MessageType.DICTIONARY_GENERATION_PROGRESS]: (msg) => {
+      dictionary.handleProgress(msg);
+    },
     [MessageType.CONTEXT_RESULT]: (msg) => {
       context.handleContextResult(msg);
       setError(''); // Clear error on success
@@ -471,6 +478,10 @@ export const App: React.FC = () => {
             sourceUri={dictionary.sourceUri}
             relativePath={dictionary.relativePath}
             onSourceChange={dictionary.setSource}
+            isFastGenerating={dictionary.isFastGenerating}
+            fastGenerationProgress={dictionary.fastGenerationProgress}
+            lastFastGenerationMetadata={dictionary.lastFastGenerationMetadata}
+            onFastGeneratingChange={dictionary.setFastGenerating}
           />
         )}
       </main>

--- a/src/presentation/webview/App.tsx
+++ b/src/presentation/webview/App.tsx
@@ -155,6 +155,7 @@ export const App: React.FC = () => {
         analysis.setLoading(false);
       } else if (errorSource === 'dictionary') {
         dictionary.setLoading(false);
+        dictionary.setFastGenerating(false);
       } else if (errorSource === 'context') {
         context.setLoading(false);
       } else if (errorSource.startsWith('settings.') || errorSource.startsWith('file_ops.') || errorSource.startsWith('ui.') || errorSource === 'publishing') {
@@ -165,6 +166,7 @@ export const App: React.FC = () => {
         analysis.setLoading(false);
         metrics.setLoading(false);
         dictionary.setLoading(false);
+        dictionary.setFastGenerating(false);
         context.setLoading(false);
         search.setLoading(false);
       }

--- a/src/presentation/webview/components/UtilitiesTab.tsx
+++ b/src/presentation/webview/components/UtilitiesTab.tsx
@@ -381,6 +381,7 @@ export const UtilitiesTab: React.FC<UtilitiesTabProps> = ({
               )}
             </div>
           </div>
+          <LoadingWidget />
         </div>
       )}
 

--- a/src/presentation/webview/components/UtilitiesTab.tsx
+++ b/src/presentation/webview/components/UtilitiesTab.tsx
@@ -343,7 +343,7 @@ export const UtilitiesTab: React.FC<UtilitiesTabProps> = ({
             disabled={!word.trim() || isLoading || isFastGenerating}
             title="Experimental: Generate using parallel API calls (2-4× faster)"
           >
-            ⚡ Fast Generate
+            ⚡ Fast Generate (Experimental)
           </button>
         )}
       </div>

--- a/src/presentation/webview/components/UtilitiesTab.tsx
+++ b/src/presentation/webview/components/UtilitiesTab.tsx
@@ -9,6 +9,19 @@ import { MarkdownRenderer } from './MarkdownRenderer';
 import { LoadingWidget } from './LoadingWidget';
 import { formatAnalysisAsMarkdown } from '../utils/resultFormatter';
 
+interface FastGenerationProgress {
+  completedBlocks: string[];
+  totalBlocks: number;
+}
+
+interface FastGenerationMetadata {
+  totalDuration: number;
+  blockDurations: Record<string, number>;
+  partialFailures: string[];
+  successCount: number;
+  totalBlocks: number;
+}
+
 interface UtilitiesTabProps {
   selectedText: string;
   vscode: any;
@@ -29,6 +42,11 @@ interface UtilitiesTabProps {
   sourceUri?: string;
   relativePath?: string;
   onSourceChange: (uri?: string, relativePath?: string) => void;
+  // Fast generation props
+  isFastGenerating?: boolean;
+  fastGenerationProgress?: FastGenerationProgress | null;
+  lastFastGenerationMetadata?: FastGenerationMetadata | null;
+  onFastGeneratingChange?: (isGenerating: boolean) => void;
 }
 
 export const UtilitiesTab: React.FC<UtilitiesTabProps> = ({
@@ -50,7 +68,11 @@ export const UtilitiesTab: React.FC<UtilitiesTabProps> = ({
   setHasWordBeenEdited,
   sourceUri,
   relativePath,
-  onSourceChange
+  onSourceChange,
+  isFastGenerating = false,
+  fastGenerationProgress,
+  lastFastGenerationMetadata,
+  onFastGeneratingChange
 }) => {
   const lastLookupRef = React.useRef<{ word: string; context: string } | null>(null);
 
@@ -147,6 +169,30 @@ export const UtilitiesTab: React.FC<UtilitiesTabProps> = ({
       payload: {
         word: sanitizedWord,
         contextText: context.trim() || undefined
+      },
+      timestamp: Date.now()
+    });
+  };
+
+  const handleFastGenerate = () => {
+    const sanitizedWord = enforceWordLimit(word);
+    if (!sanitizedWord) {
+      return;
+    }
+
+    onFastGeneratingChange?.(true);
+
+    lastLookupRef.current = {
+      word: sanitizedWord,
+      context: context.trim()
+    };
+
+    vscode.postMessage({
+      type: MessageType.FAST_GENERATE_DICTIONARY,
+      source: 'webview.utilities.tab',
+      payload: {
+        word: sanitizedWord,
+        context: context.trim() || undefined
       },
       timestamp: Date.now()
     });
@@ -286,10 +332,20 @@ export const UtilitiesTab: React.FC<UtilitiesTabProps> = ({
         <button
           className="btn btn-primary"
           onClick={handleLookup}
-          disabled={!word.trim() || isLoading}
+          disabled={!word.trim() || isLoading || isFastGenerating}
         >
           Generate Dictionary Entry
         </button>
+        {onFastGeneratingChange && (
+          <button
+            className="btn btn-secondary"
+            onClick={handleFastGenerate}
+            disabled={!word.trim() || isLoading || isFastGenerating}
+            title="Experimental: Generate using parallel API calls (2-4× faster)"
+          >
+            ⚡ Fast Generate
+          </button>
+        )}
       </div>
 
       {isLoading && (
@@ -301,6 +357,30 @@ export const UtilitiesTab: React.FC<UtilitiesTabProps> = ({
             </div>
           </div>
           <LoadingWidget />
+        </div>
+      )}
+
+      {isFastGenerating && (
+        <div className="loading-indicator">
+          <div className="loading-header">
+            <div className="spinner"></div>
+            <div className="loading-text">
+              <div>{statusMessage || '⚡ Fast generating dictionary entry...'}</div>
+              {fastGenerationProgress && (
+                <div className="progress-bar-container">
+                  <div
+                    className="progress-bar"
+                    style={{
+                      width: `${(fastGenerationProgress.completedBlocks.length / fastGenerationProgress.totalBlocks) * 100}%`
+                    }}
+                  />
+                  <span className="progress-text">
+                    {fastGenerationProgress.completedBlocks.length} / {fastGenerationProgress.totalBlocks} blocks
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       )}
 

--- a/src/presentation/webview/index.css
+++ b/src/presentation/webview/index.css
@@ -568,6 +568,37 @@ select:focus {
   }
 }
 
+/* Progress bar for parallel generation */
+.progress-bar-container {
+  width: 100%;
+  height: 8px;
+  background-color: var(--vscode-progressBar-background);
+  border-radius: 4px;
+  margin-top: var(--spacing-sm);
+  position: relative;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  background-color: var(--vscode-progressBar-background);
+  background-image: linear-gradient(
+    90deg,
+    var(--vscode-charts-blue) 0%,
+    var(--vscode-charts-green) 100%
+  );
+  border-radius: 4px;
+  transition: width 0.3s ease-out;
+}
+
+.progress-text {
+  display: block;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  margin-top: var(--spacing-xs);
+  text-align: center;
+}
+
 /* Guide ticker animation */
 .guide-ticker-container {
   margin-top: var(--spacing-xs);

--- a/src/shared/types/messages/base.ts
+++ b/src/shared/types/messages/base.ts
@@ -80,7 +80,12 @@ export enum MessageType {
   DELETE_API_KEY = 'delete_api_key'
   ,
   // Webview diagnostics
-  WEBVIEW_ERROR = 'webview_error'
+  WEBVIEW_ERROR = 'webview_error',
+
+  // Fast dictionary generation (parallel)
+  FAST_GENERATE_DICTIONARY = 'fast_generate_dictionary',
+  FAST_GENERATE_DICTIONARY_RESULT = 'fast_generate_dictionary_result',
+  DICTIONARY_GENERATION_PROGRESS = 'dictionary_generation_progress'
 }
 
 export enum TabId {

--- a/src/shared/types/messages/dictionary.ts
+++ b/src/shared/types/messages/dictionary.ts
@@ -3,7 +3,7 @@
  * Dictionary lookup and word operations
  */
 
-import { MessageEnvelope, MessageType } from './base';
+import { MessageEnvelope, MessageType, TokenUsage } from './base';
 
 export interface LookupDictionaryPayload {
   word: string;
@@ -40,6 +40,7 @@ export interface DictionaryBlockResult {
   content: string;
   duration: number;
   error?: string;
+  usage?: TokenUsage;
 }
 
 export interface FastGenerateDictionaryResultPayload {
@@ -52,6 +53,7 @@ export interface FastGenerateDictionaryResultPayload {
     successCount: number;
     totalBlocks: number;
   };
+  usage?: TokenUsage; // Aggregated usage across all blocks
 }
 
 export interface FastGenerateDictionaryResultMessage extends MessageEnvelope<FastGenerateDictionaryResultPayload> {

--- a/src/shared/types/messages/dictionary.ts
+++ b/src/shared/types/messages/dictionary.ts
@@ -22,3 +22,48 @@ export interface DictionaryResultPayload {
 export interface DictionaryResultMessage extends MessageEnvelope<DictionaryResultPayload> {
   type: MessageType.DICTIONARY_RESULT;
 }
+
+// Fast (parallel) dictionary generation
+
+export interface FastGenerateDictionaryPayload {
+  word: string;
+  context?: string;
+  sourceUri?: string;
+}
+
+export interface FastGenerateDictionaryMessage extends MessageEnvelope<FastGenerateDictionaryPayload> {
+  type: MessageType.FAST_GENERATE_DICTIONARY;
+}
+
+export interface DictionaryBlockResult {
+  blockName: string;
+  content: string;
+  duration: number;
+  error?: string;
+}
+
+export interface FastGenerateDictionaryResultPayload {
+  word: string;
+  result: string; // Combined markdown result
+  metadata: {
+    totalDuration: number;
+    blockDurations: Record<string, number>;
+    partialFailures: string[];
+    successCount: number;
+    totalBlocks: number;
+  };
+}
+
+export interface FastGenerateDictionaryResultMessage extends MessageEnvelope<FastGenerateDictionaryResultPayload> {
+  type: MessageType.FAST_GENERATE_DICTIONARY_RESULT;
+}
+
+export interface DictionaryGenerationProgressPayload {
+  word: string;
+  completedBlocks: string[];
+  totalBlocks: number;
+}
+
+export interface DictionaryGenerationProgressMessage extends MessageEnvelope<DictionaryGenerationProgressPayload> {
+  type: MessageType.DICTIONARY_GENERATION_PROGRESS;
+}

--- a/src/shared/types/messages/index.ts
+++ b/src/shared/types/messages/index.ts
@@ -26,7 +26,10 @@ import {
 } from './analysis';
 import {
   LookupDictionaryMessage,
-  DictionaryResultMessage
+  DictionaryResultMessage,
+  FastGenerateDictionaryMessage,
+  FastGenerateDictionaryResultMessage,
+  DictionaryGenerationProgressMessage
 } from './dictionary';
 import {
   GenerateContextMessage,
@@ -121,7 +124,8 @@ export type WebviewToExtensionMessage =
   | RequestApiKeyMessage
   | UpdateApiKeyMessage
   | DeleteApiKeyMessage
-  | WebviewErrorMessage;
+  | WebviewErrorMessage
+  | FastGenerateDictionaryMessage;
 
 export type ExtensionToWebviewMessage =
   | AnalysisResultMessage
@@ -144,4 +148,6 @@ export type ExtensionToWebviewMessage =
   | ChapterGlobsMessage
   | PublishingStandardsDataMessage
   | TokenUsageUpdateMessage
-  | ApiKeyStatusMessage;
+  | ApiKeyStatusMessage
+  | FastGenerateDictionaryResultMessage
+  | DictionaryGenerationProgressMessage;


### PR DESCRIPTION
## Summary

- ⚡ **Fast Generate (Experimental)**: Parallel dictionary generation using fan-out pattern (2-4× faster)
- 14 dictionary blocks generated concurrently with 7-thread limit via `p-limit`
- Progress bar UI with real-time block completion updates
- Token usage aggregation across all parallel API calls
- Error recovery and retry logic for failed blocks

## Changes

**Backend:**
- `DictionaryService.generateParallelDictionary()` - Fan-out orchestration
- `DictionaryHandler` - New message route for fast generation
- 14 block-specific prompts in `resources/system-prompts/dictionary-fast/`

**Frontend:**
- New "⚡ Fast Generate (Experimental)" button in Dictionary tab
- Progress bar showing `X / 14 blocks` completion
- `useDictionary` hook extended with fast generation state

**Bug Fixes:**
- Error recovery resets `isFastGenerating` state
- LoadingWidget consistency for fast generation

## Test plan

- [x] Regular dictionary lookup still works
- [x] Fast Generate completes with progress updates
- [x] Token usage aggregated correctly
- [x] Error handling recovers UI state
- [x] Build passes (`npm run compile`)
- [x] Tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)