### PR TITLE
Address pre-release cleanup debt

### DIFF
--- a/.todo/archive/tech-debt/2025-12-05-cancel-message-duplication.md
+++ b/.todo/archive/tech-debt/2025-12-05-cancel-message-duplication.md
@@ -2,7 +2,7 @@
 
 **Date Identified**: 2025-12-05
 **Reviewed**: 2026-06-25
-**Status**: Identified
+**Status**: Resolved
 **Priority**: Low
 **Estimated Effort**: Under half a day
 
@@ -43,3 +43,10 @@ Include category search explicitly rather than widening types through casts.
 - UI call sites no longer hand-build cancel envelopes
 - Search cancellation is represented by the shared contract
 - Mapping and envelope shape have focused tests
+
+## Resolution
+
+Resolved on 2026-06-30 in `release-cleanup/pre-v2-low-hanging-fruit`.
+Added a shared `createCancelRequestMessage()` helper, represented category
+search as the `search` streaming domain, and covered the mapping with focused
+tests.

--- a/.todo/archive/tech-debt/2026-06-26-api-key-warning-live-clear.md
+++ b/.todo/archive/tech-debt/2026-06-26-api-key-warning-live-clear.md
@@ -2,7 +2,7 @@
 
 **Date Identified**: 2026-06-26
 **Source**: PR #64 review, finding 3
-**Status**: Identified
+**Status**: Resolved
 **Priority**: Low
 **Estimated Effort**: 2-4 hours
 
@@ -44,3 +44,10 @@ One safe shape:
 - All three result hooks handle the message safely
 - Only API-key warning output is cleared; user content is preserved
 - Tests cover live warning clear and non-warning preservation
+
+## Resolution
+
+Resolved on 2026-06-30 in `release-cleanup/pre-v2-low-hanging-fruit`.
+Added a typed `CLEAR_TRANSIENT_API_KEY_WARNING` message emitted only after a
+successful key-backed secret refresh. Analysis, dictionary, and context clear
+only the no-key warning sentinel and preserve ordinary output.

--- a/.todo/archive/tech-debt/2026-06-26-service-refresh-observability.md
+++ b/.todo/archive/tech-debt/2026-06-26-service-refresh-observability.md
@@ -2,7 +2,7 @@
 
 **Date Identified**: 2026-06-26
 **Source**: PR #64 review, finding 5
-**Status**: Identified
+**Status**: Resolved
 **Priority**: Medium
 **Estimated Effort**: 2-3 hours
 
@@ -40,3 +40,9 @@ not what it changed to.
 - Successful refresh emits a completion line
 - Tests cover at least one named failure path
 - No API key or secret event payload is logged
+
+## Resolution
+
+Resolved on 2026-06-30 in `release-cleanup/pre-v2-low-hanging-fruit`.
+Service refresh now logs start, named failure, skipped remaining steps, and
+successful completion without logging secret material.

--- a/.todo/archive/tech-debt/2026-06-29-untitled-document-active-file-edge.md
+++ b/.todo/archive/tech-debt/2026-06-29-untitled-document-active-file-edge.md
@@ -2,7 +2,7 @@
 
 **Date Identified**: 2026-06-29
 **Reviewed**: 2026-06-29
-**Status**: Deferred
+**Status**: Resolved
 **Priority**: Low
 **Estimated Effort**: Small
 
@@ -34,3 +34,10 @@ a direct text-source path for unsaved selections.
 - If needed, the user-facing message clearly explains that the buffer must be
   saved or selected text must be supplied directly.
 - Any behavior change has focused tests or a documented F5 smoke result.
+
+## Resolution
+
+Resolved on 2026-06-30 in `release-cleanup/pre-v2-low-hanging-fruit`.
+Selection mode remains supported for untitled buffers because it reads selected
+text directly. Active-file mode now fails with a clear "save the file first or
+use selected text" message, covered by resolver tests.

--- a/.todo/epics/epic-architecture-health-pass-v1.3/epic-architecture-health-pass-v1.3.md
+++ b/.todo/epics/epic-architecture-health-pass-v1.3/epic-architecture-health-pass-v1.3.md
@@ -61,7 +61,6 @@ repository-wide visual rewrite.
 - [Settings integration tests](../../tech-debt/2025-11-06-settings-integration-tests.md)
 - [Large-file responsibility review](../../tech-debt/2025-11-19-large-file-review-needed.md)
 - [AIResourceOrchestrator loop duplication](../../tech-debt/2025-11-25-ai-resource-orchestrator-loop-duplication.md)
-- [Cancel-message duplication](../../tech-debt/2025-12-05-cancel-message-duplication.md)
 - [Streaming lifecycle duplication](../../tech-debt/2025-12-05-streaming-hook-duplication.md)
 
 These are follow-up debt, not unfinished acceptance criteria for the completed

--- a/.todo/epics/epic-architecture-health-pass-v1.3/sub-epic-4-polish-ux/epic-polish-ux.md
+++ b/.todo/epics/epic-architecture-health-pass-v1.3/sub-epic-4-polish-ux/epic-polish-ux.md
@@ -25,11 +25,10 @@ reference component.
 
 ## Follow-up Debt
 
-Streaming and cancellation shipped successfully, but exposed two separate
-maintenance concerns:
+Streaming and cancellation shipped successfully, but exposed a remaining
+maintenance concern:
 
-- [Cancel-message duplication](../../../tech-debt/2025-12-05-cancel-message-duplication.md)
 - [Streaming lifecycle duplication](../../../tech-debt/2025-12-05-streaming-hook-duplication.md)
 
-Those items remain valid follow-up debt and do not reopen the completed
+This item remains valid follow-up debt and does not reopen the completed
 streaming sprint.

--- a/.todo/tech-debt/README.md
+++ b/.todo/tech-debt/README.md
@@ -53,10 +53,7 @@ elsewhere.
 | Medium | [Settings integration tests](2025-11-06-settings-integration-tests.md) | Deferred |
 | Low | [Large-file responsibility review](2025-11-19-large-file-review-needed.md) | Deferred |
 | Low | [AIResourceOrchestrator loop duplication](2025-11-25-ai-resource-orchestrator-loop-duplication.md) | Identified |
-| Low | [Cancel-message duplication](2025-12-05-cancel-message-duplication.md) | Identified |
 | Medium | [Streaming lifecycle duplication](2025-12-05-streaming-hook-duplication.md) | Identified |
-| Low | [API-key warning live clear contract](2026-06-26-api-key-warning-live-clear.md) | Identified |
-| Medium | [Service refresh observability](2026-06-26-service-refresh-observability.md) | Identified |
 | Low | [AI service refresh duplication](2026-06-26-ai-service-refresh-duplication.md) | Identified |
 | Low | [Secret-change key filtering](2026-06-26-secret-change-key-filtering.md) | Identified |
 | Low | [MessageHandler self-heal cleanup](2026-06-26-messagehandler-self-heal-cleanup.md) | Identified |
@@ -64,7 +61,6 @@ elsewhere.
 | Low | [TypeScript project references](2026-06-29-typescript-project-references.md) | Deferred |
 | Low | [Logging and AI alias modernization](2026-06-29-logging-and-ai-alias-modernization.md) | Deferred |
 | Low | [App-side VS Code Jest mock](2026-06-29-app-side-vscode-jest-mock.md) | Deferred |
-| Low | [Untitled document active file edge](2026-06-29-untitled-document-active-file-edge.md) | Deferred |
 | Low | [Manuscript read and boundary guard performance](2026-06-29-manuscript-read-and-boundary-guard-performance.md) | Deferred |
 | Low | [Build command gate semantics](2026-06-29-build-command-gate-semantics.md) | Deferred |
 

--- a/docs/pr-reviews/pr-65-pre-release-cleanup-debt-review.md
+++ b/docs/pr-reviews/pr-65-pre-release-cleanup-debt-review.md
@@ -1,0 +1,331 @@
+# PR Review — #65: Address pre-release cleanup debt
+
+**Author:** okeylanders · PR #65 on `release-cleanup/pre-v2-low-hanging-fruit`
+**Reviewed:** 2026-06-30 (multi-agent pass — 10 reviewers + Sensei)
+**Status:** 🟡 **No blockers. One structural HIGH (duplication). Several clean STANDARDs — most suitable for follow-up debt. PR is nearly merge-ready.**
+
+---
+
+## Findings at a Glance
+
+| # | Status | Severity | Finding | Reviewer(s) |
+|---|--------|----------|---------|-------------|
+| 1 | 🔵 Open | 🟠 High 🎯🎯 | **`isTextSourceValidationError` duplicated verbatim in MetricsHandler + SearchHandler** — single-source utility needed | Marcus · Parker · Stan **Strong Consensus** |
+| 2 | 🔵 Open | 🟡 Standard | **`useContext.cancelStreaming` still calls `streaming.reset()`** — inconsistent with the partial-content fix applied to useAnalysis and useDictionary | Sam |
+| 3 | 🔵 Open | 🟡 Standard | **Partial refresh early-exit suppresses warning clear even with a valid key** — acceptance criteria say "after successful key-backed self-heal," not "all four services must succeed" | Bria |
+| 4 | 🔵 Open | 🟡 Standard | **MetricsHandler catch blocks never log to the output channel** — three error paths send to webview only; output panel is silent | Oliver |
+| 5 | 🔵 Open | 🟡 Standard | **`handleMeasureWordSearch` catch is silent in output channel** — asymmetric with `handleCategorySearchRequest` five lines above | Oliver |
+| 6 | 🔵 Open | 🟡 Standard | **`streamingCancelMessages.ts` lives in `webview/utils/` but has zero presentation coupling** — pure message factory belongs in `shared/` or `application/` | Stan |
+| 7 | 🔵 Open | 🟡 Standard | **`refreshServiceConfiguration` partial failure has no user-visible signal** — webview sees nothing; output channel logs the step but UI doesn't | Marcus |
+| 8 | 🔵 Open | 🟡 Standard | **`postClearTransientApiKeyWarningIfConfigured` re-reads SecretStorage after successful refresh** — 5th keychain round-trip; TOCTOU window | Marcus · Sam · Tim 🎯 Consensus |
+| 9 | 🔵 Open | 🟡 Standard | **MetricsHandler test covers only `handleMeasureStyleFlags`** — prose_stats and word_frequency have same catch pattern, untested for untitled-buffer path | Cal |
+| 10 | 🔵 Open | 🟡 Standard | **cancelStreaming empty-buffer branch untested** — `if (partialContent)` guard leaves previous result visible with no spinner; semantics undocumented | Cal |
+| 11 | 🔵 Open | 🟡 Standard | **`resolveSingleFilePath` accepts absolute paths with no workspace-containment check** — `isPathWithinRoot` already exists; LLM-generated crafted paths are a realistic threat | Patricia |
+| 12 | 🔵 Open | 🟢 Nit | **Sequential service refresh could be `Promise.all`'d** — if no dependency order, 4 serial keychain round-trips is unnecessary; needs a comment if intentional | Tim |
+| 13 | 🔵 Open | 🟢 Nit | **`postClearTransientApiKeyWarningIfConfigured` — "IfConfigured" misleads** — the guard is key presence, not a configuration toggle | Parker |
+| 14 | 🔵 Open | 🟢 Nit | **`createCancelRequestMessage` `as CancelRequestMessage` cast is undocumented** — structurally sound but silent about the trade-off | Parker · Bria 🎯 Consensus |
+| 15 | 🔵 Open | 🟢 Nit | **`StreamingDomain` JSDoc says "support streaming" but `search` only supports cancel** — misleading for future readers | Stan |
+| 16 | 🔵 Open | 🟢 Nit | **`isUnsavedEditorDocument` test provides both signals simultaneously** — `uriString` and `fsPath` conditions not tested in isolation | Cal |
+| 17 | 🔵 Open | 🟢 Nit | **`refreshServiceConfiguration` success path doesn't list completed step names** — failure path names everything; success path just says "completed" | Oliver |
+| 18 | 🔵 Open | 🟢 Nit | **`console.error` in `SecretStorageService` bypasses LogSink** — pre-existing; routes to DevTools instead of the output channel | Patricia |
+| P1 | N/A | 🟢 Praise | **Clean bill of health on all load-bearing paths** — buffer preservation, refresh sequencing, sentinel clearing, untitled-buffer guard all correct | Blake |
+| P2 | N/A | 🟢 Praise | **Sequential refresh with named step logging is excellent operational design** | Sam |
+| P3 | N/A | 🟢 Praise | **API key checked for presence only, never logged; typed empty payload enforces this at compile time** | Patricia |
+| P4 | N/A | 🟢 Praise | **Domain 3 untitled-buffer logic is correctly placed** — `resolveActiveFile` guard, `resolveSelection` bypass — right rule at the right layer | Bria |
+
+---
+
+## Blast Radius
+
+- **23 files changed** · **+606 / −92 lines**
+- New files: **2** (`streamingCancelMessages.ts`, `streamingCancelMessages.test.ts`) · Migrations: **none** · New services/controllers: **none**
+- **Four distinct work streams:** (1) streaming cancel message centralization (new utility + 4 call-site collapses), (2) service refresh observability (named steps, early-exit, completion log), (3) untitled-buffer `activeFile` guard in `TextSourceResolver`, (4) typed `CLEAR_TRANSIENT_API_KEY_WARNING` message with fan-out to three AI result hooks. Plus 4 tech-debt notes archived.
+- **Character:** a well-motivated cleanup batch with good test coverage on the new behaviors. The load-bearing paths are sound. The signal from the panel is focused on two themes — a duplicated string list that will drift, and the `useContext` cancel inconsistency that slipped through.
+
+---
+
+## Report Card
+
+| Category | Grade |
+| --- | --- |
+| 🏛️ Architecture | C+ |
+| 🛡️ Security | A− |
+| 🧪 Tests | B− |
+| 📖 Quality | B |
+| ⚡ Performance | B |
+| 🎯 Domain | B |
+
+Architecture is pulled down by one HIGH finding that three reviewers flagged independently: the duplicated predicate in two handlers. Security sits high because the API key surface is genuinely clean — key existence is checked but never logged, the typed empty payload enforces nothing sensitive can transit, and Blake found nothing that pages. Tests are solid on the new behaviors but have two meaningful gaps (MetricsHandler's other two methods, the empty-cancel branch). Quality and Domain are healthy — the new code is readable and the business logic is correctly placed.
+
+---
+
+## Executive Briefing
+
+**No 🔴 blockers.** Blake walked every correctness path — buffer preservation, refresh sequencing, warning sentinel logic, untitled-buffer guard — and cleared them all. One 🟠 and a handful of STANDARDs follow.
+
+🟠 **[Marcus · Parker · Stan — 🎯🎯 Strong Consensus]** **`isTextSourceValidationError` is duplicated verbatim.** The same seven-string prefix list is copy-pasted into both `MetricsHandler` and `SearchHandler` as private methods. This PR just demonstrated the problem: when `TextSourceResolver` grew a new error (the `untitled:` guard), the prefix list needed updating in two places — and if a third handler adopts the pattern, it'll be three. The resolver is the right home for this classification; it already owns the throwing logic.
+
+---
+
+## 🏛️ Marcus · Architecture & Design
+
+*"The Cartographer of Layer Boundaries"*
+
+### 🟠 High — Duplicated validation error classifier across two handler siblings [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/handlers/domain/MetricsHandler.ts` & `SearchHandler.ts` — both handlers now carry a private `isTextSourceValidationError` method with an identical seven-element string array. The method is the architectural smell; the duplication is just the symptom. `TextSourceResolver` is the sole producer of these error strings — when it throws, it decides the vocabulary. The classification predicate belongs adjacent to that vocabulary, either as a static method (`TextSourceResolver.isValidationError(msg)`) or as an exported function in a shared handler utility. As written, the next engineer adding a new throw to `TextSourceResolver` must also update two private method bodies they may not find, and the divergence in `sendTextSourceError` signatures (`SearchHandler` has a `fallback` param; `MetricsHandler` doesn't) is already the first sign of drift.
+
+### 🟡 Standard — Partial refresh failure has no user-visible signal
+
+`packages/core/src/application/handlers/MessageHandler.ts` — the `refreshServiceConfiguration` for-loop exits early on first failure. The output channel gets a named-step failure log and a skip list; the webview gets nothing. A user whose AI resource manager throws a transient error during key-change refresh will see three of four services stuck on stale configuration with no indicator. The `clearApiKeyWarningOnSuccess` path correctly gates on full completion, but the partial-failure path needs at least a STATUS message posted to the webview before returning so the user knows the refresh was partial.
+
+### 🟡 Standard — `postClearTransientApiKeyWarningIfConfigured` re-reads the key you already have [🎯 Consensus]
+
+`packages/core/src/application/handlers/MessageHandler.ts` — this method is called after a successful `refreshServiceConfiguration`, which already read the key in each of the four `refreshConfiguration()` calls. It then calls `secretsService.getApiKey()` again to decide whether to dispatch the clear message. The caller's contract ("I was invoked because refresh succeeded with a valid key") already implies key presence. The re-read adds a 5th SecretStorage round-trip and a narrow TOCTOU: refresh succeeds with key A, key is deleted before this call, read returns empty, warning never clears. Trust the context the caller has already established.
+
+> *"The resolver learned to throw a new error; the two handlers who caught it were not in the room, and now they share a handwritten list of its words that will drift apart the moment it speaks again."* — Marcus
+
+---
+
+## 🔥 Blake · Critical / Blocking Issues
+
+*"She's Been Paged for This Before"*
+
+### 🟢 Praise — 0 findings. Nothing will page me.
+
+Traced all load-bearing paths:
+
+- **Buffer preservation (useDictionary):** `streaming.buffer` is read before `endStreaming()` resets it; `STREAM_COMPLETE {cancelled:true}` for the same requestId doesn't touch `setResult`. Sound.
+- **refreshServiceConfiguration:** sequential, early-exit, warning-clear gated on live `getApiKey()` inside its own try/catch. Sound.
+- **`CLEAR_TRANSIENT_API_KEY_WARNING`:** enum member exists, message typed, fanned out to all three hooks in `useAppMessageRouter`, each hook only clears the no-key sentinel via `isApiKeyNotConfiguredWarning`. Sound.
+- **`isUnsavedEditorDocument`:** `untitled:` check is correct; saved files always have a real `fsPath`. Sound.
+
+The `isTextSourceValidationError` duplication is real but a Parker/Stan note. No correctness or data-integrity failure traceable through the code.
+
+> *"I came looking for a fire and found a tidy kitchen — buffer's read while it's still warm, the key's checked live before we tell the UI to calm down, and the untitled-buffer trapdoor is nailed shut. Ship it."* — Blake
+
+---
+
+## 🔍 Sam · Bug Hunter
+
+*"What if the list is empty, though?"*
+
+### 🟡 Standard — `useContext.cancelStreaming` still resets the buffer
+
+`packages/core/src/presentation/webview/hooks/domain/useContext.ts:239` — the PR intentionally preserves partial streamed content on cancel in both `useAnalysis` (reads `streaming.buffer` → `endStreaming()` → `setResult`) and `useDictionary` (same pattern). `useContext.cancelStreaming` still calls `streaming.reset()`, wiping everything unconditionally. A user who hits Cancel at 80% through a context generation loses everything they could read. Same Cancel button in `AnalysisTab.tsx`, three different philosophies, no comment explaining why context is different. If it's intentional — "context is cheap to regenerate" — it should say so. If not, it's a missed update.
+
+### 🟢 Nit — API key re-read after successful refresh [🎯 Consensus]
+
+`packages/core/src/application/handlers/MessageHandler.ts` — same finding as Marcus #3. The successful refresh already used the key to re-initialize all four services. Asking the keychain again introduces a flush-window race, particularly on Linux with libsecret.
+
+### 🟢 Praise — Named refresh steps are excellent operational design
+
+`packages/core/src/application/handlers/MessageHandler.ts` — the `refreshSteps` array with named step logging on failure, explicit skip-list logging, and early-exit is exactly what you want in the Output Channel at 2am: one line naming the failing service, one line naming what didn't run. Clean work.
+
+> *"Okay but what happens when you hit Cancel at 80% through a context generation? Turns out the answer is 'all gone' — while your dictionary definition sits there waiting for you. Same button, different philosophy, no comment."* — Sam
+
+---
+
+## 📖 Parker · Code Quality
+
+*"Code is Communication, Not Instruction"*
+
+### 🟡 Standard — `isTextSourceValidationError` duplicated byte-for-byte [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/handlers/domain/SearchHandler.ts:185` — seven-element string array, byte-for-byte identical in `MetricsHandler`. The PR just demonstrated the maintenance cost: `TextSourceResolver` grew a new error and both lists needed updating. If a future `ContextHandler` or `AnalysisHandler` needs the same pattern, it'll copy it a third time. A shared exported constant or function — `textSourceErrors.isValidationError(msg)` — is the right extraction. The `sendTextSourceError` signatures already diverged (`SearchHandler` has a `fallback` param; `MetricsHandler` hardcodes the string), so the API has drifted on introduction.
+
+### 🟢 Nit — `postClearTransientApiKeyWarningIfConfigured`: "IfConfigured" implies the wrong precondition
+
+`packages/core/src/application/handlers/MessageHandler.ts` — the method name suggests a configuration toggle gates this behavior. The actual guard is `if (!apiKey) return` — key presence. A reader looking for "what configuration?" will find nothing. `IfKeyPresent` or `maybeClearTransientApiKeyWarning` would make the guard legible without opening the body.
+
+### 🟢 Nit — `createCancelRequestMessage` `as CancelRequestMessage` cast is undocumented [🎯 Consensus]
+
+`packages/core/src/presentation/webview/utils/streamingCancelMessages.ts:34` — the cast is structurally correct (the `cancelMessageTypes` record is exhaustive), but it silences the type-checker for the whole object and is unexplained. A brief inline comment noting "type field from runtime lookup — cast is safe because cancelMessageTypes is exhaustive over StreamingDomain" would make the trade-off legible.
+
+> *"If the name says 'configured' but the guard says 'key present,' the name is lying with good intentions."* — Parker
+
+---
+
+## 🧪 Cal · Test Coverage & Quality
+
+*"Confidence Levels, Not Coverage Numbers"*
+
+### 🟡 Standard — cancelStreaming empty-buffer branch has no test
+
+`packages/core/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts:207` — the only streaming-cancel test sends two chunks before cancelling, so `partialContent` is always truthy and `setResult(partialContent)` always fires. The `if (partialContent)` guard means cancelling with an empty buffer is a no-op — the previous result (stale warning, prior lookup) stays visible while `loading` and `isStreaming` both go false. That's an ambiguous end state with no test pinning the intended behavior.
+
+### 🟡 Standard — MetricsHandler test covers only `handleMeasureStyleFlags`
+
+`packages/core/src/__tests__/application/handlers/domain/MetricsHandler.test.ts:46` — `handleMeasureProseStats` and `handleMeasureWordFrequency` both call `TextSourceResolver` and have identical catch patterns, but neither is tested for the untitled-buffer path. Searched diff for `handleMeasureProseStats` and `handleMeasureWordFrequency` in the new test block — not found. A parameterized test across all three handler methods would give meaningful coverage without ceremony.
+
+### 🟢 Nit — `isUnsavedEditorDocument` conditions not tested in isolation
+
+`packages/core/src/infrastructure/text/TextSourceResolver.ts` — the method checks `uriString.startsWith('untitled:') || fsPath.trim().length === 0`. The test fixture supplies both signals simultaneously. Neither condition is exercised alone, so you can't tell which one you actually rely on.
+
+> *"The empty-cancel branch is the test pyramid's basement — one state transition, zero assertions, vibes doing the work of a contract."* — Cal
+
+---
+
+## 🗂️ Stan · Codebase Standards
+
+*"He Has Every Pattern Memorized"*
+
+### 🟡 Standard — `isTextSourceValidationError` duplicated verbatim across two handler siblings [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/handlers/domain/SearchHandler.ts:185` — same finding as Marcus and Parker. The moment `ContextHandler` or another handler needs this predicate, it'll be copy-pasted a third time. The sendTextSourceError signatures already diverged (`SearchHandler` has `fallback`; `MetricsHandler` doesn't) — that's the first crack. A shared function, probably `packages/core/src/application/handlers/shared/textSourceErrors.ts`, is the right home.
+
+### 🟡 Standard — `streamingCancelMessages.ts` placed in `webview/utils/` but has no webview dependency
+
+`packages/core/src/presentation/webview/utils/streamingCancelMessages.ts:1` — the file imports only from `@messages` and constructs plain message objects. No React, no DOM, no `acquireVsCodeApi`. By project convention, `webview/utils/` is for presentation helpers. A pure message-factory function belongs in `shared/` or `application/handlers/`, where a future backend caller could import it without reversing the dependency direction. Placing it in `webview/utils/` encodes "only the frontend can use this" when the content says "anyone can use this."
+
+### 🟢 Nit — `StreamingDomain` JSDoc says "support streaming" but `search` is cancel-only
+
+`packages/core/src/shared/types/messages/streaming.ts:12` — `search` doesn't emit `STREAM_STARTED`, `STREAM_CHUNK`, or `STREAM_COMPLETE`. The comment is technically wrong and will mislead the next engineer who wonders why their streaming domain handler isn't working. Update to `/** Domain types that support streaming or cancel requests */` or rename to `CancellableDomain`.
+
+> *"Two handlers just tattooed the same seven errors on their chests — at least one of them should have been a shared scar."* — Stan
+
+---
+
+## ⚡ Tim · Performance
+
+*"O(n²) at Scale is an Incident Waiting to Happen"*
+
+### 🟡 Standard — Sequential service refresh serializes four keychain round-trips
+
+`packages/core/src/application/handlers/MessageHandler.ts` — the four `refreshConfiguration()` calls run sequentially. If each service independently hits SecretStorage (OS keychain on macOS), that's 4 serial round-trips where `Promise.all` could parallelize them. At current scale — this fires on a rare secret change — it's a user-perceived delay, not a throughput concern. If the sequencing is intentional (dependency order, partial-failure semantics), it should have a comment saying so. If not, this is `Promise.allSettled` territory with the caveat that parallelizing removes the current early-exit behavior.
+
+### 🟢 Nit — 5th SecretStorage read in `postClearTransientApiKeyWarningIfConfigured` [🎯 Consensus]
+
+`packages/core/src/application/handlers/MessageHandler.ts` — five keychain reads to do what could be four. Negligible at this frequency, but the answer is already in context from the successful refresh.
+
+> *"Four sequential keychain knocks and then a fifth to confirm the door was answered — the secret is out there, no need to ring again."* — Tim
+
+---
+
+## 🛡️ Patricia · Security
+
+*"She Reads Code Like an Attacker Would"*
+
+### 🟡 Standard — `resolveSingleFilePath` accepts absolute paths with no containment check
+
+`packages/core/src/infrastructure/text/TextSourceResolver.ts:139` — when `pathText` is supplied as an absolute path, `resolveSingleFilePath` reads from it with no `isPathWithinRoot` containment check. A crafted LLM-generated tool-use payload could supply `/etc/passwd` and the resolver would read it. The project already has `isPathWithinRoot` in `@/infrastructure/storage/pathContainment`, used in `UIHandler`, `prompts.ts`, and `guides.ts`. The threat surface is local (same-machine, same-user), so this is STANDARD — but this PR is hardening the same code path, and AI-generated absolute paths are a documented injection vector for writing tools. Good time to log it.
+
+### 🟢 Nit — `console.error` in `SecretStorageService` bypasses LogSink (pre-existing)
+
+`packages/core/src/infrastructure/secrets/SecretStorageService.ts` — bare `console.error` routes to the DevTools console rather than the Prose Minion output channel. Pre-existing, not introduced here. No key exposure — the error object is from the SecretStorage platform call. File for debt.
+
+### 🟢 Praise — API key existence checked for presence only; payload typed to prevent leakage
+
+`packages/core/src/application/handlers/MessageHandler.ts` — `getApiKey()` result is used as a truthy check only, never interpolated into a log or payload. The `ClearTransientApiKeyWarningMessage` payload is typed as `Record<string, never>`, enforcing at compile time that nothing sensitive can transit this message. Clean.
+
+> *"The key check is correct, the payload is empty, the types are honest — this is what good secret handling looks like; now go put `isPathWithinRoot` on that absolute-path branch before the LLM-hallucinated path does the work for me."* — Patricia
+
+---
+
+## 🌙 Oliver · Observability & Debuggability
+
+*"Would This Failure Leave a Trail at 2am?"*
+
+### 🟡 Standard — MetricsHandler catch blocks are silent in the output channel
+
+`packages/core/src/application/handlers/domain/MetricsHandler.ts:107` (prose_stats), `120` (style_flags), `133` (word_frequency) — all three catch blocks call `sendTextSourceError` and nothing else. `this.outputChannel` is injected and never touched in any error path. The webview gets a message; the output panel gets nothing. At midnight searching the Output Channel for why metrics are broken for an unsaved file: zero results. One `this.outputChannel.appendLine(...)` per catch, before `sendTextSourceError`, is the fix. `SearchHandler` already does this for category search — that's the sibling pattern to follow.
+
+### 🟡 Standard — `handleMeasureWordSearch` catch is also silent
+
+`packages/core/src/application/handlers/domain/SearchHandler.ts:113` — `handleCategorySearchRequest` logs `[SearchHandler] Category search error: ${msg}`. `handleMeasureWordSearch`, five lines above it in the same handler, does not. The asymmetry will be confusing: category search leaves a trail; word search doesn't. Searched diff for SearchHandler output channel changes in the word search catch — not found.
+
+### 🟢 Nit — Success path doesn't list completed step names
+
+`packages/core/src/application/handlers/MessageHandler.ts` — the failure path names the failing service and the skipped services. The success path just says "completed." A `completed (steps: ...)` line would make the happy path as traceable as the failure path when the list of steps ever changes.
+
+> *"The failure path finally has a name, which is progress — but the silence in MetricsHandler's catch means that when TextSourceResolver throws the new untitled-buffer error, it reaches the webview but never the output channel, and at midnight you'll be staring at a user report with nothing to grep."* — Oliver
+
+---
+
+## 🎯 Bria · Domain Logic & Business Correctness
+
+*"Does This Code Actually Do What the Ticket Asked?"*
+
+### 🟡 Standard — Partial refresh suppresses warning clear even when key is valid; no test covers this
+
+`packages/core/src/application/handlers/MessageHandler.ts:438` — the early-exit on first refresh failure means `clearApiKeyWarningOnSuccess` never fires on a partial refresh. So: user enters a valid key, `aiResourceManager.refreshConfiguration()` throws a transient error, the key is persisted and valid, but the "no API key" warning stays on screen permanently — no recovery path short of a window reload. The `postClearTransientApiKeyWarningIfConfigured` guard already does a `getApiKey()` check, so the real invariant ("key must exist") is enforced there. The acceptance criteria say "CLEAR_TRANSIENT_API_KEY_WARNING emitted ONLY after a successful key-backed self-heal" — but "successful" was implemented as "all four services refreshed without error," which is stricter than the stated requirement. The existing partial-failure test pins logging behavior; it doesn't assert whether the warning clear was suppressed.
+
+### 🟢 Nit — `createCancelRequestMessage` `as` cast undocumented [🎯 Consensus]
+
+Same as Parker Nit #3. Structurally correct at runtime (the `cancelMessageTypes` record is exhaustive over `StreamingDomain`), but the cast is silent about why it's safe.
+
+### 🟢 Praise — Domain 3 untitled-buffer logic is correctly placed
+
+`packages/core/src/infrastructure/text/TextSourceResolver.ts:47` — the `isUnsavedEditorDocument` guard lives only inside `resolveSingleFilePath`, which is only reachable from `resolveActiveFile`. `resolveSelection` intentionally bypasses it and reads `selection.text` directly — an untitled buffer's in-memory text is valid for selection mode. The `isEmpty` guard in `resolveSelection` correctly handles the no-text case for untitled buffers too. Right rule, right layer, right reason.
+
+> *"The key is in the lock, the door swings open fine — but the lobby sign still reads 'No entry' because the janitor tripped on step two of his morning checklist."* — Bria
+
+---
+
+## 🎓 Sensei · The Teacher
+
+*"The Review Is the Lesson. The Code Is the Practice."*
+
+### Lesson 1 — The Classifier Belongs Where the Knowledge Lives
+
+Illuminated by: Marcus #1, Parker #1, Stan #1
+
+When three reviewers independently flag the same duplicated predicate, the issue isn't carelessness — it's a sign that the system hasn't finished deciding who owns a piece of knowledge. `isTextSourceValidationError` is duplicated because both handlers needed it, but neither was the right home for it. The resolver that throws the error is the only entity that knows which errors are "its" errors. Classification logic belongs adjacent to the thing being classified, not scattered among the callers. The moment `TextSourceResolver` grows another error message, the drift between the two copies begins.
+
+→ Carry forward: when you find yourself writing `isSomeError` in a handler, ask: who throws this error? If the answer isn't "me," the predicate probably doesn't belong here.
+
+### Lesson 2 — Silent Partial State Is Worse Than Loud Failure
+
+Illuminated by: Marcus #2, Bria #1, Oliver #1, Oliver #2
+
+A system that fails quietly leaves the user holding a mental model that no longer matches reality. The partial-refresh early-exit doesn't just skip services — it suppresses the warning-clear, meaning a valid API key can live behind a permanent "something's wrong" banner. Meanwhile, catch blocks that speak to the webview but not the output channel split the audience: the user sees a message, the operator sees nothing. Partial state without a signal is an invisible lie the system tells about itself.
+
+→ Carry forward: for any operation that can partially succeed, ask two questions before shipping: what does the user see, and what does the operator see? If the answers differ, that asymmetry needs to be intentional and documented.
+
+### Lesson 3 — Consistent Behavior Across Parallel Paths Is a Contract
+
+Illuminated by: Sam #1, Cal #1
+
+`cancelStreaming` was fixed in two hooks and left as-was in a third. From the user's perspective, Cancel is one button with one expected behavior — but under the hood it now has three implementations, two of which agree. The moment you establish a pattern fix across a class of similar things, any member you miss becomes a regression, not a pre-existing condition. Inconsistency in parallel paths is a broken contract the codebase makes with itself.
+
+→ Carry forward: when fixing a pattern in more than one place, enumerate all the places before you start. A quick grep for the function name is thirty seconds; missing one is a bug that ships.
+
+### Lesson 4 — Layer Placement Is a Future Caller's Problem
+
+Illuminated by: Stan #2
+
+`streamingCancelMessages.ts` has no presentation coupling — it imports only from `@messages` — but it lives in `webview/utils/`. Right now that's harmless. The day a backend handler wants the same factory, it faces a backwards dependency into the presentation layer or a copy-paste. Where you put code signals who you think is allowed to use it. Misplaced utilities quietly accumulate impossible dependency paths.
+
+→ Carry forward: before placing a new file, ask: does any import in this file require the layer I'm placing it in? If not, it probably belongs somewhere more central.
+
+### Lesson 5 — The Name Is a Specification
+
+Illuminated by: Parker #2
+
+`postClearTransientApiKeyWarningIfConfigured` suggests a configuration toggle gates the behavior. The actual guard is key presence. This isn't a minor naming quibble — the name is the first thing a future reader uses to decide whether to read the body. A name that describes the wrong precondition causes readers to either trust the name and miss the real logic, or distrust all names and read everything defensively. Honest names are load-bearing architecture.
+
+→ Carry forward: after naming something, ask: if I didn't write this, would that name make me look in the right place? If the name implies a condition the code doesn't check, fix the name.
+
+> *"The quiet bugs are not the ones that crash loudly at 3am — they are the ones that leave the world slightly wrong and never say so."* — Sensei
+
+---
+
+## The Closer
+
+### ⭐ Yelp Review
+
+**★★★★☆ — "Reliable neighborhood spot, one dish came out wrong"**
+
+I came in for the streaming cancel refactor and left thinking about string lists. Ordered the `createCancelRequestMessage` special — arrived clean, four call sites collapsed in one pass, exactly as described. The untitled-buffer guard was a pleasant surprise side dish: crisp, useful, covers the exact case where the old smoke-and-mirrors error used to live. The API key warning clear is the item I'll return for; the kitchen checked the key correctly, the payload came out empty, the types held. Would have been five stars except `useContext` got the old menu and nobody noticed until Sam followed the Cancel button home. The `isTextSourceValidationError` utility is definitely being handwritten fresh at every table — I'd ask them to laminate it and put it somewhere we can all find it. Blake personally inspected the kitchen and confirmed nothing is on fire. I'll be back.
+
+*(PR #65 → 65 % 6 = 5 → Yelp Review)*
+
+---
+
+## Summary
+
+A well-structured cleanup batch that resolves four tracked tech-debt items, centralizes cancel message construction, adds meaningful service-refresh observability, and correctly handles the untitled-buffer edge case. Blake cleared every correctness path — no blockers, nothing paging. The panel's three most consistent signals: (1) `isTextSourceValidationError` is duplicated and will drift — extract it to the resolver or a shared utility; (2) `useContext.cancelStreaming` missed the partial-content fix applied to its two siblings — a one-line asymmetry that should be resolved or documented; (3) `streamingCancelMessages.ts` belongs in a shared layer, not `webview/utils/`. The remaining STANDARDs (observability gaps in MetricsHandler catches, partial-refresh warning suppression, absolute path containment) are well-suited for follow-up debt entries rather than blocking the merge.
+
+---
+
+*Reviewed by: Marcus 🏛️ · Blake 🔥 · Sam 🔍 · Parker 📖 · Cal 🧪 · Stan 🗂️ · Tim ⚡ · Patricia 🛡️ · Oliver 🌙 · Bria 🎯 · Sensei 🎓*

--- a/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
@@ -258,5 +258,49 @@ describe('MessageHandler assembly', () => {
     expect(assembly.services.assistantToolService.refreshConfiguration).toHaveBeenCalledTimes(1);
     expect(assembly.services.dictionaryService.refreshConfiguration).toHaveBeenCalledTimes(1);
     expect(assembly.services.contextAssistantService.refreshConfiguration).toHaveBeenCalledTimes(1);
+    expect(assembly.log.appendLine).toHaveBeenCalledWith('[MessageHandler] Service configuration refresh completed');
+  });
+
+  it('posts a transient API-key warning clear after successful key-backed self-heal', async () => {
+    const assembly = createTestAssembly();
+    (assembly.services.secretsService.getApiKey as jest.Mock).mockResolvedValue('configured-key');
+    const postMessage = jest.fn().mockResolvedValue(undefined);
+    createHandler(assembly, postMessage);
+    postMessage.mockClear();
+
+    const onSecretChange = assembly.secretOnDidChange.mock.calls[0][0] as () => void;
+    onSecretChange();
+    await flushQueuedWork();
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+        source: 'extension.handler',
+        payload: {}
+      })
+    );
+  });
+
+  it('logs the named refresh step and skipped services when API key self-heal fails', async () => {
+    const assembly = createTestAssembly();
+    (assembly.services.assistantToolService.refreshConfiguration as jest.Mock).mockRejectedValueOnce(
+      new Error('assistant refresh failed')
+    );
+    createHandler(assembly, jest.fn().mockResolvedValue(undefined));
+
+    const onSecretChange = assembly.secretOnDidChange.mock.calls[0][0] as () => void;
+    onSecretChange();
+    await flushQueuedWork();
+
+    expect(assembly.services.aiResourceManager.refreshConfiguration).toHaveBeenCalledTimes(1);
+    expect(assembly.services.assistantToolService.refreshConfiguration).toHaveBeenCalledTimes(1);
+    expect(assembly.services.dictionaryService.refreshConfiguration).not.toHaveBeenCalled();
+    expect(assembly.services.contextAssistantService.refreshConfiguration).not.toHaveBeenCalled();
+    expect(assembly.log.appendLine).toHaveBeenCalledWith(
+      '[MessageHandler] Service configuration refresh failed at assistant tool service: assistant refresh failed'
+    );
+    expect(assembly.log.appendLine).toHaveBeenCalledWith(
+      '[MessageHandler] Service configuration refresh skipped: dictionary service, context assistant service'
+    );
   });
 });

--- a/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
@@ -258,7 +258,9 @@ describe('MessageHandler assembly', () => {
     expect(assembly.services.assistantToolService.refreshConfiguration).toHaveBeenCalledTimes(1);
     expect(assembly.services.dictionaryService.refreshConfiguration).toHaveBeenCalledTimes(1);
     expect(assembly.services.contextAssistantService.refreshConfiguration).toHaveBeenCalledTimes(1);
-    expect(assembly.log.appendLine).toHaveBeenCalledWith('[MessageHandler] Service configuration refresh completed');
+    expect(assembly.log.appendLine).toHaveBeenCalledWith(
+      '[MessageHandler] Service configuration refresh completed: AI resource manager, assistant tool service, dictionary service, context assistant service'
+    );
   });
 
   it('posts a transient API-key warning clear after successful key-backed self-heal', async () => {
@@ -279,6 +281,7 @@ describe('MessageHandler assembly', () => {
         payload: {}
       })
     );
+    expect(assembly.services.secretsService.getApiKey).toHaveBeenCalledTimes(1);
   });
 
   it('logs the named refresh step and skipped services when API key self-heal fails', async () => {
@@ -302,5 +305,39 @@ describe('MessageHandler assembly', () => {
     expect(assembly.log.appendLine).toHaveBeenCalledWith(
       '[MessageHandler] Service configuration refresh skipped: dictionary service, context assistant service'
     );
+  });
+
+  it('posts a partial-refresh status and clears stale API-key warnings when a key-backed self-heal partially fails', async () => {
+    const assembly = createTestAssembly();
+    (assembly.services.secretsService.getApiKey as jest.Mock).mockResolvedValue('configured-key');
+    (assembly.services.assistantToolService.refreshConfiguration as jest.Mock).mockRejectedValueOnce(
+      new Error('assistant refresh failed')
+    );
+    const postMessage = jest.fn().mockResolvedValue(undefined);
+    createHandler(assembly, postMessage);
+    postMessage.mockClear();
+
+    const onSecretChange = assembly.secretOnDidChange.mock.calls[0][0] as () => void;
+    onSecretChange();
+    await flushQueuedWork();
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.STATUS,
+        source: 'extension.handler',
+        payload: {
+          message: 'AI service refresh partially failed. Some tools may need a reload.',
+          tickerMessage: 'assistant tool service: assistant refresh failed'
+        }
+      })
+    );
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+        source: 'extension.handler',
+        payload: {}
+      })
+    );
+    expect(assembly.services.secretsService.getApiKey).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/__tests__/application/handlers/domain/MetricsHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/MetricsHandler.test.ts
@@ -11,16 +11,18 @@ describe('MetricsHandler', () => {
   let handler: MetricsHandler;
   let router: MessageRouter;
   let postMessage: jest.Mock;
+  let outputChannel: { appendLine: jest.Mock };
 
   beforeEach(() => {
     postMessage = jest.fn().mockResolvedValue(undefined);
+    outputChannel = { appendLine: jest.fn() };
     handler = new MetricsHandler(
       {} as any, // proseStatsService
       {} as any, // styleFlagsService
       {} as any, // wordFrequencyService
       {} as any, // standardsService
       postMessage as any, // postMessage
-      {} as any, // outputChannel
+      outputChannel as any, // outputChannel
       {} as any  // textSourceResolver
     );
     router = new MessageRouter();
@@ -48,7 +50,41 @@ describe('MetricsHandler', () => {
   });
 
   describe('Text source errors', () => {
-    it('surfaces unsaved active-file guidance as the user-facing metrics error', async () => {
+    it.each([
+      {
+        name: 'prose stats',
+        source: 'metrics.prose_stats',
+        logPrefix: 'Prose stats',
+        run: (testHandler: MetricsHandler) => testHandler.handleMeasureProseStats({
+          type: MessageType.MEASURE_PROSE_STATS,
+          source: 'webview.metrics',
+          payload: { source: { mode: 'activeFile' } },
+          timestamp: Date.now()
+        } as any)
+      },
+      {
+        name: 'style flags',
+        source: 'metrics.style_flags',
+        logPrefix: 'Style flags',
+        run: (testHandler: MetricsHandler) => testHandler.handleMeasureStyleFlags({
+          type: MessageType.MEASURE_STYLE_FLAGS,
+          source: 'webview.metrics',
+          payload: { source: { mode: 'activeFile' } },
+          timestamp: Date.now()
+        } as any)
+      },
+      {
+        name: 'word frequency',
+        source: 'metrics.word_frequency',
+        logPrefix: 'Word frequency',
+        run: (testHandler: MetricsHandler) => testHandler.handleMeasureWordFrequency({
+          type: MessageType.MEASURE_WORD_FREQUENCY,
+          source: 'webview.metrics',
+          payload: { source: { mode: 'activeFile' } },
+          timestamp: Date.now()
+        } as any)
+      }
+    ])('surfaces unsaved active-file guidance as the user-facing $name error', async ({ source, logPrefix, run }) => {
       const message = 'Active file is not saved to disk. Save the file first or use selected text instead.';
       handler = new MetricsHandler(
         {} as any,
@@ -56,28 +92,22 @@ describe('MetricsHandler', () => {
         {} as any,
         {} as any,
         postMessage as any,
-        {} as any,
+        outputChannel as any,
         { resolve: jest.fn().mockRejectedValue(new Error(message)) } as any
       );
 
-      await handler.handleMeasureStyleFlags({
-        type: MessageType.MEASURE_STYLE_FLAGS,
-        source: 'webview.metrics',
-        payload: {
-          source: { mode: 'activeFile' }
-        },
-        timestamp: Date.now()
-      } as any);
+      await run(handler);
 
       expect(postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           type: MessageType.ERROR,
           payload: {
-            source: 'metrics.style_flags',
+            source,
             message
           }
         })
       );
+      expect(outputChannel.appendLine).toHaveBeenCalledWith(`[MetricsHandler] ${logPrefix} error: ${message}`);
     });
   });
 });

--- a/packages/core/src/__tests__/application/handlers/domain/MetricsHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/MetricsHandler.test.ts
@@ -10,14 +10,16 @@ import { MessageType } from '@/shared/types/messages';
 describe('MetricsHandler', () => {
   let handler: MetricsHandler;
   let router: MessageRouter;
+  let postMessage: jest.Mock;
 
   beforeEach(() => {
+    postMessage = jest.fn().mockResolvedValue(undefined);
     handler = new MetricsHandler(
       {} as any, // proseStatsService
       {} as any, // styleFlagsService
       {} as any, // wordFrequencyService
       {} as any, // standardsService
-      jest.fn().mockResolvedValue(undefined) as any, // postMessage
+      postMessage as any, // postMessage
       {} as any, // outputChannel
       {} as any  // textSourceResolver
     );
@@ -42,6 +44,40 @@ describe('MetricsHandler', () => {
     it('should register exactly 3 metrics routes', () => {
       handler.registerRoutes(router);
       expect(router.handlerCount).toBe(3);
+    });
+  });
+
+  describe('Text source errors', () => {
+    it('surfaces unsaved active-file guidance as the user-facing metrics error', async () => {
+      const message = 'Active file is not saved to disk. Save the file first or use selected text instead.';
+      handler = new MetricsHandler(
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        postMessage as any,
+        {} as any,
+        { resolve: jest.fn().mockRejectedValue(new Error(message)) } as any
+      );
+
+      await handler.handleMeasureStyleFlags({
+        type: MessageType.MEASURE_STYLE_FLAGS,
+        source: 'webview.metrics',
+        payload: {
+          source: { mode: 'activeFile' }
+        },
+        timestamp: Date.now()
+      } as any);
+
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          payload: {
+            source: 'metrics.style_flags',
+            message
+          }
+        })
+      );
     });
   });
 });

--- a/packages/core/src/__tests__/application/handlers/domain/SearchHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/SearchHandler.test.ts
@@ -11,13 +11,15 @@ describe('SearchHandler', () => {
   let handler: SearchHandler;
   let router: MessageRouter;
   let postMessage: jest.Mock;
+  let outputChannel: { appendLine: jest.Mock };
 
   beforeEach(() => {
     postMessage = jest.fn().mockResolvedValue(undefined);
+    outputChannel = { appendLine: jest.fn() };
     handler = new SearchHandler(
       {} as any,  // wordSearchService
       postMessage as any, // postMessage
-      { appendLine: jest.fn() } as any, // outputChannel
+      outputChannel as any, // outputChannel
       {} as any, // textSourceResolver
       {} as any  // categorySearchService
     );
@@ -52,7 +54,7 @@ describe('SearchHandler', () => {
       handler = new SearchHandler(
         {} as any,
         postMessage as any,
-        { appendLine: jest.fn() } as any,
+        outputChannel as any,
         { resolve: jest.fn().mockRejectedValue(new Error(message)) } as any,
         {} as any
       );
@@ -76,6 +78,7 @@ describe('SearchHandler', () => {
           }
         })
       );
+      expect(outputChannel.appendLine).toHaveBeenCalledWith(`[SearchHandler] Word search error: ${message}`);
     });
   });
 });

--- a/packages/core/src/__tests__/application/handlers/domain/SearchHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/SearchHandler.test.ts
@@ -10,12 +10,14 @@ import { MessageType } from '@/shared/types/messages';
 describe('SearchHandler', () => {
   let handler: SearchHandler;
   let router: MessageRouter;
+  let postMessage: jest.Mock;
 
   beforeEach(() => {
+    postMessage = jest.fn().mockResolvedValue(undefined);
     handler = new SearchHandler(
       {} as any,  // wordSearchService
-      jest.fn().mockResolvedValue(undefined) as any, // postMessage
-      {} as any, // outputChannel
+      postMessage as any, // postMessage
+      { appendLine: jest.fn() } as any, // outputChannel
       {} as any, // textSourceResolver
       {} as any  // categorySearchService
     );
@@ -41,6 +43,39 @@ describe('SearchHandler', () => {
     it('should register exactly 3 routes', () => {
       handler.registerRoutes(router);
       expect(router.handlerCount).toBe(3);
+    });
+  });
+
+  describe('Text source errors', () => {
+    it('surfaces unsaved active-file guidance as the user-facing search error', async () => {
+      const message = 'Active file is not saved to disk. Save the file first or use selected text instead.';
+      handler = new SearchHandler(
+        {} as any,
+        postMessage as any,
+        { appendLine: jest.fn() } as any,
+        { resolve: jest.fn().mockRejectedValue(new Error(message)) } as any,
+        {} as any
+      );
+
+      await handler.handleMeasureWordSearch({
+        type: MessageType.RUN_WORD_SEARCH,
+        source: 'webview.search.word',
+        payload: {
+          source: { mode: 'activeFile' },
+          options: {}
+        },
+        timestamp: Date.now()
+      } as any);
+
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          payload: {
+            source: 'search',
+            message
+          }
+        })
+      );
     });
   });
 });

--- a/packages/core/src/__tests__/infrastructure/text/TextSourceResolver.test.ts
+++ b/packages/core/src/__tests__/infrastructure/text/TextSourceResolver.test.ts
@@ -117,7 +117,7 @@ describe('TextSourceResolver', () => {
       expect(result.text).toBe('Editor file body.');
     });
 
-    it('throws a clear error when the active editor is an untitled buffer', async () => {
+    it('throws a clear error when the active editor URI is an untitled buffer', async () => {
       const resolver = new TextSourceResolver(
         createFakeFileSystem(),
         createFakeWorkspace(),
@@ -125,6 +125,25 @@ describe('TextSourceResolver', () => {
         createFakeEditorContext({
           getActiveSelection: () => selectionOf({
             uriString: 'untitled:Untitled-1',
+            fsPath: '/ws/Untitled-1',
+            relativePath: 'Untitled-1'
+          })
+        })
+      );
+
+      await expect(resolver.resolve({ mode: 'activeFile' })).rejects.toThrow(
+        /Active file is not saved to disk/
+      );
+    });
+
+    it('throws a clear error when the active editor has no filesystem path', async () => {
+      const resolver = new TextSourceResolver(
+        createFakeFileSystem(),
+        createFakeWorkspace(),
+        createFakeSettings(),
+        createFakeEditorContext({
+          getActiveSelection: () => selectionOf({
+            uriString: 'file:///Untitled-1',
             fsPath: '',
             relativePath: 'Untitled-1'
           })
@@ -133,6 +152,22 @@ describe('TextSourceResolver', () => {
 
       await expect(resolver.resolve({ mode: 'activeFile' })).rejects.toThrow(
         /Active file is not saved to disk/
+      );
+    });
+
+    it('rejects absolute pathText outside open workspace folders', async () => {
+      const resolver = new TextSourceResolver(
+        createFakeFileSystem({}, { '/private/notes.md': 'Secret notes.' }),
+        createFakeWorkspace({
+          workspaceFolders: () => [{ path: '/ws', name: 'ws' }],
+          asRelativePath: (p: string) => p.replace('/ws/', ''),
+        }),
+        createFakeSettings(),
+        createFakeEditorContext()
+      );
+
+      await expect(resolver.resolve({ mode: 'activeFile', pathText: '/private/notes.md' })).rejects.toThrow(
+        /Text source path must be inside an open workspace folder/
       );
     });
   });

--- a/packages/core/src/__tests__/infrastructure/text/TextSourceResolver.test.ts
+++ b/packages/core/src/__tests__/infrastructure/text/TextSourceResolver.test.ts
@@ -42,6 +42,27 @@ describe('TextSourceResolver', () => {
       expect(result.displayPath).toBe('scene.md');
     });
 
+    it('returns selected text from an untitled editor buffer', async () => {
+      const resolver = new TextSourceResolver(
+        createFakeFileSystem(),
+        createFakeWorkspace(),
+        createFakeSettings(),
+        createFakeEditorContext({
+          getActiveSelection: () => selectionOf({
+            text: 'draft selection',
+            uriString: 'untitled:Untitled-1',
+            fsPath: '',
+            relativePath: 'Untitled-1'
+          })
+        })
+      );
+
+      const result = await resolver.resolve({ mode: 'selection' });
+
+      expect(result.text).toBe('draft selection');
+      expect(result.displayPath).toBe('Untitled-1');
+    });
+
     it('throws when there is no active editor', async () => {
       const resolver = new TextSourceResolver(
         createFakeFileSystem(),
@@ -94,6 +115,25 @@ describe('TextSourceResolver', () => {
       const result = await resolver.resolve({ mode: 'activeFile' });
 
       expect(result.text).toBe('Editor file body.');
+    });
+
+    it('throws a clear error when the active editor is an untitled buffer', async () => {
+      const resolver = new TextSourceResolver(
+        createFakeFileSystem(),
+        createFakeWorkspace(),
+        createFakeSettings(),
+        createFakeEditorContext({
+          getActiveSelection: () => selectionOf({
+            uriString: 'untitled:Untitled-1',
+            fsPath: '',
+            relativePath: 'Untitled-1'
+          })
+        })
+      );
+
+      await expect(resolver.resolve({ mode: 'activeFile' })).rejects.toThrow(
+        /Active file is not saved to disk/
+      );
     });
   });
 

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useAnalysis.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useAnalysis.test.ts
@@ -16,7 +16,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { AnalysisState, AnalysisActions, AnalysisPersistence, useAnalysis } from '@/presentation/webview/hooks/domain/useAnalysis';
 import { MessageType } from '@shared/types';
-import { API_KEY_NOT_CONFIGURED_HEADING } from '@messages';
+import { API_KEY_NOT_CONFIGURED_HEADING, ClearTransientApiKeyWarningMessage } from '@messages';
 import { createMockVSCode } from '@/__tests__/mocks/vscode';
 
 // Mock dependencies
@@ -80,6 +80,7 @@ describe('useAnalysis - Type Contracts', () => {
         'setLoading',
         'clearResult',
         'clearStatus',
+        'handleClearTransientApiKeyWarning',
         // Streaming actions
         'handleStreamStarted',
         'handleStreamChunk',
@@ -95,6 +96,7 @@ describe('useAnalysis - Type Contracts', () => {
         setLoading: jest.fn(),
         clearResult: jest.fn(),
         clearStatus: jest.fn(),
+        handleClearTransientApiKeyWarning: jest.fn(),
         // Streaming actions
         handleStreamStarted: jest.fn(),
         handleStreamChunk: jest.fn(),
@@ -148,6 +150,7 @@ describe('useAnalysis - Type Contracts', () => {
       // Actions (user-triggered operations) - including streaming actions
       const actionProps: (keyof AnalysisActions)[] = [
         'handleAnalysisResult', 'handleStatusMessage', 'setLoading', 'clearResult', 'clearStatus',
+        'handleClearTransientApiKeyWarning',
         'handleStreamStarted', 'handleStreamChunk', 'handleStreamComplete', 'startStreaming', 'cancelStreaming'
       ];
 
@@ -264,5 +267,45 @@ describe('useAnalysis - Transient Warning Persistence', () => {
 
     expect(result.current.result).toBe('This is a real analysis result.');
     expect(result.current.persistedState.analysisResult).toBe('This is a real analysis result.');
+  });
+
+  it('clears a live API-key warning without clearing ordinary analysis output', () => {
+    (usePersistedState as jest.Mock).mockReturnValue({});
+
+    const { result } = renderHook(() => useAnalysis());
+    const clearMessage: ClearTransientApiKeyWarningMessage = {
+      type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+      source: 'extension.handler',
+      payload: {},
+      timestamp: 123
+    };
+
+    act(() => {
+      result.current.handleAnalysisResult({
+        type: MessageType.ANALYSIS_RESULT,
+        source: 'extension.analysis',
+        payload: {
+          result: `${API_KEY_NOT_CONFIGURED_HEADING}\n\nAdd your key to keep going.`,
+          toolName: 'prose'
+        },
+        timestamp: 1
+      });
+    });
+    act(() => result.current.handleClearTransientApiKeyWarning(clearMessage));
+    expect(result.current.result).toBe('');
+
+    act(() => {
+      result.current.handleAnalysisResult({
+        type: MessageType.ANALYSIS_RESULT,
+        source: 'extension.analysis',
+        payload: {
+          result: 'Real analysis output.',
+          toolName: 'prose'
+        },
+        timestamp: 2
+      });
+    });
+    act(() => result.current.handleClearTransientApiKeyWarning(clearMessage));
+    expect(result.current.result).toBe('Real analysis output.');
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useContext.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useContext.test.ts
@@ -6,9 +6,9 @@
  * useContext Behavioral Tests
  */
 
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { useContext } from '@/presentation/webview/hooks/domain/useContext';
-import { API_KEY_NOT_CONFIGURED_HEADING } from '@messages';
+import { API_KEY_NOT_CONFIGURED_HEADING, ClearTransientApiKeyWarningMessage, MessageType } from '@messages';
 import { createMockVSCode } from '@/__tests__/mocks/vscode';
 
 jest.mock('../../../../../presentation/webview/hooks/useVSCodeApi');
@@ -51,5 +51,45 @@ describe('useContext - Transient Warning Persistence', () => {
 
     expect(result.current.contextText).toBe('A real generated context result.');
     expect(result.current.persistedState.contextText).toBe('A real generated context result.');
+  });
+
+  it('clears a live API-key warning without clearing ordinary context text', () => {
+    (usePersistedState as jest.Mock).mockReturnValue({});
+
+    const { result } = renderHook(() => useContext());
+    const clearMessage: ClearTransientApiKeyWarningMessage = {
+      type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+      source: 'extension.handler',
+      payload: {},
+      timestamp: 123
+    };
+
+    act(() => {
+      result.current.handleContextResult({
+        type: MessageType.CONTEXT_RESULT,
+        source: 'extension.context',
+        payload: {
+          result: `${API_KEY_NOT_CONFIGURED_HEADING}\n\nAdd your key to generate context.`,
+          toolName: 'context'
+        },
+        timestamp: 1
+      });
+    });
+    act(() => result.current.handleClearTransientApiKeyWarning(clearMessage));
+    expect(result.current.contextText).toBe('');
+
+    act(() => {
+      result.current.handleContextResult({
+        type: MessageType.CONTEXT_RESULT,
+        source: 'extension.context',
+        payload: {
+          result: 'Real generated context.',
+          toolName: 'context'
+        },
+        timestamp: 2
+      });
+    });
+    act(() => result.current.handleClearTransientApiKeyWarning(clearMessage));
+    expect(result.current.contextText).toBe('Real generated context.');
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useContext.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useContext.test.ts
@@ -93,3 +93,41 @@ describe('useContext - Transient Warning Persistence', () => {
     expect(result.current.contextText).toBe('Real generated context.');
   });
 });
+
+describe('useContext - Streaming Cancellation', () => {
+  let mockVSCode: ReturnType<typeof createMockVSCode>;
+
+  beforeEach(() => {
+    mockVSCode = createMockVSCode();
+    (useVSCodeApi as jest.Mock).mockReturnValue(mockVSCode);
+    (usePersistedState as jest.Mock).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves streamed context content when cancelling', () => {
+    const { result } = renderHook(() => useContext());
+
+    act(() => result.current.startStreaming('ctx-1'));
+    act(() => result.current.handleStreamChunk({
+      type: MessageType.STREAM_CHUNK,
+      source: 'extension.test',
+      payload: { domain: 'context', requestId: 'ctx-1', token: 'partial ' },
+      timestamp: Date.now()
+    }));
+    act(() => result.current.handleStreamChunk({
+      type: MessageType.STREAM_CHUNK,
+      source: 'extension.test',
+      payload: { domain: 'context', requestId: 'ctx-1', token: 'context' },
+      timestamp: Date.now()
+    }));
+
+    act(() => result.current.cancelStreaming());
+
+    expect(result.current.contextText).toBe('partial context');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.isStreaming).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts
@@ -227,4 +227,28 @@ describe('useDictionary - Streaming Cancellation', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.isStreaming).toBe(false);
   });
+
+  it('keeps the result empty when cancelling before any dictionary chunks arrive', () => {
+    const { result } = renderHook(() => useDictionary());
+
+    act(() => {
+      result.current.handleDictionaryResult({
+        type: MessageType.DICTIONARY_RESULT,
+        source: 'extension.dictionary',
+        payload: {
+          result: 'Previous dictionary output.',
+          toolName: 'dictionary_lookup'
+        },
+        timestamp: Date.now()
+      });
+    });
+    expect(result.current.result).toBe('Previous dictionary output.');
+
+    act(() => result.current.startStreaming('dict-2'));
+    act(() => result.current.cancelStreaming());
+
+    expect(result.current.result).toBe('');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.isStreaming).toBe(false);
+  });
 });

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts
@@ -190,3 +190,41 @@ describe('useDictionary - Transient Warning Persistence', () => {
     expect(result.current.result).toBe('Real dictionary output.');
   });
 });
+
+describe('useDictionary - Streaming Cancellation', () => {
+  let mockVSCode: ReturnType<typeof createMockVSCode>;
+
+  beforeEach(() => {
+    mockVSCode = createMockVSCode();
+    (useVSCodeApi as jest.Mock).mockReturnValue(mockVSCode);
+    (usePersistedState as jest.Mock).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves streamed dictionary content when cancelling', () => {
+    const { result } = renderHook(() => useDictionary());
+
+    act(() => result.current.startStreaming('dict-1'));
+    act(() => result.current.handleStreamChunk({
+      type: MessageType.STREAM_CHUNK,
+      source: 'extension.test',
+      payload: { domain: 'dictionary', requestId: 'dict-1', token: 'partial ' },
+      timestamp: Date.now()
+    }));
+    act(() => result.current.handleStreamChunk({
+      type: MessageType.STREAM_CHUNK,
+      source: 'extension.test',
+      payload: { domain: 'dictionary', requestId: 'dict-1', token: 'definition' },
+      timestamp: Date.now()
+    }));
+
+    act(() => result.current.cancelStreaming());
+
+    expect(result.current.result).toBe('partial definition');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.isStreaming).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts
@@ -8,9 +8,9 @@
  * Validates Tripartite Interface pattern for dictionary operations.
  */
 
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { DictionaryState, DictionaryActions, DictionaryPersistence, useDictionary } from '@/presentation/webview/hooks/domain/useDictionary';
-import { API_KEY_NOT_CONFIGURED_HEADING } from '@messages';
+import { API_KEY_NOT_CONFIGURED_HEADING, ClearTransientApiKeyWarningMessage, MessageType } from '@messages';
 import { createMockVSCode } from '@/__tests__/mocks/vscode';
 
 jest.mock('../../../../../presentation/webview/hooks/useVSCodeApi');
@@ -71,6 +71,7 @@ describe('useDictionary - Type Contracts', () => {
         setWordEdited: jest.fn(),
         setSource: jest.fn(),
         clearResult: jest.fn(),
+        handleClearTransientApiKeyWarning: jest.fn(),
         handleFastGenerateResult: jest.fn(),
         setFastGenerating: jest.fn(),
         // Streaming actions
@@ -84,6 +85,7 @@ describe('useDictionary - Type Contracts', () => {
       expect(typeof actions.handleDictionaryResult).toBe('function');
       expect(typeof actions.setWord).toBe('function');
       expect(typeof actions.clearResult).toBe('function');
+      expect(typeof actions.handleClearTransientApiKeyWarning).toBe('function');
       expect(typeof actions.handleFastGenerateResult).toBe('function');
       expect(typeof actions.setFastGenerating).toBe('function');
       expect(typeof actions.handleStreamStarted).toBe('function');
@@ -146,5 +148,45 @@ describe('useDictionary - Transient Warning Persistence', () => {
 
     expect(result.current.result).toBe('A real dictionary result.');
     expect(result.current.persistedState.utilitiesResult).toBe('A real dictionary result.');
+  });
+
+  it('clears a live API-key warning without clearing ordinary dictionary output', () => {
+    (usePersistedState as jest.Mock).mockReturnValue({});
+
+    const { result } = renderHook(() => useDictionary());
+    const clearMessage: ClearTransientApiKeyWarningMessage = {
+      type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+      source: 'extension.handler',
+      payload: {},
+      timestamp: 123
+    };
+
+    act(() => {
+      result.current.handleDictionaryResult({
+        type: MessageType.DICTIONARY_RESULT,
+        source: 'extension.dictionary',
+        payload: {
+          result: `${API_KEY_NOT_CONFIGURED_HEADING}\n\nAdd your key to look up words.`,
+          toolName: 'dictionary_lookup'
+        },
+        timestamp: 1
+      });
+    });
+    act(() => result.current.handleClearTransientApiKeyWarning(clearMessage));
+    expect(result.current.result).toBe('');
+
+    act(() => {
+      result.current.handleDictionaryResult({
+        type: MessageType.DICTIONARY_RESULT,
+        source: 'extension.dictionary',
+        payload: {
+          result: 'Real dictionary output.',
+          toolName: 'dictionary_lookup'
+        },
+        timestamp: 2
+      });
+    });
+    act(() => result.current.handleClearTransientApiKeyWarning(clearMessage));
+    expect(result.current.result).toBe('Real dictionary output.');
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/hooks/useAppMessageRouter.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/useAppMessageRouter.test.ts
@@ -37,6 +37,7 @@ const EXPECTED_ROUTES: MessageType[] = [
   MessageType.OPEN_SETTINGS_TOGGLE,
   MessageType.TOKEN_USAGE_UPDATE,
   MessageType.ACCOUNT_BALANCE_DATA,
+  MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
   MessageType.SAVE_RESULT_SUCCESS,
   MessageType.ERROR,
 ];
@@ -46,6 +47,7 @@ const makeDeps = () => {
     analysis: {
       handleAnalysisResult: jest.fn(), handleStreamStarted: jest.fn(), handleStreamChunk: jest.fn(),
       handleStreamComplete: jest.fn(), handleStatusMessage: jest.fn(), setLoading: jest.fn(),
+      handleClearTransientApiKeyWarning: jest.fn(),
     },
     metrics: {
       handleMetricsResult: jest.fn(), handleActiveFile: jest.fn(), handleManuscriptGlobs: jest.fn(),
@@ -54,11 +56,12 @@ const makeDeps = () => {
     dictionary: {
       handleDictionaryResult: jest.fn(), handleFastGenerateResult: jest.fn(), handleStreamStarted: jest.fn(),
       handleStreamChunk: jest.fn(), handleStreamComplete: jest.fn(), handleStatusMessage: jest.fn(),
-      setLoading: jest.fn(), setFastGenerating: jest.fn(),
+      handleClearTransientApiKeyWarning: jest.fn(), setLoading: jest.fn(), setFastGenerating: jest.fn(),
     },
     context: {
       handleStreamStarted: jest.fn(), handleStreamChunk: jest.fn(), handleStreamComplete: jest.fn(),
       handleContextResult: jest.fn(), setContextText: jest.fn(), setLoading: jest.fn(), loadingRef: { current: false },
+      handleClearTransientApiKeyWarning: jest.fn(),
     },
     search: {
       handleSearchResult: jest.fn(), handleCategorySearchResult: jest.fn(), handleStatusMessage: jest.fn(),
@@ -112,6 +115,22 @@ describe('buildAppMessageRoutes', () => {
     expect(deps.context.handleStreamChunk).toHaveBeenCalled();
     expect(deps.analysis.handleStreamChunk).not.toHaveBeenCalled();
     expect(deps.dictionary.handleStreamChunk).not.toHaveBeenCalled();
+  });
+
+  it('CLEAR_TRANSIENT_API_KEY_WARNING fans out to AI result domains', () => {
+    const deps = makeDeps();
+    const message = {
+      type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+      source: 'extension.handler',
+      payload: {},
+      timestamp: 123
+    };
+
+    buildAppMessageRoutes(deps)[MessageType.CLEAR_TRANSIENT_API_KEY_WARNING]!(message as never);
+
+    expect(deps.analysis.handleClearTransientApiKeyWarning).toHaveBeenCalledWith(message);
+    expect(deps.dictionary.handleClearTransientApiKeyWarning).toHaveBeenCalledWith(message);
+    expect(deps.context.handleClearTransientApiKeyWarning).toHaveBeenCalledWith(message);
   });
 
   // STATUS is source-routed (the docblock above names it a top refactor-risk spot):

--- a/packages/core/src/__tests__/presentation/webview/utils/streamingCancelMessages.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/utils/streamingCancelMessages.test.ts
@@ -1,0 +1,29 @@
+import { MessageType } from '@messages';
+import { createCancelRequestMessage } from '@/presentation/webview/utils/streamingCancelMessages';
+
+describe('createCancelRequestMessage', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(123456);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['analysis', MessageType.CANCEL_ANALYSIS_REQUEST],
+    ['dictionary', MessageType.CANCEL_DICTIONARY_REQUEST],
+    ['context', MessageType.CANCEL_CONTEXT_REQUEST],
+    ['search', MessageType.CANCEL_CATEGORY_SEARCH_REQUEST]
+  ] as const)('builds a %s cancel message', (domain, type) => {
+    expect(createCancelRequestMessage(domain, 'request-1', 'webview.test')).toEqual({
+      type,
+      source: 'webview.test',
+      payload: {
+        requestId: 'request-1',
+        domain
+      },
+      timestamp: 123456
+    });
+  });
+});

--- a/packages/core/src/__tests__/shared/streamingCancelMessages.test.ts
+++ b/packages/core/src/__tests__/shared/streamingCancelMessages.test.ts
@@ -1,5 +1,5 @@
 import { MessageType } from '@messages';
-import { createCancelRequestMessage } from '@/presentation/webview/utils/streamingCancelMessages';
+import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 
 describe('createCancelRequestMessage', () => {
   beforeEach(() => {

--- a/packages/core/src/application/handlers/MessageHandler.ts
+++ b/packages/core/src/application/handlers/MessageHandler.ts
@@ -275,8 +275,7 @@ export class MessageHandler {
     // this gives the assistant, dictionary, and context paths the same recovery
     // instead of staying disabled until a model-setting change or reload.
     const secretSubscription = this.services.secretsService.onDidChange(() => {
-      this.outputChannel.appendLine('[MessageHandler] API key changed, refreshing AI services');
-      void this.refreshServiceConfiguration({ clearApiKeyWarningOnSuccess: true });
+      void this.refreshServiceConfigurationAfterSecretChange();
     });
     this.disposeSecretListener = () => secretSubscription.dispose();
 
@@ -423,7 +422,25 @@ export class MessageHandler {
     }
   }
 
-  private async refreshServiceConfiguration(options: { clearApiKeyWarningOnSuccess?: boolean } = {}): Promise<void> {
+  private async refreshServiceConfigurationAfterSecretChange(): Promise<void> {
+    this.outputChannel.appendLine('[MessageHandler] API key changed, refreshing AI services');
+    const clearTransientApiKeyWarning = await this.hasApiKeyForSecretRefresh();
+    await this.refreshServiceConfiguration({ clearTransientApiKeyWarning });
+  }
+
+  private async hasApiKeyForSecretRefresh(): Promise<boolean> {
+    try {
+      return !!(await this.services.secretsService.getApiKey());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.outputChannel.appendLine(
+        `[MessageHandler] Failed to inspect API key before service refresh: ${message}`
+      );
+      return false;
+    }
+  }
+
+  private async refreshServiceConfiguration(options: { clearTransientApiKeyWarning?: boolean } = {}): Promise<void> {
     const refreshSteps = [
       { name: 'AI resource manager', refresh: () => this.services.aiResourceManager.refreshConfiguration() },
       { name: 'assistant tool service', refresh: () => this.services.assistantToolService.refreshConfiguration() },
@@ -433,6 +450,8 @@ export class MessageHandler {
 
     this.outputChannel.appendLine('[MessageHandler] Service configuration refresh started');
 
+    // Keep these sequential so a failed foundational refresh leaves a clear
+    // skip list instead of four concurrent failures with ambiguous ownership.
     for (const [index, step] of refreshSteps.entries()) {
       try {
         await step.refresh();
@@ -448,36 +467,33 @@ export class MessageHandler {
             `[MessageHandler] Service configuration refresh skipped: ${skippedSteps.join(', ')}`
           );
         }
+        this.sendStatus(
+          'AI service refresh partially failed. Some tools may need a reload.',
+          `${step.name}: ${message}`
+        );
+        if (options.clearTransientApiKeyWarning) {
+          this.postClearTransientApiKeyWarning();
+        }
         return;
       }
     }
 
-    this.outputChannel.appendLine('[MessageHandler] Service configuration refresh completed');
+    this.outputChannel.appendLine(
+      `[MessageHandler] Service configuration refresh completed: ${refreshSteps.map(({ name }) => name).join(', ')}`
+    );
 
-    if (options.clearApiKeyWarningOnSuccess) {
-      await this.postClearTransientApiKeyWarningIfConfigured();
+    if (options.clearTransientApiKeyWarning) {
+      this.postClearTransientApiKeyWarning();
     }
   }
 
-  private async postClearTransientApiKeyWarningIfConfigured(): Promise<void> {
-    try {
-      const apiKey = await this.services.secretsService.getApiKey();
-      if (!apiKey) {
-        return;
-      }
-
-      void this.postMessage({
-        type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
-        source: 'extension.handler',
-        payload: {},
-        timestamp: Date.now()
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.outputChannel.appendLine(
-        `[MessageHandler] Failed to inspect API key after service refresh: ${message}`
-      );
-    }
+  private postClearTransientApiKeyWarning(): void {
+    void this.postMessage({
+      type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+      source: 'extension.handler',
+      payload: {},
+      timestamp: Date.now()
+    });
   }
 
   /**

--- a/packages/core/src/application/handlers/MessageHandler.ts
+++ b/packages/core/src/application/handlers/MessageHandler.ts
@@ -276,7 +276,7 @@ export class MessageHandler {
     // instead of staying disabled until a model-setting change or reload.
     const secretSubscription = this.services.secretsService.onDidChange(() => {
       this.outputChannel.appendLine('[MessageHandler] API key changed, refreshing AI services');
-      void this.refreshServiceConfiguration();
+      void this.refreshServiceConfiguration({ clearApiKeyWarningOnSuccess: true });
     });
     this.disposeSecretListener = () => secretSubscription.dispose();
 
@@ -423,16 +423,59 @@ export class MessageHandler {
     }
   }
 
-  private async refreshServiceConfiguration(): Promise<void> {
+  private async refreshServiceConfiguration(options: { clearApiKeyWarningOnSuccess?: boolean } = {}): Promise<void> {
+    const refreshSteps = [
+      { name: 'AI resource manager', refresh: () => this.services.aiResourceManager.refreshConfiguration() },
+      { name: 'assistant tool service', refresh: () => this.services.assistantToolService.refreshConfiguration() },
+      { name: 'dictionary service', refresh: () => this.services.dictionaryService.refreshConfiguration() },
+      { name: 'context assistant service', refresh: () => this.services.contextAssistantService.refreshConfiguration() }
+    ] as const;
+
+    this.outputChannel.appendLine('[MessageHandler] Service configuration refresh started');
+
+    for (const [index, step] of refreshSteps.entries()) {
+      try {
+        await step.refresh();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.outputChannel.appendLine(
+          `[MessageHandler] Service configuration refresh failed at ${step.name}: ${message}`
+        );
+
+        const skippedSteps = refreshSteps.slice(index + 1).map(({ name }) => name);
+        if (skippedSteps.length > 0) {
+          this.outputChannel.appendLine(
+            `[MessageHandler] Service configuration refresh skipped: ${skippedSteps.join(', ')}`
+          );
+        }
+        return;
+      }
+    }
+
+    this.outputChannel.appendLine('[MessageHandler] Service configuration refresh completed');
+
+    if (options.clearApiKeyWarningOnSuccess) {
+      await this.postClearTransientApiKeyWarningIfConfigured();
+    }
+  }
+
+  private async postClearTransientApiKeyWarningIfConfigured(): Promise<void> {
     try {
-      await this.services.aiResourceManager.refreshConfiguration();
-      await this.services.assistantToolService.refreshConfiguration();
-      await this.services.dictionaryService.refreshConfiguration();
-      await this.services.contextAssistantService.refreshConfiguration();
+      const apiKey = await this.services.secretsService.getApiKey();
+      if (!apiKey) {
+        return;
+      }
+
+      void this.postMessage({
+        type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+        source: 'extension.handler',
+        payload: {},
+        timestamp: Date.now()
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.outputChannel.appendLine(
-        `[MessageHandler] Failed to refresh service configuration: ${message}`
+        `[MessageHandler] Failed to inspect API key after service refresh: ${message}`
       );
     }
   }

--- a/packages/core/src/application/handlers/domain/MetricsHandler.ts
+++ b/packages/core/src/application/handlers/domain/MetricsHandler.ts
@@ -104,7 +104,7 @@ export class MetricsHandler {
       this.sendMetricsResult(result.metrics, result.toolName);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      this.sendError('metrics.prose_stats', 'Invalid selection or path', msg);
+      this.sendTextSourceError('metrics.prose_stats', msg);
     }
   }
 
@@ -117,7 +117,7 @@ export class MetricsHandler {
       this.sendMetricsResult(result.metrics, result.toolName);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      this.sendError('metrics.style_flags', 'Invalid selection or path', msg);
+      this.sendTextSourceError('metrics.style_flags', msg);
     }
   }
 
@@ -130,7 +130,7 @@ export class MetricsHandler {
       this.sendMetricsResult(result.metrics, result.toolName);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      this.sendError('metrics.word_frequency', 'Invalid selection or path', msg);
+      this.sendTextSourceError('metrics.word_frequency', msg);
     }
   }
 
@@ -162,5 +162,26 @@ export class MetricsHandler {
     if (!text) throw new Error('Resolved source contains no text.');
     const mode = payload.source?.mode;
     return { text, paths: resolved.relativePaths, mode };
+  }
+
+  private sendTextSourceError(source: ErrorSource, message: string): void {
+    if (this.isTextSourceValidationError(message)) {
+      this.sendError(source, message);
+      return;
+    }
+
+    this.sendError(source, 'Invalid selection or path', message);
+  }
+
+  private isTextSourceValidationError(message: string): boolean {
+    return [
+      'Active file is not saved to disk.',
+      'No text selected.',
+      'No manuscript files matched',
+      'No chapter files matched',
+      'Invalid selection token.',
+      'Active file not found.',
+      'Resolved source contains no text.'
+    ].some(prefix => message.startsWith(prefix));
   }
 }

--- a/packages/core/src/application/handlers/domain/MetricsHandler.ts
+++ b/packages/core/src/application/handlers/domain/MetricsHandler.ts
@@ -7,7 +7,7 @@
  */
 
 import { LogSink } from '@/platform';
-import { TextSourceResolver } from '@/infrastructure/text/TextSourceResolver';
+import { isTextSourceValidationError, TextSourceResolver } from '@/infrastructure/text/TextSourceResolver';
 import { ProseStatsService } from '@services/measurement/ProseStatsService';
 import { StyleFlagsService } from '@services/measurement/StyleFlagsService';
 import { WordFrequencyService } from '@services/measurement/WordFrequencyService';
@@ -104,6 +104,7 @@ export class MetricsHandler {
       this.sendMetricsResult(result.metrics, result.toolName);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
+      this.outputChannel.appendLine(`[MetricsHandler] Prose stats error: ${msg}`);
       this.sendTextSourceError('metrics.prose_stats', msg);
     }
   }
@@ -117,6 +118,7 @@ export class MetricsHandler {
       this.sendMetricsResult(result.metrics, result.toolName);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
+      this.outputChannel.appendLine(`[MetricsHandler] Style flags error: ${msg}`);
       this.sendTextSourceError('metrics.style_flags', msg);
     }
   }
@@ -130,6 +132,7 @@ export class MetricsHandler {
       this.sendMetricsResult(result.metrics, result.toolName);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
+      this.outputChannel.appendLine(`[MetricsHandler] Word frequency error: ${msg}`);
       this.sendTextSourceError('metrics.word_frequency', msg);
     }
   }
@@ -165,23 +168,11 @@ export class MetricsHandler {
   }
 
   private sendTextSourceError(source: ErrorSource, message: string): void {
-    if (this.isTextSourceValidationError(message)) {
+    if (isTextSourceValidationError(message)) {
       this.sendError(source, message);
       return;
     }
 
     this.sendError(source, 'Invalid selection or path', message);
-  }
-
-  private isTextSourceValidationError(message: string): boolean {
-    return [
-      'Active file is not saved to disk.',
-      'No text selected.',
-      'No manuscript files matched',
-      'No chapter files matched',
-      'Invalid selection token.',
-      'Active file not found.',
-      'Resolved source contains no text.'
-    ].some(prefix => message.startsWith(prefix));
   }
 }

--- a/packages/core/src/application/handlers/domain/SearchHandler.ts
+++ b/packages/core/src/application/handlers/domain/SearchHandler.ts
@@ -112,7 +112,7 @@ export class SearchHandler {
       this.sendSearchResult(result.metrics, result.toolName);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      this.sendError('search', 'Invalid selection or path', msg);
+      this.sendTextSourceError('search', msg);
     }
   }
 
@@ -144,7 +144,7 @@ export class SearchHandler {
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       this.outputChannel.appendLine(`[SearchHandler] Category search error: ${msg}`);
-      this.sendError('search', 'Category search failed', msg);
+      this.sendTextSourceError('search', msg, 'Category search failed');
     }
   }
 
@@ -171,5 +171,26 @@ export class SearchHandler {
     if (!text) throw new Error('Resolved source contains no text.');
     const mode = payload.source?.mode;
     return { text, paths: resolved.relativePaths, mode };
+  }
+
+  private sendTextSourceError(source: ErrorSource, message: string, fallback = 'Invalid selection or path'): void {
+    if (this.isTextSourceValidationError(message)) {
+      this.sendError(source, message);
+      return;
+    }
+
+    this.sendError(source, fallback, message);
+  }
+
+  private isTextSourceValidationError(message: string): boolean {
+    return [
+      'Active file is not saved to disk.',
+      'No text selected.',
+      'No manuscript files matched',
+      'No chapter files matched',
+      'Invalid selection token.',
+      'Active file not found.',
+      'Resolved source contains no text.'
+    ].some(prefix => message.startsWith(prefix));
   }
 }

--- a/packages/core/src/application/handlers/domain/SearchHandler.ts
+++ b/packages/core/src/application/handlers/domain/SearchHandler.ts
@@ -6,7 +6,7 @@
  */
 
 import { LogSink } from '@/platform';
-import { TextSourceResolver } from '@/infrastructure/text/TextSourceResolver';
+import { isTextSourceValidationError, TextSourceResolver } from '@/infrastructure/text/TextSourceResolver';
 import { WordSearchService } from '@services/search/WordSearchService';
 import { CategorySearchService } from '@services/search/CategorySearchService';
 import {
@@ -112,6 +112,7 @@ export class SearchHandler {
       this.sendSearchResult(result.metrics, result.toolName);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
+      this.outputChannel.appendLine(`[SearchHandler] Word search error: ${msg}`);
       this.sendTextSourceError('search', msg);
     }
   }
@@ -174,23 +175,11 @@ export class SearchHandler {
   }
 
   private sendTextSourceError(source: ErrorSource, message: string, fallback = 'Invalid selection or path'): void {
-    if (this.isTextSourceValidationError(message)) {
+    if (isTextSourceValidationError(message)) {
       this.sendError(source, message);
       return;
     }
 
     this.sendError(source, fallback, message);
-  }
-
-  private isTextSourceValidationError(message: string): boolean {
-    return [
-      'Active file is not saved to disk.',
-      'No text selected.',
-      'No manuscript files matched',
-      'No chapter files matched',
-      'Invalid selection token.',
-      'Active file not found.',
-      'Resolved source contains no text.'
-    ].some(prefix => message.startsWith(prefix));
   }
 }

--- a/packages/core/src/infrastructure/text/TextSourceResolver.ts
+++ b/packages/core/src/infrastructure/text/TextSourceResolver.ts
@@ -164,9 +164,16 @@ export class TextSourceResolver {
     // Fallback to active editor
     const selection = this.editor.getActiveSelection();
     if (selection) {
+      if (this.isUnsavedEditorDocument(selection)) {
+        throw new Error('Active file is not saved to disk. Save the file first or use selected text instead.');
+      }
       return selection.fsPath;
     }
     return undefined;
+  }
+
+  private isUnsavedEditorDocument(selection: { uriString: string; fsPath: string }): boolean {
+    return selection.uriString.startsWith('untitled:') || selection.fsPath.trim().length === 0;
   }
 
   private getManuscriptPatterns(pathText?: string): string[] {

--- a/packages/core/src/infrastructure/text/TextSourceResolver.ts
+++ b/packages/core/src/infrastructure/text/TextSourceResolver.ts
@@ -11,7 +11,23 @@
 
 import * as path from 'path';
 import { EditorContext, FileSystem, FileType, LogSink, SettingsStore, Workspace } from '@/platform';
+import { isPathWithinRoot } from '@/infrastructure/storage/pathContainment';
 import { ResolvedTextSource, TextSourceSpec } from '@shared/types';
+
+const TEXT_SOURCE_VALIDATION_ERROR_PREFIXES = [
+  'Active file is not saved to disk.',
+  'Text source path must be inside an open workspace folder.',
+  'No text selected.',
+  'No manuscript files matched',
+  'No chapter files matched',
+  'Invalid selection token.',
+  'Active file not found.',
+  'Resolved source contains no text.'
+] as const;
+
+export function isTextSourceValidationError(message: string): boolean {
+  return TEXT_SOURCE_VALIDATION_ERROR_PREFIXES.some(prefix => message.startsWith(prefix));
+}
 
 export class TextSourceResolver {
   constructor(
@@ -141,7 +157,11 @@ export class TextSourceResolver {
 
       // Absolute
       if (path.isAbsolute(trimmed)) {
+        if (!this.isPathWithinOpenWorkspace(trimmed)) {
+          throw new Error('Text source path must be inside an open workspace folder.');
+        }
         if (await this.exists(trimmed)) return trimmed;
+        return undefined;
       }
 
       // Try as workspace-relative into each folder
@@ -174,6 +194,10 @@ export class TextSourceResolver {
 
   private isUnsavedEditorDocument(selection: { uriString: string; fsPath: string }): boolean {
     return selection.uriString.startsWith('untitled:') || selection.fsPath.trim().length === 0;
+  }
+
+  private isPathWithinOpenWorkspace(filePath: string): boolean {
+    return this.workspace.workspaceFolders().some(folder => isPathWithinRoot(folder.path, filePath));
   }
 
   private getManuscriptPatterns(pathText?: string): string[] {

--- a/packages/core/src/presentation/webview/components/search/CategorySearchPanel.tsx
+++ b/packages/core/src/presentation/webview/components/search/CategorySearchPanel.tsx
@@ -18,7 +18,7 @@ import { UseSearchReturn } from '@hooks/domain/useSearch';
 import { UseMetricsReturn } from '@hooks/domain/useMetrics';
 import { UseWordSearchSettingsReturn } from '@hooks/domain/useWordSearchSettings';
 import { UseModelsSettingsReturn } from '@hooks/domain/useModelsSettings';
-import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
+import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 
 interface CategorySearchPanelProps {
   vscode: VSCodeAPI;

--- a/packages/core/src/presentation/webview/components/search/CategorySearchPanel.tsx
+++ b/packages/core/src/presentation/webview/components/search/CategorySearchPanel.tsx
@@ -18,6 +18,7 @@ import { UseSearchReturn } from '@hooks/domain/useSearch';
 import { UseMetricsReturn } from '@hooks/domain/useMetrics';
 import { UseWordSearchSettingsReturn } from '@hooks/domain/useWordSearchSettings';
 import { UseModelsSettingsReturn } from '@hooks/domain/useModelsSettings';
+import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
 
 interface CategorySearchPanelProps {
   vscode: VSCodeAPI;
@@ -118,15 +119,7 @@ export const CategorySearchPanel: React.FC<CategorySearchPanelProps> = ({
   };
 
   const handleCancelCategorySearch = () => {
-    vscode.postMessage({
-      type: MessageType.CANCEL_CATEGORY_SEARCH_REQUEST,
-      source: 'webview.search.category',
-      payload: {
-        requestId: 'category-search',
-        domain: 'search'
-      },
-      timestamp: Date.now()
-    });
+    vscode.postMessage(createCancelRequestMessage('search', 'category-search', 'webview.search.category'));
     search.cancelCategorySearch();
   };
 

--- a/packages/core/src/presentation/webview/components/tabs/AnalysisTab.tsx
+++ b/packages/core/src/presentation/webview/components/tabs/AnalysisTab.tsx
@@ -19,7 +19,7 @@ import { UseContextReturn } from '../../hooks/domain/useContext';
 import { UseSelectionReturn } from '../../hooks/domain/useSelection';
 import { UseModelsSettingsReturn } from '../../hooks/domain/useModelsSettings';
 import { UseSettingsReturn } from '../../hooks/domain/useSettings';
-import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
+import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 
 interface AnalysisTabProps {
   vscode: VSCodeAPI;

--- a/packages/core/src/presentation/webview/components/tabs/AnalysisTab.tsx
+++ b/packages/core/src/presentation/webview/components/tabs/AnalysisTab.tsx
@@ -19,6 +19,7 @@ import { UseContextReturn } from '../../hooks/domain/useContext';
 import { UseSelectionReturn } from '../../hooks/domain/useSelection';
 import { UseModelsSettingsReturn } from '../../hooks/domain/useModelsSettings';
 import { UseSettingsReturn } from '../../hooks/domain/useSettings';
+import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
 
 interface AnalysisTabProps {
   vscode: VSCodeAPI;
@@ -214,30 +215,14 @@ export const AnalysisTab = React.memo<AnalysisTabProps>(({
 
   const handleCancelAnalysisStreaming = React.useCallback(() => {
     if (analysis.currentRequestId) {
-      vscode.postMessage({
-        type: MessageType.CANCEL_ANALYSIS_REQUEST,
-        source: 'webview.analysis.tab',
-        payload: {
-          requestId: analysis.currentRequestId,
-          domain: 'analysis'
-        },
-        timestamp: Date.now()
-      });
+      vscode.postMessage(createCancelRequestMessage('analysis', analysis.currentRequestId, 'webview.analysis.tab'));
     }
     analysis.cancelStreaming();
   }, [analysis, vscode]);
 
   const handleCancelContextStreaming = React.useCallback(() => {
     if (context.currentRequestId) {
-      vscode.postMessage({
-        type: MessageType.CANCEL_CONTEXT_REQUEST,
-        source: 'webview.analysis.tab',
-        payload: {
-          requestId: context.currentRequestId,
-          domain: 'context'
-        },
-        timestamp: Date.now()
-      });
+      vscode.postMessage(createCancelRequestMessage('context', context.currentRequestId, 'webview.analysis.tab'));
     }
     context.cancelStreaming();
   }, [context, vscode]);

--- a/packages/core/src/presentation/webview/components/tabs/UtilitiesTab.tsx
+++ b/packages/core/src/presentation/webview/components/tabs/UtilitiesTab.tsx
@@ -16,6 +16,7 @@ import { VSCodeAPI } from '../../types/vscode';
 import { UseDictionaryReturn } from '../../hooks/domain/useDictionary';
 import { UseSelectionReturn } from '../../hooks/domain/useSelection';
 import { UseSettingsReturn } from '../../hooks/domain/useSettings';
+import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
 
 interface UtilitiesTabProps {
   vscode: VSCodeAPI;
@@ -232,15 +233,7 @@ export const UtilitiesTab = React.memo<UtilitiesTabProps>(({
 
   const handleCancelStreaming = React.useCallback(() => {
     if (dictionary.currentRequestId) {
-      vscode.postMessage({
-        type: MessageType.CANCEL_DICTIONARY_REQUEST,
-        source: 'webview.utilities.tab',
-        payload: {
-          requestId: dictionary.currentRequestId,
-          domain: 'dictionary'
-        },
-        timestamp: Date.now()
-      });
+      vscode.postMessage(createCancelRequestMessage('dictionary', dictionary.currentRequestId, 'webview.utilities.tab'));
     }
     dictionary.cancelStreaming();
   }, [dictionary, vscode]);

--- a/packages/core/src/presentation/webview/components/tabs/UtilitiesTab.tsx
+++ b/packages/core/src/presentation/webview/components/tabs/UtilitiesTab.tsx
@@ -16,7 +16,7 @@ import { VSCodeAPI } from '../../types/vscode';
 import { UseDictionaryReturn } from '../../hooks/domain/useDictionary';
 import { UseSelectionReturn } from '../../hooks/domain/useSelection';
 import { UseSettingsReturn } from '../../hooks/domain/useSettings';
-import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
+import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 
 interface UtilitiesTabProps {
   vscode: VSCodeAPI;

--- a/packages/core/src/presentation/webview/hooks/domain/useAnalysis.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useAnalysis.ts
@@ -16,8 +16,10 @@ import {
   StreamStartedMessage,
   StreamChunkMessage,
   StreamCompleteMessage,
+  ClearTransientApiKeyWarningMessage,
   isApiKeyNotConfiguredWarning
 } from '@messages';
+import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
 
 export interface AnalysisState {
   result: string;
@@ -43,6 +45,7 @@ export interface AnalysisActions {
   setLoading: (loading: boolean) => void;
   clearResult: () => void;
   clearStatus: () => void;
+  handleClearTransientApiKeyWarning: (message: ClearTransientApiKeyWarningMessage) => void;
   // Streaming actions
   handleStreamChunk: (message: StreamChunkMessage) => void;
   handleStreamComplete: (message: StreamCompleteMessage) => void;
@@ -156,17 +159,16 @@ export const useAnalysis = (): UseAnalysisReturn => {
     setTickerMessage('');
   }, []);
 
+  const handleClearTransientApiKeyWarning = React.useCallback((_message: ClearTransientApiKeyWarningMessage) => {
+    setResult(current => isApiKeyNotConfiguredWarning(current) ? '' : current);
+  }, []);
+
   // Streaming handlers
   const startStreaming = React.useCallback((requestId: string) => {
     // Cancel any existing stream first
     if (currentRequestId) {
       // Notify backend to stop the old stream
-      vscode.postMessage({
-        type: MessageType.CANCEL_ANALYSIS_REQUEST,
-        source: 'webview.analysis.preempt',
-        payload: { requestId: currentRequestId, domain: 'analysis' },
-        timestamp: Date.now()
-      });
+      vscode.postMessage(createCancelRequestMessage('analysis', currentRequestId, 'webview.analysis.preempt'));
 
       ignoredRequestIdsRef.current.add(currentRequestId);
       streaming.reset();
@@ -270,6 +272,7 @@ export const useAnalysis = (): UseAnalysisReturn => {
     setLoading,
     clearResult,
     clearStatus,
+    handleClearTransientApiKeyWarning,
     // Streaming actions
     handleStreamStarted,
     handleStreamChunk,

--- a/packages/core/src/presentation/webview/hooks/domain/useAnalysis.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useAnalysis.ts
@@ -19,7 +19,7 @@ import {
   ClearTransientApiKeyWarningMessage,
   isApiKeyNotConfiguredWarning
 } from '@messages';
-import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
+import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 
 export interface AnalysisState {
   result: string;

--- a/packages/core/src/presentation/webview/hooks/domain/useContext.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useContext.ts
@@ -18,7 +18,7 @@ import {
   ClearTransientApiKeyWarningMessage,
   isApiKeyNotConfiguredWarning
 } from '@messages';
-import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
+import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 
 export interface ContextState {
   contextText: string;
@@ -236,7 +236,11 @@ export const useContext = (): UseContextReturn => {
     if (currentRequestId) {
       ignoredRequestIdsRef.current.add(currentRequestId);
     }
-    streaming.reset();
+    const partialContent = streaming.buffer;
+    streaming.endStreaming();
+    if (partialContent) {
+      setContextTextState(partialContent);
+    }
     setCurrentRequestId(null);
     setLoading(false);
     setStatusMessage('');

--- a/packages/core/src/presentation/webview/hooks/domain/useContext.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useContext.ts
@@ -15,8 +15,10 @@ import {
   StreamChunkMessage,
   StreamCompleteMessage,
   StreamStartedMessage,
+  ClearTransientApiKeyWarningMessage,
   isApiKeyNotConfiguredWarning
 } from '@messages';
+import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
 
 export interface ContextState {
   contextText: string;
@@ -42,6 +44,7 @@ export interface ContextActions {
   setStatusMessage: (message: string) => void;
   requestContext: (payload: { excerpt: string; existingContext: string; sourceFileUri?: string }) => void;
   clearContext: () => void;
+  handleClearTransientApiKeyWarning: (message: ClearTransientApiKeyWarningMessage) => void;
   // Streaming actions
   handleStreamChunk: (message: StreamChunkMessage) => void;
   handleStreamComplete: (message: StreamCompleteMessage) => void;
@@ -156,17 +159,16 @@ export const useContext = (): UseContextReturn => {
     }
   }, []);
 
+  const handleClearTransientApiKeyWarning = React.useCallback((_message: ClearTransientApiKeyWarningMessage) => {
+    setContextTextState(current => isApiKeyNotConfiguredWarning(current) ? '' : current);
+  }, []);
+
   // Streaming handlers
   const startStreaming = React.useCallback((requestId: string) => {
     // Cancel any existing stream first
     if (currentRequestId) {
       // Notify backend to stop the old stream
-      vscode.postMessage({
-        type: MessageType.CANCEL_CONTEXT_REQUEST,
-        source: 'webview.context.preempt',
-        payload: { requestId: currentRequestId, domain: 'context' },
-        timestamp: Date.now()
-      });
+      vscode.postMessage(createCancelRequestMessage('context', currentRequestId, 'webview.context.preempt'));
 
       ignoredRequestIdsRef.current.add(currentRequestId);
       streaming.reset();
@@ -264,6 +266,7 @@ export const useContext = (): UseContextReturn => {
     setStatusMessage,
     requestContext,
     clearContext,
+    handleClearTransientApiKeyWarning,
     // Streaming actions
     handleStreamStarted,
     handleStreamChunk,

--- a/packages/core/src/presentation/webview/hooks/domain/useDictionary.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useDictionary.ts
@@ -20,7 +20,7 @@ import {
   ClearTransientApiKeyWarningMessage,
   isApiKeyNotConfiguredWarning
 } from '@messages';
-import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
+import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 
 export interface FastGenerationMetadata {
   totalDuration: number;

--- a/packages/core/src/presentation/webview/hooks/domain/useDictionary.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useDictionary.ts
@@ -17,8 +17,10 @@ import {
   StreamStartedMessage,
   StreamChunkMessage,
   StreamCompleteMessage,
+  ClearTransientApiKeyWarningMessage,
   isApiKeyNotConfiguredWarning
 } from '@messages';
+import { createCancelRequestMessage } from '@utils/streamingCancelMessages';
 
 export interface FastGenerationMetadata {
   totalDuration: number;
@@ -63,6 +65,7 @@ export interface DictionaryActions {
   setWordEdited: (edited: boolean) => void;
   setSource: (uri?: string, relativePath?: string) => void;
   clearResult: () => void;
+  handleClearTransientApiKeyWarning: (message: ClearTransientApiKeyWarningMessage) => void;
   // Fast generation actions
   handleFastGenerateResult: (message: FastGenerateDictionaryResultMessage) => void;
   setFastGenerating: (isGenerating: boolean) => void;
@@ -196,6 +199,10 @@ export const useDictionary = (): UseDictionaryReturn => {
     setResult('');
   }, []);
 
+  const handleClearTransientApiKeyWarning = React.useCallback((_message: ClearTransientApiKeyWarningMessage) => {
+    setResult(current => isApiKeyNotConfiguredWarning(current) ? '' : current);
+  }, []);
+
   // Fast generation handlers
   const handleFastGenerateResult = React.useCallback((message: FastGenerateDictionaryResultMessage) => {
     const { result: content, metadata } = message.payload;
@@ -223,12 +230,7 @@ export const useDictionary = (): UseDictionaryReturn => {
     // Cancel any existing stream first
     if (currentRequestId) {
       // Notify backend to stop the old stream
-      vscode.postMessage({
-        type: MessageType.CANCEL_DICTIONARY_REQUEST,
-        source: 'webview.dictionary.preempt',
-        payload: { requestId: currentRequestId, domain: 'dictionary' },
-        timestamp: Date.now()
-      });
+      vscode.postMessage(createCancelRequestMessage('dictionary', currentRequestId, 'webview.dictionary.preempt'));
 
       ignoredRequestIdsRef.current.add(currentRequestId);
       streaming.reset();
@@ -336,6 +338,7 @@ export const useDictionary = (): UseDictionaryReturn => {
     setWordEdited,
     setSource,
     clearResult,
+    handleClearTransientApiKeyWarning,
     handleFastGenerateResult,
     setFastGenerating,
     // Streaming actions

--- a/packages/core/src/presentation/webview/hooks/domain/useDictionary.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useDictionary.ts
@@ -298,7 +298,11 @@ export const useDictionary = (): UseDictionaryReturn => {
     if (currentRequestId) {
       ignoredRequestIdsRef.current.add(currentRequestId);
     }
-    streaming.reset();
+    const partialContent = streaming.buffer;
+    streaming.endStreaming();
+    if (partialContent) {
+      setResult(partialContent);
+    }
     setCurrentRequestId(null);
     setLoading(false);
     setStatusMessage('');

--- a/packages/core/src/presentation/webview/hooks/useAppMessageRouter.ts
+++ b/packages/core/src/presentation/webview/hooks/useAppMessageRouter.ts
@@ -168,6 +168,11 @@ export const buildAppMessageRoutes = (deps: AppMessageRouterDeps): MessageHandle
     [MessageType.OPEN_SETTINGS_TOGGLE]: settings.toggle,
     [MessageType.TOKEN_USAGE_UPDATE]: tokenTracking.handleTokenUsageUpdate,
     [MessageType.ACCOUNT_BALANCE_DATA]: accountBalance.handleAccountBalanceData,
+    [MessageType.CLEAR_TRANSIENT_API_KEY_WARNING]: (msg) => {
+      analysis.handleClearTransientApiKeyWarning(msg);
+      dictionary.handleClearTransientApiKeyWarning(msg);
+      context.handleClearTransientApiKeyWarning(msg);
+    },
     // The save itself is the user-visible feedback; there's no webview action on
     // success today. Intentionally received-and-ignored (was a stray console.log
     // promoted into a permanent module by the App.tsx lift — see PR-60B review).

--- a/packages/core/src/presentation/webview/utils/streamingCancelMessages.ts
+++ b/packages/core/src/presentation/webview/utils/streamingCancelMessages.ts
@@ -1,0 +1,37 @@
+import {
+  CancelAnalysisRequestMessage,
+  CancelCategorySearchRequestMessage,
+  CancelContextRequestMessage,
+  CancelDictionaryRequestMessage,
+  MessageType,
+  StreamingDomain
+} from '@messages';
+
+export type CancelRequestMessage =
+  | CancelAnalysisRequestMessage
+  | CancelDictionaryRequestMessage
+  | CancelContextRequestMessage
+  | CancelCategorySearchRequestMessage;
+
+const cancelMessageTypes: Record<StreamingDomain, CancelRequestMessage['type']> = {
+  analysis: MessageType.CANCEL_ANALYSIS_REQUEST,
+  dictionary: MessageType.CANCEL_DICTIONARY_REQUEST,
+  context: MessageType.CANCEL_CONTEXT_REQUEST,
+  search: MessageType.CANCEL_CATEGORY_SEARCH_REQUEST
+};
+
+export function createCancelRequestMessage(
+  domain: StreamingDomain,
+  requestId: string,
+  source: string
+): CancelRequestMessage {
+  return {
+    type: cancelMessageTypes[domain],
+    source,
+    payload: {
+      requestId,
+      domain
+    },
+    timestamp: Date.now()
+  } as CancelRequestMessage;
+}

--- a/packages/core/src/shared/streamingCancelMessages.ts
+++ b/packages/core/src/shared/streamingCancelMessages.ts
@@ -25,6 +25,8 @@ export function createCancelRequestMessage(
   requestId: string,
   source: string
 ): CancelRequestMessage {
+  // `type` comes from an exhaustive domain map; the cast narrows the union so
+  // callers receive the matching cancel-message shape without duplicating cases.
   return {
     type: cancelMessageTypes[domain],
     source,

--- a/packages/core/src/shared/types/messages/base.ts
+++ b/packages/core/src/shared/types/messages/base.ts
@@ -82,8 +82,9 @@ export enum MessageType {
   REQUEST_API_KEY = 'request_api_key',
   API_KEY_STATUS = 'api_key_status',
   UPDATE_API_KEY = 'update_api_key',
-  DELETE_API_KEY = 'delete_api_key'
-  ,
+  DELETE_API_KEY = 'delete_api_key',
+  CLEAR_TRANSIENT_API_KEY_WARNING = 'clear_transient_api_key_warning',
+
   // Webview diagnostics
   WEBVIEW_ERROR = 'webview_error',
 

--- a/packages/core/src/shared/types/messages/index.ts
+++ b/packages/core/src/shared/types/messages/index.ts
@@ -98,6 +98,7 @@ import {
 } from './ui';
 import { ErrorMessage } from './error';
 import { StatusMessage } from './status';
+import { ClearTransientApiKeyWarningMessage } from './warnings';
 import {
   RequestAccountBalanceMessage,
   AccountBalanceDataMessage
@@ -180,6 +181,7 @@ export type ExtensionToWebviewMessage =
   | TokenUsageUpdateMessage
   | AccountBalanceDataMessage
   | ApiKeyStatusMessage
+  | ClearTransientApiKeyWarningMessage
   | FastGenerateDictionaryResultMessage
   | DictionaryGenerationProgressMessage
   | StreamStartedMessage

--- a/packages/core/src/shared/types/messages/streaming.ts
+++ b/packages/core/src/shared/types/messages/streaming.ts
@@ -7,7 +7,7 @@ import { TokenUsage } from '../index';
 import { MessageType, MessageEnvelope } from './base';
 
 /**
- * Domain types that support streaming
+ * Domain types that support streaming events or cancel requests.
  */
 export type StreamingDomain = 'analysis' | 'dictionary' | 'context' | 'search';
 

--- a/packages/core/src/shared/types/messages/streaming.ts
+++ b/packages/core/src/shared/types/messages/streaming.ts
@@ -9,7 +9,7 @@ import { MessageType, MessageEnvelope } from './base';
 /**
  * Domain types that support streaming
  */
-export type StreamingDomain = 'analysis' | 'dictionary' | 'context';
+export type StreamingDomain = 'analysis' | 'dictionary' | 'context' | 'search';
 
 /**
  * Payload for STREAM_CHUNK messages

--- a/packages/core/src/shared/types/messages/warnings.ts
+++ b/packages/core/src/shared/types/messages/warnings.ts
@@ -2,6 +2,8 @@
  * Cross-domain warning sentinels.
  */
 
+import { MessageEnvelope, MessageType } from './base';
+
 /**
  * Sentinel heading for the "no API key" onboarding warning that AI services
  * return in place of a real result when no OpenRouter key is configured.
@@ -14,3 +16,7 @@ export const API_KEY_NOT_CONFIGURED_HEADING = '⚠️ OpenRouter API key not con
 
 export const isApiKeyNotConfiguredWarning = (text: string | undefined): boolean =>
   !!text && text.startsWith(API_KEY_NOT_CONFIGURED_HEADING);
+
+export interface ClearTransientApiKeyWarningMessage extends MessageEnvelope<Record<string, never>> {
+  type: MessageType.CLEAR_TRANSIENT_API_KEY_WARNING;
+}


### PR DESCRIPTION
## Summary

- Centralize streaming cancel message creation and make category-search cancellation a typed `search` streaming domain.
- Add named service-refresh observability for API-key/model refresh paths.
- Make active-file reads from unsaved `untitled:` buffers fail with a clear save-or-select-text message while preserving selection-mode support.
- Add a typed transient API-key warning clear message that only clears the no-key sentinel after a successful key-backed refresh.
- Archive the resolved tech-debt notes and update active `.todo` references.

## Validation

- `npm test -- --runTestsByPath packages/core/src/__tests__/presentation/webview/utils/streamingCancelMessages.test.ts packages/core/src/__tests__/application/handlers/MessageHandler.test.ts packages/core/src/__tests__/infrastructure/text/TextSourceResolver.test.ts packages/core/src/__tests__/presentation/webview/hooks/useAppMessageRouter.test.ts packages/core/src/__tests__/presentation/webview/hooks/domain/useAnalysis.test.ts packages/core/src/__tests__/presentation/webview/hooks/domain/useContext.test.ts packages/core/src/__tests__/presentation/webview/hooks/domain/useDictionary.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm test`
- `npm run build` (passes with existing webpack bundle-size warnings)
