### PR TITLE
fix(dictionary): prevent duplicate special focus in fast fan-out

### DIFF
--- a/src/__tests__/infrastructure/api/services/dictionary/DictionaryService.test.ts
+++ b/src/__tests__/infrastructure/api/services/dictionary/DictionaryService.test.ts
@@ -41,4 +41,72 @@ describe('DictionaryService', () => {
       result.result.indexOf('# special focus')
     );
   });
+
+  it('only asks the special-focus block to generate the Special Focus section', async () => {
+    const loadPrompts = jest.fn().mockImplementation(async (paths: string[]) => paths[0]);
+    const executeWithoutCapabilities = jest.fn().mockResolvedValue({
+      content: '## content',
+      usage: undefined
+    });
+
+    const aiResourceManager = {
+      initializeResources: jest.fn().mockResolvedValue(undefined),
+      getOrchestrator: jest.fn().mockReturnValue({ executeWithoutCapabilities })
+    };
+
+    const service = new DictionaryService(
+      aiResourceManager as any,
+      {
+        getPromptLoader: () => ({ loadPrompts })
+      } as any,
+      {} as any
+    );
+
+    await service.generateParallelDictionary('crash', 'Need scene-specific guidance.');
+
+    const specialFocusCalls = executeWithoutCapabilities.mock.calls.filter((call) => call[0] === 'dictionary-fast-special-focus');
+    const definitionCalls = executeWithoutCapabilities.mock.calls.filter((call) => call[0] === 'dictionary-fast-definition');
+
+    expect(specialFocusCalls).toHaveLength(1);
+    expect(definitionCalls).toHaveLength(1);
+    expect(specialFocusCalls[0][2]).toContain('generate the dedicated "Special Focus" section');
+    expect(definitionCalls[0][2]).toContain('Do NOT generate a "Special Focus" section in this block.');
+  });
+
+  it('strips stray Special Focus sections from non-special-focus blocks during assembly', async () => {
+    const loadPrompts = jest.fn().mockImplementation(async (paths: string[]) => paths[0]);
+    const executeWithoutCapabilities = jest.fn().mockImplementation(async (toolName: string) => {
+      if (toolName === 'dictionary-fast-special-focus') {
+        return {
+          content: '## **Special Focus: Scene Fit**\n- Keep it punchy.',
+          usage: undefined
+        };
+      }
+
+      return {
+        content: `## ${toolName}\n- Core block content.\n\n## **Special Focus: Duplicate**\n- Should be removed.`,
+        usage: undefined
+      };
+    });
+
+    const aiResourceManager = {
+      initializeResources: jest.fn().mockResolvedValue(undefined),
+      getOrchestrator: jest.fn().mockReturnValue({ executeWithoutCapabilities })
+    };
+
+    const service = new DictionaryService(
+      aiResourceManager as any,
+      {
+        getPromptLoader: () => ({ loadPrompts })
+      } as any,
+      {} as any
+    );
+
+    const result = await service.generateParallelDictionary('crash', 'Need scene-specific guidance.');
+    const specialFocusMatches = result.result.match(/## \*\*Special Focus:/g) ?? [];
+
+    expect(specialFocusMatches).toHaveLength(1);
+    expect(result.result).toContain('## **Special Focus: Scene Fit**');
+    expect(result.result).not.toContain('## **Special Focus: Duplicate**');
+  });
 });

--- a/src/infrastructure/api/services/dictionary/DictionaryService.ts
+++ b/src/infrastructure/api/services/dictionary/DictionaryService.ts
@@ -359,7 +359,7 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
       const systemMessage = `${baseInstructions}\n\n---\n\n${blockPrompt}`;
 
       // Build user message
-      const userMessage = this.buildBlockUserMessage(word, context);
+      const userMessage = this.buildBlockUserMessage(blockName, word, context);
 
       this.outputChannel?.appendLine(`[DictionaryService] Generating block: ${blockName}`);
 
@@ -395,7 +395,7 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
         this.outputChannel?.appendLine(`[DictionaryService] Retrying block "${blockName}"...`);
         const blockPrompt = await this.loadBlockPrompt(`${paddedNumber}-${blockName}-block`);
         const systemMessage = `${baseInstructions}\n\n---\n\n${blockPrompt}`;
-        const userMessage = this.buildBlockUserMessage(word, context);
+        const userMessage = this.buildBlockUserMessage(blockName, word, context);
 
         const result = await orchestrator.executeWithoutCapabilities(
           `dictionary-fast-${blockName}-retry`,
@@ -449,21 +449,27 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
   /**
    * Build user message for block generation
    */
-  private buildBlockUserMessage(word: string, context?: string): string {
+  private buildBlockUserMessage(blockName: DictionaryBlockName, word: string, context?: string): string {
     const lines = [
       `Generate the dictionary section for the following word:`,
       '',
-      `Word: ${word.trim()}`
+      `Word: ${word.trim()}`,
+      `Requested block: ${blockName}`
     ];
 
     if (context?.trim()) {
       lines.push('', 'Context (use to tailor examples and usage notes):', context.trim());
     }
 
-    lines.push(
-      '',
-      'If context is provided, generate a dedicated "Special Focus" section that directly answers the writer\'s contextual question or use case.'
-    );
+    if (blockName === 'special-focus') {
+      lines.push(
+        '',
+        'Use the provided context to generate the dedicated "Special Focus" section and answer the writer\'s contextual question or use case directly.'
+      );
+    } else {
+      lines.push('', 'Do NOT generate a "Special Focus" section in this block.');
+    }
+
     lines.push('', 'Output ONLY the section content as specified in the block instructions.');
 
     return lines.join('\n');
@@ -512,7 +518,7 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
           partialFailures.push(blockName);
         } else if (result.content.trim()) {
           successCount++;
-          orderedContent.push(result.content.trim());
+          orderedContent.push(this.normalizeBlockContent(blockName, result.content));
         }
       }
     }
@@ -559,5 +565,19 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
     if (this.statusEmitter) {
       this.statusEmitter(message, progress, tickerMessage);
     }
+  }
+
+  /**
+   * Defensive cleanup for block spillover when the model ignores block boundaries.
+   */
+  private normalizeBlockContent(blockName: DictionaryBlockName, content: string): string {
+    const trimmed = content.trim();
+
+    if (blockName === 'special-focus') {
+      return trimmed;
+    }
+
+    const specialFocusHeader = /(?:^|\n)## \*\*Special Focus:[\s\S]*$/i;
+    return trimmed.replace(specialFocusHeader, '').trim();
   }
 }


### PR DESCRIPTION
## Summary
Fix the fast dictionary fan-out so the Special Focus section is generated only once when context is provided.

## Changes
- scope Special Focus prompting to the dedicated special-focus block
- strip stray Special Focus output from non-special-focus blocks during assembly
- add regression tests covering prompt scoping and duplicate cleanup

---
Generated with Codex
