### PR TITLE
feat(workshop): Sprint 04 actions and polish

### DIFF
--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-06
 **Status**: In Progress
-**Progress**: 3/4 sprints merged; Sprint 04 complete on branch (Sprint 01 merged 2026-07-06, [PR #66](https://github.com/okeylanders/prose-minion-vscode/pull/66); Sprint 02 merged 2026-07-07, [PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67); Sprint 03 merged 2026-07-07, [PR #68](https://github.com/okeylanders/prose-minion-vscode/pull/68))
+**Progress**: 3/6 sprints merged; Sprint 04 complete on branch; Sprints 05-06 planned (Sprint 01 merged 2026-07-06, [PR #66](https://github.com/okeylanders/prose-minion-vscode/pull/66); Sprint 02 merged 2026-07-07, [PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67); Sprint 03 merged 2026-07-07, [PR #68](https://github.com/okeylanders/prose-minion-vscode/pull/68))
 **Design source**: [Direction B — Split & Pinned](../../design/Prose%20Minion%20-%20Assistant%20Tab.html)
 **ADR**: [2026-07-03 — Assistant as a Full Editor Tab](../../adr/2026-07-03-assistant-editor-tab.md)
 **Integration branch**: `epic/workshop-editor-tab`
@@ -20,6 +20,14 @@ The ADR's thesis: the genuinely new code is **one provider, one handler, one
 service, one hook, one React root**. Everything else — the 14 tools, streaming,
 cancellation, token tracking, balance, model scoping — already exists and is
 reused, not reinvented.
+
+After Sprint 04, the Workshop expands from **tool-first conversation** to
+**persona-hosted conversation**. A user should be able to pin an excerpt, pick a
+Writers' Room host (Jill by default; Margot, Quinn, Wren, and the other
+specialists as sharper lenses), and start chatting before running a tool. Tool
+runs remain deterministic actions; when triggered inside a persona chat, their
+results should feed back into the active persona conversation as side-pass
+material instead of replacing the persona's voice.
 
 ## Sequencing
 
@@ -40,8 +48,10 @@ Each sprint is independently shippable behind the (initially unregistered)
 | 2 | `claude/sprint-02-session-spine-skndyo` ([PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67)) | [Session spine](sprints/02-session-spine.md) | Host-side session state + one streaming turn into the thread. |
 | 3 | `feat/workshop-s3-multiturn` ([PR #68](https://github.com/okeylanders/prose-minion-vscode/pull/68)) | [Multi-turn](sprints/03-multiturn.md) | Follow-ups continue the same conversation. The "now tighten it" loop. |
 | 4 | `feat/workshop-s4-actions-polish` | [Actions & polish](sprints/04-actions-polish.md) | The approved prototype's feel: quick actions, cards, toasts. |
+| 5 | `sprint/workshop-editor-tab-05-persona-chat` | [Persona-hosted chat](sprints/05-persona-chat.md) | The user can start a retained Workshop chat with Jill or a Writers' Room specialist before running a tool. |
+| 6 | `sprint/workshop-editor-tab-06-tool-side-pass` | [Tool side-pass integration](sprints/06-tool-side-pass.md) | Tool runs inside a persona chat become structured side-pass material injected back into the persona conversation. |
 
-Final step after Sprint 4 merges: one PR `epic/workshop-editor-tab → main`.
+Final step after Sprint 6 merges: one PR `epic/workshop-editor-tab → main`.
 
 ## Architectural Invariants (hold across every sprint)
 
@@ -55,6 +65,13 @@ Final step after Sprint 4 merges: one PR `epic/workshop-editor-tab → main`.
   second build pipeline.
 - **Quick actions are deterministic.** Static `toolId → labels → prompt
   templates` map in code. The LLM produces content, never button labels.
+- **Personas are deterministic lenses, not runtime filesystem dependencies.**
+  Their catalog and packaged prompt resources live under this repo (for
+  example `packages/core/resources/workshop-personas/`), even if their source
+  material begins in Okey's `zsh-setup` prompt-library.
+- **Personas are not tools.** Tools remain structured actions mapped to the
+  existing analysis contracts; persona chat owns the conversational voice and
+  follow-up loop.
 - **Domain mirroring stays honest**: `useWorkshop` ↔ `WorkshopHandler`,
   registered in `MessageHandler` exactly like the other 11 domains (workshop
   is the 12th).
@@ -69,6 +86,36 @@ Final step after Sprint 4 merges: one PR `epic/workshop-editor-tab → main`.
 - **Sidebar reskin** and the **Model Browser** — separate follow-ups. A
   temporary look divergence between sidebar and Workshop is acceptable in alpha.
 
+## Planned Persona Expansion (Sprints 05-06)
+
+The Writers' Room personas come from Okey's existing prompt-library source
+material:
+
+- Jill: `/Users/okey.landers/GitHub/zsh-setup/prompt-library/claude-personas/CLAUDE-Jill.md`
+- Specialists: `/Users/okey.landers/GitHub/zsh-setup/prompt-library/claude-skills/`
+  (`agnes`, `cliff`, `dev`, `edna`, `felix`, `harper`, `margot`, `penny`,
+  `quinn`, `theo`, `wren`)
+
+Those paths are **authoring sources only**. Runtime Workshop resources must be
+copied, transformed, or curated into the Prose Minion repo so the extension is
+portable and packageable.
+
+Target behavior:
+
+- A pinned excerpt plus selected persona can start a retained conversation
+  before any tool has run.
+- Jill is the default general Workshop host; specialist personas are selected
+  from a dropdown when the writer wants a narrower craft lens.
+- The composer is enabled when an excerpt is pinned and a persona is selected,
+  even if `selectedToolId` is still empty.
+- Triggering a tool during persona chat does not replace the persona system
+  prompt. The tool result is presented to the active persona as structured
+  side-pass evidence, and the persona responds in the same conversation.
+- Context loading starts compact: pinned excerpt, source provenance, and a
+  concise context/catalog summary. Additional files should be loaded on demand
+  through existing resource-request patterns instead of eagerly stuffing the
+  prompt.
+
 ## Known Risks
 
 - `retainContextWhenHidden` keeps the panel process alive in the background —
@@ -78,6 +125,13 @@ Final step after Sprint 4 merges: one PR `epic/workshop-editor-tab → main`.
   *supports* continuation (`startConversation` / `addMessage` / `getMessages`),
   but token budgeting across turns, system-prompt handling on continuation, and
   conversation disposal on reset are unproven. Sized in Sprint 3.
+- Persona-first chat introduces a second valid conversation origin: a persona
+  prompt rather than a completed tool run. `WorkshopSessionService` must make
+  that origin explicit so follow-up enablement does not depend on
+  `selectedToolId`.
+- Tool side-pass integration can accidentally blur model roles if implemented
+  as "the persona pretends to be the tool." Keep tool execution deterministic
+  and inject the result as evidence into the active persona conversation.
 - ~~`ConversationManager` still logs via raw `console.*`~~ — migrated to the
   injected `LogSink` in Sprint 02 (PR #67).
 - **Markdown sanitization (shared `MarkdownRenderer`)**: untrusted model

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
@@ -2,7 +2,7 @@
 
 **Created**: 2026-07-06
 **Status**: In Progress
-**Progress**: 2/4 sprints complete (Sprint 01 merged 2026-07-06, [PR #66](https://github.com/okeylanders/prose-minion-vscode/pull/66); Sprint 02 merged 2026-07-07, [PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67))
+**Progress**: 3/4 sprints merged; Sprint 04 complete on branch (Sprint 01 merged 2026-07-06, [PR #66](https://github.com/okeylanders/prose-minion-vscode/pull/66); Sprint 02 merged 2026-07-07, [PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67); Sprint 03 merged 2026-07-07, [PR #68](https://github.com/okeylanders/prose-minion-vscode/pull/68))
 **Design source**: [Direction B — Split & Pinned](../../design/Prose%20Minion%20-%20Assistant%20Tab.html)
 **ADR**: [2026-07-03 — Assistant as a Full Editor Tab](../../adr/2026-07-03-assistant-editor-tab.md)
 **Integration branch**: `epic/workshop-editor-tab`
@@ -38,7 +38,7 @@ Each sprint is independently shippable behind the (initially unregistered)
 |---|--------|--------|--------|
 | 1 | `claude/sprint-01-workshop-editor-tab-u49fd5` ([PR #66](https://github.com/okeylanders/prose-minion-vscode/pull/66)) | [Shell](sprints/01-shell.md) | The second surface exists and boots. Zero AI. |
 | 2 | `claude/sprint-02-session-spine-skndyo` ([PR #67](https://github.com/okeylanders/prose-minion-vscode/pull/67)) | [Session spine](sprints/02-session-spine.md) | Host-side session state + one streaming turn into the thread. |
-| 3 | `feat/workshop-s3-multiturn` | [Multi-turn](sprints/03-multiturn.md) | Follow-ups continue the same conversation. The "now tighten it" loop. |
+| 3 | `feat/workshop-s3-multiturn` ([PR #68](https://github.com/okeylanders/prose-minion-vscode/pull/68)) | [Multi-turn](sprints/03-multiturn.md) | Follow-ups continue the same conversation. The "now tighten it" loop. |
 | 4 | `feat/workshop-s4-actions-polish` | [Actions & polish](sprints/04-actions-polish.md) | The approved prototype's feel: quick actions, cards, toasts. |
 
 Final step after Sprint 4 merges: one PR `epic/workshop-editor-tab → main`.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/04-actions-polish.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/04-actions-polish.md
@@ -63,8 +63,8 @@ Completed on `feat/workshop-s4-actions-polish` (2026-07-07).
   turns display the clicked label while the model receives the fuller prompt
   template.
 - Workshop UI now has contextual quick-action bars, the 14-tool modal/palette,
-  variation-card rendering for the strict `### Variation N - Label` markdown
-  format, Copy / Save to notes actions through existing file-ops messages,
+  variation-card rendering for the prompted `### Variation N - Label` markdown
+  format with tolerant parsing for model drift, Copy / Save to notes actions through existing file-ops messages,
   toasts, a richer welcome/empty state, and a visible status ticker.
 - Session snapshots now include `selectedToolId` so reload/reopen can restore
   the active lens without falsely marking a completed session as still running.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/04-actions-polish.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/04-actions-polish.md
@@ -1,6 +1,6 @@
 # Sprint 04: Actions & Polish
 
-**Status**: Not Started
+**Status**: Complete
 **Priority**: Medium
 **Branch**: `feat/workshop-s4-actions-polish` → PR into `epic/workshop-editor-tab`
 **Estimated Effort**: 2–4 days
@@ -27,31 +27,69 @@ not smuggled.
 
 ## Tasks
 
-- [ ] Add `WORKSHOP_QUICK_ACTION` to `workshop.ts`.
-- [ ] Static quick-action map in code: `toolId → action labels → prompt
+- [x] Add `WORKSHOP_QUICK_ACTION` to `workshop.ts`.
+- [x] Static quick-action map in code: `toolId → action labels → prompt
       templates`, ported from the prototype's `ASSIST` table. Deterministic
       routing; **no model-generated labels**.
-- [ ] Render the contextual quick-action bar beneath each assistant turn;
+- [x] Render the contextual quick-action bar beneath each assistant turn;
       a chip dispatches `WORKSHOP_QUICK_ACTION`, which routes through the
       Sprint-3 continuation path (a quick action is a templated follow-up).
-- [ ] Tools modal: a palette/modal for selecting the active tool from the 14.
-- [ ] Variation cards: render variations with Copy and "Save to notes" actions.
+- [x] Tools modal: a palette/modal for selecting the active tool from the 14.
+- [x] Variation cards: render variations with Copy and "Save to notes" actions.
       (No Apply-to-draft — filed as `.todo`.)
-- [ ] Toasts for copy / save / error acknowledgements.
-- [ ] Welcome / empty state for a fresh session (no excerpt, no turns).
-- [ ] Full status-ticker and token integration (`useAnalysis` status patterns,
+- [x] Toasts for copy / save / error acknowledgements.
+- [x] Welcome / empty state for a fresh session (no excerpt, no turns).
+- [x] Full status-ticker and token integration (`useAnalysis` status patterns,
       `useTokenTracking`).
-- [ ] Persistence hardening: confirm reload/reopen restores thread, excerpt,
+- [x] Persistence hardening: confirm reload/reopen restores thread, excerpt,
       active tool, and conversation id via the host-side aggregate +
       `retainContextWhenHidden`.
-- [ ] File `.todo` entries for the parked items:
+- [x] File `.todo` entries for the parked items:
       - `apply-to-draft` (write-back via `FileOperationsHandler`)
       - `WebviewPanelSerializer` (persistence across VS Code restarts)
       - sidebar reskin (Frame Minion across the sidebar)
       - Model Browser (header dropdown → full browser)
       - branch board (Direction C) on variation cards
-- [ ] Register the sidebar-Assistant button that opens the Workshop (the
+- [x] Register the sidebar-Assistant button that opens the Workshop (the
       user-facing entry point beyond the command palette).
+
+## Completion Notes
+
+Completed on `feat/workshop-s4-actions-polish` (2026-07-07).
+
+- Quick actions now live in a deterministic shared map
+  (`workshopQuickActions.ts`) and route through `WORKSHOP_QUICK_ACTION` into the
+  existing Sprint 03 retained-conversation follow-up path. Quick-action user
+  turns display the clicked label while the model receives the fuller prompt
+  template.
+- Workshop UI now has contextual quick-action bars, the 14-tool modal/palette,
+  variation-card rendering for the strict `### Variation N - Label` markdown
+  format, Copy / Save to notes actions through existing file-ops messages,
+  toasts, a richer welcome/empty state, and a visible status ticker.
+- Session snapshots now include `selectedToolId` so reload/reopen can restore
+  the active lens without falsely marking a completed session as still running.
+- The sidebar Assistant tab has a Workshop button that opens the editor-tab
+  surface via an injected UI action; VS Code command execution remains in the
+  adapter/composition-root side.
+- Parked follow-ups filed:
+  `.todo/features/feature-workshop-apply-to-draft/README.md`,
+  `.todo/tech-debt/2026-07-07-workshop-webviewpanelserializer.md`,
+  `.todo/features/feature-sidebar-frame-minion-reskin/README.md`,
+  `.todo/features/feature-workshop-header-model-browser/README.md`,
+  `.todo/features/feature-workshop-branch-board/README.md`.
+
+## Verification
+
+- `npm test -- --runTestsByPath packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts packages/core/src/__tests__/application/services/WorkshopSessionService.test.ts packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts` — pass (72 tests).
+- `npm run typecheck` — pass (core, webview, extension).
+- `npm test` — pass (61 suites / 541 tests).
+- `npm run build` — pass; includes `verify:bundle` pass. Webpack still reports
+  the existing webview asset-size warning.
+- `npm run lint` — pass with warnings only (0 errors; existing naming/curly
+  warnings remain).
+- `git diff --check` — pass.
+- Bundle delta vs Sprint 03 / PR #68 baseline: `dist/webview.js` 549,388 B →
+  568,879 B (**+19,491 B / +3.55%**). Current `dist/extension.js`: 2,260,176 B.
 
 ## Acceptance Criteria
 

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/05-persona-chat.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/05-persona-chat.md
@@ -1,0 +1,87 @@
+# Sprint 05: Persona-Hosted Chat
+
+**Status**: Planned
+**Priority**: High
+**Branch**: `sprint/workshop-editor-tab-05-persona-chat` -> PR into `epic/workshop-editor-tab`
+**Estimated Effort**: 2-4 days
+**Depends on**: Sprint 04
+
+## Goal
+
+Let a writer start a Workshop conversation before running a tool. The flow is:
+pin an excerpt, choose a Writers' Room persona, then chat. Jill is the default
+Workshop host; specialists such as Margot, Quinn, Wren, Theo, and Dev provide
+narrower craft lenses.
+
+Personas are conversation hosts, not tools. They own voice, judgment, and the
+retained conversation. The existing 14 tools remain deterministic actions.
+
+## Current Reality
+
+- Sprint 03 added `WORKSHOP_SEND_MESSAGE`, but it only works after a successful
+  tool run creates a retained conversation.
+- `WorkshopSessionService` treats conversation identity as "the last successful
+  tool run." That is no longer enough once a persona can start the session.
+- The persona source material currently lives outside this repo:
+  - Jill: `/Users/okey.landers/GitHub/zsh-setup/prompt-library/claude-personas/CLAUDE-Jill.md`
+  - Specialists: `/Users/okey.landers/GitHub/zsh-setup/prompt-library/claude-skills/`
+- Runtime must not depend on those absolute paths. Curate/copy prompts into
+  packageable resources under this repo.
+
+## Tasks
+
+- [ ] Add a deterministic persona catalog, likely
+      `packages/core/src/shared/constants/workshopPersonas.ts`, with ids,
+      labels, specialties, descriptions, and packaged prompt resource paths.
+- [ ] Add packaged persona prompt resources under a repo-owned directory such
+      as `packages/core/resources/workshop-personas/`.
+- [ ] Include Jill plus the Writers' Room specialists:
+      `agnes`, `cliff`, `dev`, `edna`, `felix`, `harper`, `margot`, `penny`,
+      `quinn`, `theo`, `wren`.
+- [ ] Add message contracts for selecting a persona and starting a chat, e.g.
+      `WORKSHOP_SELECT_PERSONA` and `WORKSHOP_START_CHAT`, or a single
+      start-chat payload carrying `personaId` and text.
+- [ ] Extend `WorkshopSessionService` so a session has an explicit
+      conversation origin (`persona` or `tool`) and selected persona id.
+- [ ] Add an `AssistantToolService`/orchestration entry point that starts and
+      retains a Workshop persona conversation from:
+      - persona system prompt
+      - pinned excerpt
+      - source provenance
+      - compact context/catalog summary
+      - initial user message
+- [ ] Enable the composer when an excerpt is pinned and a persona is selected,
+      even when no tool conversation exists yet.
+- [ ] Add a persona dropdown to the Workshop header/composer area. Default to
+      Jill for new sessions.
+- [ ] Persist selected persona in the host-side snapshot so reload/reopen
+      restores the active host.
+- [ ] Update status, stream, cancel, reset, and conversation-disposal paths for
+      persona-origin conversations.
+- [ ] Add tests for persona catalog invariants, session origin transitions,
+      start-chat handler behavior, reload snapshot behavior, and composer
+      enablement.
+
+## Acceptance Criteria
+
+- A writer can pin an excerpt, leave the default persona as Jill, type a
+  message, and receive a streamed retained conversation response.
+- A writer can switch to a specialist persona before starting the chat.
+- Follow-up messages continue the persona conversation without requiring a
+  prior tool run.
+- Running reset clears the conversation while preserving the pinned excerpt
+  according to the current Workshop reset semantics.
+- Runtime persona prompts are loaded from this repo, not from Okey's absolute
+  `zsh-setup` paths.
+- Typecheck, focused Workshop tests, and bundle verification pass.
+
+## Notes / Guardrails
+
+- Do not model personas as `WorkshopToolId`. Keep `WorkshopPersonaId` separate.
+- Do not let the model generate persona dropdown labels.
+- Keep initial context compact. Do not eagerly pack a whole project or long
+  source stack into the first prompt.
+- If a persona asks for more context, route that through existing resource
+  request patterns rather than inventing a new file-loading loop.
+- Tool side-pass behavior is Sprint 06. This sprint may leave tool runs with
+  existing replacement semantics if needed, as long as the UI is honest.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/06-tool-side-pass.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/06-tool-side-pass.md
@@ -1,0 +1,82 @@
+# Sprint 06: Tool Side-Pass Integration
+
+**Status**: Planned
+**Priority**: High
+**Branch**: `sprint/workshop-editor-tab-06-tool-side-pass` -> PR into `epic/workshop-editor-tab`
+**Estimated Effort**: 3-5 days
+**Depends on**: Sprint 05
+
+## Goal
+
+When a user triggers a Workshop tool during a persona-hosted chat, run the tool
+as a structured side pass and inject its result into the active persona
+conversation. The persona remains the host; the tool provides evidence.
+
+This is the preferred behavior over replacing the persona conversation with the
+tool's system prompt.
+
+## Current Reality
+
+- Today, `WORKSHOP_RUN_TOOL` starts a fresh retained tool conversation and the
+  session adopts that conversation id.
+- That behavior is correct for tool-first sessions, but wrong for a
+  persona-hosted thread. If the user is chatting with Jill and runs Continuity,
+  Jill should not vanish.
+- Quick actions already prove the desired pattern in miniature: deterministic
+  UI action resolves to a code-owned prompt and routes through the retained
+  conversation path.
+
+## Tasks
+
+- [ ] Define the session policy for `WORKSHOP_RUN_TOOL` when an active persona
+      conversation exists:
+      - run the selected tool with its existing prompt and pinned excerpt
+      - do not adopt the tool conversation as the session conversation
+      - append/render the tool result as a distinct side-pass turn or evidence
+      - send a structured follow-up into the active persona conversation
+- [ ] Extend `WorkshopTurn` or add metadata so the thread can distinguish:
+      - persona user turns
+      - persona assistant turns
+      - tool side-pass result turns
+      - persona synthesis turns after side-pass injection
+- [ ] Add an injection prompt template that summarizes the tool result for the
+      persona without asking the persona to impersonate the tool.
+- [ ] Preserve the tool-first path for sessions with no active persona
+      conversation.
+- [ ] Update quick actions so chips on side-pass/persona turns resolve against
+      the correct active lens and do not send stale tool prompts into the wrong
+      conversation.
+- [ ] Add UI treatment for side-pass turns: visibly separate the tool evidence
+      from the persona's response while keeping both in the same thread.
+- [ ] Ensure Copy / Save to notes works for side-pass results and persona
+      synthesis results with correct deterministic tool/persona names.
+- [ ] Add tests for:
+      - tool-first behavior remains unchanged
+      - persona-hosted tool run does not replace the persona conversation id
+      - side-pass result is rendered and persisted
+      - persona synthesis receives the tool result
+      - reset/dispose discards all retained conversations cleanly
+
+## Acceptance Criteria
+
+- In a Jill-hosted chat, running a tool produces a tool result and then a Jill
+  response that uses that result.
+- The active persona remains selected after the tool run.
+- Follow-up messages after the side pass continue the persona conversation.
+- Tool-first sessions still work as they did after Sprint 04.
+- The thread, selected persona, selected tool, side-pass result, and active
+  conversation restore correctly after webview reload.
+- Typecheck, focused Workshop tests, and bundle verification pass.
+
+## Notes / Guardrails
+
+- Do not implement this by merging persona and tool prompts into one giant
+  system prompt. The tool and persona have different responsibilities.
+- Do not let side-pass tool runs silently discard or replace the persona
+  conversation.
+- Keep context loading inspectable. Status messages should make it clear
+  whether the Workshop is running a tool, injecting evidence, or waiting on the
+  persona response.
+- If side-pass orchestration grows too large for `WorkshopHandler`, extract a
+  focused application service rather than turning the handler into a workflow
+  script.

--- a/.todo/features/feature-sidebar-frame-minion-reskin/README.md
+++ b/.todo/features/feature-sidebar-frame-minion-reskin/README.md
@@ -1,0 +1,29 @@
+# Feature: Sidebar Frame Minion Reskin
+
+**Date Identified**: 2026-07-07
+**Source**: Workshop editor-tab Sprint 04 parked item
+**Status**: Parked
+**Priority**: Medium
+
+## Problem
+
+The Workshop ships with the warm Frame Minion-inspired editor-tab treatment,
+while the sidebar remains on its existing surface. The temporary visual
+divergence is acceptable for the Workshop alpha, but it should be resolved as a
+separate design pass rather than folded into Sprint 04.
+
+## Related Files
+
+- `docs/design/Prose Minion - Design Refresh.html`
+- `docs/design/pm-mock.css`
+- `packages/core/src/presentation/webview/App.tsx`
+- `packages/core/src/presentation/webview/index.css`
+
+## Completion Criteria
+
+- Sidebar chrome, tabs, cards, and controls align with the approved design
+  refresh without regressing narrow sidebar usability.
+- Existing sidebar workflows still pass: analysis, metrics, dictionary, search,
+  settings, account balance, save/copy.
+- Visual changes are scoped to sidebar styles and shared components where
+  appropriate.

--- a/.todo/features/feature-workshop-apply-to-draft/README.md
+++ b/.todo/features/feature-workshop-apply-to-draft/README.md
@@ -1,0 +1,29 @@
+# Feature: Workshop Apply to Draft
+
+**Date Identified**: 2026-07-07
+**Source**: Workshop editor-tab Sprint 04 parked item
+**Status**: Parked
+**Priority**: Medium
+
+## Problem
+
+Workshop variation cards now support Copy and Save to notes only. Applying a
+variation directly back into the source draft needs a separate write-back design
+so the extension does not overwrite the wrong range, dirty buffer, or stale
+selection.
+
+## Related Files
+
+- `packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx`
+- `packages/core/src/application/handlers/domain/FileOperationsHandler.ts`
+- `packages/core/src/application/handlers/domain/UIHandler.ts`
+- `packages/core/src/platform/EditorContext.ts`
+
+## Completion Criteria
+
+- Write-back routes through a host-side handler/port, not browser APIs.
+- The design handles dirty buffers, stale ranges, and missing source provenance.
+- Variation cards expose Apply to draft only when the target range is known and
+  safe.
+- Focused tests cover happy path, stale source, missing source, and mid-edit
+  conflict behavior.

--- a/.todo/features/feature-workshop-branch-board/README.md
+++ b/.todo/features/feature-workshop-branch-board/README.md
@@ -1,0 +1,28 @@
+# Feature: Workshop Branch Board
+
+**Date Identified**: 2026-07-07
+**Source**: Workshop editor-tab Sprint 04 parked item
+**Status**: Parked
+**Priority**: Medium
+
+## Problem
+
+The approved Sprint 04 scope ships linear variation cards. Direction C's branch
+board and branching semantics remain out of scope because they require their
+own state model: what counts as a branch, how branches relate to conversations,
+and how a writer compares or returns to them.
+
+## Related Files
+
+- `docs/design/Prose Minion - Design Refresh.html`
+- `docs/design/pm-frames-fulltab.js`
+- `packages/core/src/application/services/WorkshopSessionService.ts`
+- `packages/core/src/presentation/webview/WorkshopApp.tsx`
+
+## Completion Criteria
+
+- Branches have an explicit data model instead of being presentation-only.
+- The UI can create, select, and compare branches without losing the linear
+  conversation.
+- Reload/reopen restores branch state consistently.
+- Tests cover branch creation, selection, reset, and snapshot behavior.

--- a/.todo/features/feature-workshop-header-model-browser/README.md
+++ b/.todo/features/feature-workshop-header-model-browser/README.md
@@ -1,0 +1,28 @@
+# Feature: Workshop Header Model Browser
+
+**Date Identified**: 2026-07-07
+**Source**: Workshop editor-tab Sprint 04 parked item
+**Status**: Parked
+**Priority**: Medium
+
+## Problem
+
+The Workshop header currently reuses the compact assistant model selector. The
+prototype points toward a full model-browser affordance from that header so
+writers can inspect capabilities, pricing, and context before switching models.
+
+## Related Files
+
+- `docs/design/Prose Minion - Model Browser.html`
+- `packages/core/src/presentation/webview/components/shared/ModelSelector.tsx`
+- `packages/core/src/presentation/webview/components/shared/ModelBrowserModal.tsx`
+- `packages/core/src/presentation/webview/WorkshopApp.tsx`
+
+## Completion Criteria
+
+- The Workshop header opens the full model browser in a way that matches the
+  approved Workshop visual language.
+- Browser selection updates the assistant model scope through existing
+  `SET_MODEL_SELECTION` plumbing.
+- Pricing/context display clearly distinguishes live data from fallback data.
+- Typecheck, focused model-browser tests, and Workshop smoke coverage pass.

--- a/.todo/tech-debt/2026-07-07-workshop-webviewpanelserializer.md
+++ b/.todo/tech-debt/2026-07-07-workshop-webviewpanelserializer.md
@@ -1,0 +1,28 @@
+# Tech Debt: Workshop WebviewPanelSerializer
+
+**Date Identified**: 2026-07-07
+**Source**: Workshop editor-tab Sprint 04 parked item
+**Status**: Parked
+**Priority**: Medium
+
+## Problem
+
+Workshop v1 restores across reload/reopen inside the same VS Code window via
+`WorkshopSessionService` and `retainContextWhenHidden`. It does not yet restore
+the editor tab across a full VS Code restart because no `WebviewPanelSerializer`
+is registered for the Workshop panel.
+
+## Related Files
+
+- `apps/vscode-extension/src/application/providers/WorkshopPanelProvider.ts`
+- `apps/vscode-extension/src/extension.ts`
+- `packages/core/src/application/services/WorkshopSessionService.ts`
+
+## Completion Criteria
+
+- Register a Workshop `WebviewPanelSerializer` in the VS Code adapter.
+- Decide which session state persists across VS Code restart and where it is
+  stored.
+- Rehydration preserves pinned excerpt, selected tool, thread, and conversation
+  affordance honestly, or explicitly marks any lost conversation as unavailable.
+- Tests cover serializer registration and restore behavior.

--- a/apps/vscode-extension/src/application/providers/ProseToolsViewProvider.ts
+++ b/apps/vscode-extension/src/application/providers/ProseToolsViewProvider.ts
@@ -30,7 +30,8 @@ export class ProseToolsViewProvider implements vscode.WebviewViewProvider {
     private readonly extensionUri: vscode.Uri,
     private readonly coreServices: CoreServices,
     private readonly outputChannel: vscode.OutputChannel,
-    private readonly platform: Platform
+    private readonly platform: Platform,
+    private readonly uiActions: { openWorkshop?: () => void } = {}
   ) {}
 
   public resolveWebviewView(
@@ -58,7 +59,8 @@ export class ProseToolsViewProvider implements vscode.WebviewViewProvider {
       this.coreServices,
       (message) => webviewView.webview.postMessage(message),
       this.platform,
-      this.outputChannel
+      this.outputChannel,
+      this.uiActions
     );
 
     // Config-change watcher lives in the shell (keeps MessageHandler vscode-free).

--- a/apps/vscode-extension/src/application/providers/ProseToolsViewProvider.ts
+++ b/apps/vscode-extension/src/application/providers/ProseToolsViewProvider.ts
@@ -13,6 +13,7 @@ import {
   MessageHandler,
   CoreServices,
   Platform,
+  WorkshopUiActions,
   MessageType,
   SelectionUpdatedMessage,
   OpenSettingsToggleMessage,
@@ -31,7 +32,7 @@ export class ProseToolsViewProvider implements vscode.WebviewViewProvider {
     private readonly coreServices: CoreServices,
     private readonly outputChannel: vscode.OutputChannel,
     private readonly platform: Platform,
-    private readonly uiActions: { openWorkshop?: () => void } = {}
+    private readonly uiActions: WorkshopUiActions = {}
   ) {}
 
   public resolveWebviewView(

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -173,7 +173,10 @@ export function activate(context: vscode.ExtensionContext): void {
     context.extensionUri,
     coreServices,
     outputChannel,
-    platform
+    platform,
+    {
+      openWorkshop: () => workshopPanelProvider?.openOrReveal()
+    }
   );
 
   // Register webview provider

--- a/docs/pr-reviews/pr-69-workshop-s4-actions-polish-review.md
+++ b/docs/pr-reviews/pr-69-workshop-s4-actions-polish-review.md
@@ -14,22 +14,22 @@ act before merge · **Deferred** = real issue, safe to punt for a stated reason 
 
 | # | Sev | Finding | Reviewers | Consensus | Status |
 |---|-----|---------|-----------|-----------|--------|
-| 1 | 🟠 High | Save fires two competing toasts; copy/save toast triggers substring-match free-text STATUS prose | Parker, Blake, Sam, Oliver | 🎯🎯 Strong | **Open** |
-| 2 | 🟠 High | `makeActions` picks prompts by sniffing display labels — load-bearing for the 7 fallback tools, zero invariant tests | Parker, Cal | 🎯 | **Open** |
-| 3 | 🟠 High | `openWorkshop` crosses the boundary as three anonymous type shapes while a `prose-minion.openWorkshop` command already does the same call | Marcus, Stan | 🎯 | **Open** |
-| 4 | 🟠 High | Stale-turn quick-action chips send an old tool's lens prompt into the current (different-tool) conversation | Bria | — | **Open** |
-| 5 | 🟠 High | A failed Workshop save/copy leaves no durable trace once the 2.2s toast fades (no log line, no banner) | Oliver | — | **Open** |
-| 6 | 🟠 High | `WorkshopThread`'s `currentToolId` walk goes blind past the 100-turn snapshot window — quick actions vanish, saves mislabeled `editor-*` | Sam | — | **Deferred** — needs a 100+-turn session *and* a reload; fix = fall back to the reload-safe `session.selectedToolId` |
-| 7 | 🟡 Standard | `OPEN_WORKSHOP` / `handleOpenWorkshop` untested on both branches; the `>=` route-count assertion silently tolerates it | Marcus, Cal | 🎯 | **Open** |
-| 8 | 🟡 Standard | `parseVariations` — the gate on the sprint's headline variation-cards feature — has zero tests | Cal | — | **Open** |
-| 9 | 🟡 Standard | Save `toolName` wire contract now lives in three places; `FILE_PREFIX_MAP` curates only half the 14 tools; `null` fabricates a `writing_tools_editor` identity | Marcus, Bria | 🎯 | **Open** |
-| 10 | 🟡 Standard | `SAVE_RESULT.toolName` reaches an unvalidated `path.join` host-side (traversal verified) — contained today only by the webview CSP | Patricia | — | **Deferred** — pre-existing seam unchanged by this PR; harden with a host-side allowlist as a follow-up |
-| 11 | 🟡 Standard | Empty-state quick-start list is a second, inline, uncommented tool list that can drift from `RAIL_TOOL_IDS` (the four tools do match the prototype — the gap is the missing name/rationale) | Parker | — | **Open** |
-| 12 | 🟡 Standard | `WorkshopToolsModal` skips the `open`-prop contract both existing modals follow (`AllToolsModal`, `ModelBrowserModal`) | Stan | — | **Open** |
-| 13 | 🟡 Standard | All three new components skip the file-header doc-comment convention every sibling carries | Stan | — | **Open** |
-| 14 | 🟡 Standard | `quickActionsDisabled` (whole-list boolean) punches the PR #67 memo boundary twice per run; `parseVariations` recomputed uncached | Tim | — | **Deferred** — microseconds at current scale; add `useMemo` on `parseVariations` as cheap insurance |
-| 15 | 🟡 Standard | Completion notes claim a "strict" variation format; the parser is deliberately permissive (`##`–`####`, `-` or `:`) | Bria | — | **Open** — wording fix or an intent decision, either is fine |
-| 16 | 🟢 Nit | Variation-card React key uses the model-supplied variation number — a repeated "Variation 1" collides | Blake, Sam | 🎯 | **Open** — key by map index |
+| 1 | 🟠 High | Save fires two competing toasts; copy/save toast triggers substring-match free-text STATUS prose | Parker, Blake, Sam, Oliver | 🎯🎯 Strong | **Addressed** — Workshop now listens to structured `COPY_RESULT_SUCCESS` / `SAVE_RESULT_SUCCESS`; save STATUS no longer clobbers the toast |
+| 2 | 🟠 High | `makeActions` picks prompts by sniffing display labels — load-bearing for the 7 fallback tools, zero invariant tests | Parker, Cal | 🎯 | **Addressed** — fallback prompts are explicit and map invariants are covered |
+| 3 | 🟠 High | `openWorkshop` crosses the boundary as three anonymous type shapes while a `prose-minion.openWorkshop` command already does the same call | Marcus, Stan | 🎯 | **Addressed** — kept adapter-owned execution but replaced anonymous shapes with named `WorkshopUiActions` |
+| 4 | 🟠 High | Stale-turn quick-action chips send an old tool's lens prompt into the current (different-tool) conversation | Bria | — | **Addressed** — stale tool bars still render as provenance, but disable when their tool differs from `session.selectedToolId` |
+| 5 | 🟠 High | A failed Workshop save/copy leaves no durable trace once the 2.2s toast fades (no log line, no banner) | Oliver | — | **Addressed** — file-ops errors now write to the output channel before posting the error toast |
+| 6 | 🟠 High | `WorkshopThread`'s `currentToolId` walk goes blind past the 100-turn snapshot window — quick actions vanish, saves mislabeled `editor-*` | Sam | — | **Addressed** — action tool lookup falls back to reload-safe `session.selectedToolId`; `null` no longer fabricates `writing_tools_editor` |
+| 7 | 🟡 Standard | `OPEN_WORKSHOP` / `handleOpenWorkshop` untested on both branches; the `>=` route-count assertion silently tolerates it | Marcus, Cal | 🎯 | **Addressed** — happy and fallback branches covered; route count pinned exactly |
+| 8 | 🟡 Standard | `parseVariations` — the gate on the sprint's headline variation-cards feature — has zero tests | Cal | — | **Addressed** — parser and variation-card copy/save wiring covered |
+| 9 | 🟡 Standard | Save `toolName` wire contract now lives in three places; `FILE_PREFIX_MAP` curates only half the 14 tools; `null` fabricates a `writing_tools_editor` identity | Marcus, Bria | 🎯 | **Addressed** — shared result tool-name/prefix contract covers all 14 Workshop tools |
+| 10 | 🟡 Standard | `SAVE_RESULT.toolName` reaches an unvalidated `path.join` host-side (traversal verified) — contained today only by the webview CSP | Patricia | — | **Addressed** — host-side save prefix selection is now a closed allowlist |
+| 11 | 🟡 Standard | Empty-state quick-start list is a second, inline, uncommented tool list that can drift from `RAIL_TOOL_IDS` (the four tools do match the prototype — the gap is the missing name/rationale) | Parker | — | **Addressed** — hoisted to `EMPTY_STATE_TOOL_IDS` with prototype rationale |
+| 12 | 🟡 Standard | `WorkshopToolsModal` skips the `open`-prop contract both existing modals follow (`AllToolsModal`, `ModelBrowserModal`) | Stan | — | **Addressed** |
+| 13 | 🟡 Standard | All three new components skip the file-header doc-comment convention every sibling carries | Stan | — | **Addressed** |
+| 14 | 🟡 Standard | `quickActionsDisabled` (whole-list boolean) punches the PR #67 memo boundary twice per run; `parseVariations` recomputed uncached | Tim | — | **Addressed** — `parseVariations` is memoized per turn content; stale-turn disabling is per tool |
+| 15 | 🟡 Standard | Completion notes claim a "strict" variation format; the parser is deliberately permissive (`##`–`####`, `-` or `:`) | Bria | — | **Addressed** — sprint notes now describe prompted format plus tolerant parsing |
+| 16 | 🟢 Nit | Variation-card React key uses the model-supplied variation number — a repeated "Variation 1" collides | Blake, Sam | 🎯 | **Addressed** — key and visible number are positional |
 | 17 | 🟢 Praise | Label-vs-prompt split threaded correctly through conversation history, pinned by tests | Blake | — | **N/A** |
 | 18 | 🟢 Praise | Quick-action labels validated against a closed, host-owned map — the "model never invents an affordance" guarantee holds at the boundary | Patricia | — | **N/A** |
 | 19 | 🟢 Praise | The PR #67 token-clock memo boundary holds — this PR adds zero per-token render cost | Tim | — | **N/A** |

--- a/docs/pr-reviews/pr-69-workshop-s4-actions-polish-review.md
+++ b/docs/pr-reviews/pr-69-workshop-s4-actions-polish-review.md
@@ -1,0 +1,331 @@
+# MR Review — feat(workshop): Sprint 04 actions and polish
+
+**Author:** okeylanders · PR #69 · `feat/workshop-s4-actions-polish` → `epic/workshop-editor-tab`
+
+> Diff exceeds the ~800-line focus threshold — reviewer context centered on the highest-change code files, with the `.todo` docs summarized. All ten reviewers read the full code diff plus the post-PR source of `WorkshopHandler`, `WorkshopSessionService`, `useWorkshop`, `WorkshopApp`, `FileOperationsHandler`, and the composition-root wiring.
+
+## Resolution ledger
+
+Status is the reviewer's **initial recommendation**, not a verdict — update the `Status`
+column as findings are addressed so this file stays a living record. Legend: **Open** =
+act before merge · **Deferred** = real issue, safe to punt for a stated reason (track it)
+· **Addressed** = fixed · **Partially addressed** = fixed with a noted remainder · **N/A**
+= out of scope or superseded.
+
+| # | Sev | Finding | Reviewers | Consensus | Status |
+|---|-----|---------|-----------|-----------|--------|
+| 1 | 🟠 High | Save fires two competing toasts; copy/save toast triggers substring-match free-text STATUS prose | Parker, Blake, Sam, Oliver | 🎯🎯 Strong | **Open** |
+| 2 | 🟠 High | `makeActions` picks prompts by sniffing display labels — load-bearing for the 7 fallback tools, zero invariant tests | Parker, Cal | 🎯 | **Open** |
+| 3 | 🟠 High | `openWorkshop` crosses the boundary as three anonymous type shapes while a `prose-minion.openWorkshop` command already does the same call | Marcus, Stan | 🎯 | **Open** |
+| 4 | 🟠 High | Stale-turn quick-action chips send an old tool's lens prompt into the current (different-tool) conversation | Bria | — | **Open** |
+| 5 | 🟠 High | A failed Workshop save/copy leaves no durable trace once the 2.2s toast fades (no log line, no banner) | Oliver | — | **Open** |
+| 6 | 🟠 High | `WorkshopThread`'s `currentToolId` walk goes blind past the 100-turn snapshot window — quick actions vanish, saves mislabeled `editor-*` | Sam | — | **Deferred** — needs a 100+-turn session *and* a reload; fix = fall back to the reload-safe `session.selectedToolId` |
+| 7 | 🟡 Standard | `OPEN_WORKSHOP` / `handleOpenWorkshop` untested on both branches; the `>=` route-count assertion silently tolerates it | Marcus, Cal | 🎯 | **Open** |
+| 8 | 🟡 Standard | `parseVariations` — the gate on the sprint's headline variation-cards feature — has zero tests | Cal | — | **Open** |
+| 9 | 🟡 Standard | Save `toolName` wire contract now lives in three places; `FILE_PREFIX_MAP` curates only half the 14 tools; `null` fabricates a `writing_tools_editor` identity | Marcus, Bria | 🎯 | **Open** |
+| 10 | 🟡 Standard | `SAVE_RESULT.toolName` reaches an unvalidated `path.join` host-side (traversal verified) — contained today only by the webview CSP | Patricia | — | **Deferred** — pre-existing seam unchanged by this PR; harden with a host-side allowlist as a follow-up |
+| 11 | 🟡 Standard | Empty-state quick-start list is a second, inline, uncommented tool list that can drift from `RAIL_TOOL_IDS` (the four tools do match the prototype — the gap is the missing name/rationale) | Parker | — | **Open** |
+| 12 | 🟡 Standard | `WorkshopToolsModal` skips the `open`-prop contract both existing modals follow (`AllToolsModal`, `ModelBrowserModal`) | Stan | — | **Open** |
+| 13 | 🟡 Standard | All three new components skip the file-header doc-comment convention every sibling carries | Stan | — | **Open** |
+| 14 | 🟡 Standard | `quickActionsDisabled` (whole-list boolean) punches the PR #67 memo boundary twice per run; `parseVariations` recomputed uncached | Tim | — | **Deferred** — microseconds at current scale; add `useMemo` on `parseVariations` as cheap insurance |
+| 15 | 🟡 Standard | Completion notes claim a "strict" variation format; the parser is deliberately permissive (`##`–`####`, `-` or `:`) | Bria | — | **Open** — wording fix or an intent decision, either is fine |
+| 16 | 🟢 Nit | Variation-card React key uses the model-supplied variation number — a repeated "Variation 1" collides | Blake, Sam | 🎯 | **Open** — key by map index |
+| 17 | 🟢 Praise | Label-vs-prompt split threaded correctly through conversation history, pinned by tests | Blake | — | **N/A** |
+| 18 | 🟢 Praise | Quick-action labels validated against a closed, host-owned map — the "model never invents an affordance" guarantee holds at the boundary | Patricia | — | **N/A** |
+| 19 | 🟢 Praise | The PR #67 token-clock memo boundary holds — this PR adds zero per-token render cost | Tim | — | **N/A** |
+| 20 | 🟢 Nit | `WORKSHOP_QUICK_ACTIONS_BY_TOOL` build/lookup confirmed O(1) — no action needed | Tim | — | **N/A** |
+
+---
+
+## Blast Radius
+
+- 34 files changed · +1349 / −85 lines
+- New files: 4 code (`WorkshopQuickActionBar`, `WorkshopToast`, `WorkshopToolsModal`, `workshopQuickActions.ts`) + 5 `.todo` parked-item docs · Migrations: n/a · New services/controllers: none (1 new workshop message route, 1 new UI route)
+- Draft PR into the epic integration branch — the last sprint before `epic/workshop-editor-tab → main`
+
+---
+
+## Report Card
+
+| Category | Grade |
+| --- | --- |
+| 🏛️ Architecture | C |
+| 🛡️ Security | B |
+| 🧪 Tests | C |
+| 📖 Quality | C |
+| ⚡ Performance | B+ |
+| 🎯 Domain | C |
+
+**No blockers.** The grades reflect consensus-backed High findings in four categories — all of them seams and verification gaps, none of them broken behavior on the happy path.
+
+---
+
+## Executive Briefing
+
+🟠 **[Parker · Blake · Sam · Oliver] 🎯🎯 The toast seam is double-wired and string-matched** — every save fires two competing toasts (structured `SAVE_RESULT_SUCCESS`, then a free-text `STATUS` matched via `text.includes('Saved result')`) that visibly swap mid-air; copy success has *only* the substring match (`text.includes('copied')`) against an English sentence in another file — reword it and the toast silently dies.
+
+🟠 **[Parker · Cal] 🎯 Quick-action prompts are routed by sniffing button text** — `makeActions` infers each label's prompt strategy from `label.includes('variation')`; dead code for the 7 bespoke tools, load-bearing for the 7 fallback tools, and a label rename silently sends the wrong prompt to the model. No invariant tests on the map.
+
+🟠 **[Marcus · Stan] 🎯 The `openWorkshop` seam is a second bridge to the same island** — an anonymous `{ openWorkshop?: () => void }` re-declared in three shapes across three files, while `extension.ts` already registers `prose-minion.openWorkshop` doing the identical call three lines away.
+
+🟠 **[Bria] Stale chips cross lenses** — a quick-action chip on an old `dialogue` turn stays clickable after a `gestures` run replaced the conversation; clicking it sends a dialogue-lens prompt into the gestures-primed conversation. Nothing scopes a chip to the conversation it belonged to.
+
+🟠 **[Oliver] A failed save vanishes without a trace** — `FileOperationsHandler.sendError` never logs to the output channel, the Workshop error banner filters out `file_ops.*` sources, and the error toast self-dismisses in 2200ms. A "my save didn't work" report has nothing to point to.
+
+---
+
+## 🏛️ Marcus · Architecture & Design
+
+"The Cartographer of Layer Boundaries"
+
+### 🟠 High — `uiActions` is a second, unnamed DI channel competing with the Platform port pattern [🎯 Consensus]
+
+`apps/vscode-extension/src/application/providers/ProseToolsViewProvider.ts:34` — Every existing capability crossing the extension→core boundary goes through a named seam: the `Platform` port bundle or the `MessageTransport` alias. `uiActions: { openWorkshop?: () => void }` is neither — an anonymous inline object type re-declared verbatim in `MessageHandler.ts`, then torn apart into a bare positional `openWorkshop?: () => void` in `UIHandler.ts`. Three shapes for one concept, zero shared type name. The capability is legitimate composition-root orchestration, but it deserves a named, exported type (e.g. `WorkshopUiActions` beside `MessageHandlerContracts.ts`); as written, the next contributor adding a second UI action has no established shape to extend.
+
+### 🟡 Standard — `toolNameForResult` re-derives a wire contract that already lives (twice) elsewhere [🎯 Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:91` — The `toolName` strings (`dialogue_analysis`, `prose_analysis`, `writing_tools_<id>`) are the exact literals `AnalysisTab.tsx` already sends and `FileOperationsHandler`'s `FILE_PREFIX_MAP` treats as its routing contract. This PR adds a *third* independent site that must agree on the spelling instead of extracting the contract into `@shared/constants` — where this PR itself just added a module. The `null` fallback silently mints a fabricated `'writing_tools_editor'` identity for saved-file provenance rather than surfacing that the turn's tool was unknown.
+
+### 🟡 Standard — The new `OPEN_WORKSHOP` seam has no test coverage on either branch [🎯 Consensus]
+
+`packages/core/src/application/handlers/domain/UIHandler.ts:230` — `UIHandler.test.ts` asserts only `handlerCount >= 4` and never references `OPEN_WORKSHOP`. Neither the happy path (delegates to the injected callback) nor the fallback (`sendError('ui.workshop', …)`) is exercised — and the fallback is the actual runtime shape of the Workshop surface today.
+
+> *"A clean new load-bearing wall for the Workshop's prompts, but the doorway you cut to reach it got framed three different ways on three different floors."* — Marcus
+
+---
+
+## 🔥 Blake · Staff Engineer
+
+"She's Been Paged for This Before"
+
+No must-fix correctness, data-integrity, or contract defect survived tracing. Two bounded nits and one thing done right.
+
+### 🟢 Nit — Save success fires two toasts (`SAVE_RESULT_SUCCESS` + file_ops `STATUS`) [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:134` — Both messages land on every save; two `setToast` calls, two different strings, timer resets on the second. Not a bug — last-write-wins collapses it to one visible toast, no data loss, no exception. Pick one source (`SAVE_RESULT_SUCCESS` is the structured one) and drop the `'Saved result'` STATUS branch.
+
+### 🟢 Nit — Variation card React key collides if the model repeats a variation number [🎯 Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx:117` — `key={`${turn.id}-${variation.number}`}` trusts the model's captured digits; two "### Variation 1" headings collide. Bounded: duplicate-key warning, possible mis-reconciliation of stateless cards, content still correct. Key on the map index instead.
+
+### 🟢 Praise — Display-label vs sent-prompt split is threaded correctly — no conversation-history corruption
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:316` — The diff's riskiest data path, done right: `handleQuickAction` sends the full template to `continueConversation` (the orchestrator records the real instruction) while `beginMessageRun` stores the short label for display. The model never sees the truncated label; the thread never leaks the verbose template. Both new tests pin the behavior.
+
+> *"This one's clean — I'd merge it and actually sleep tonight; the two nits won't page anyone."* — Blake
+
+---
+
+## 🔍 Sam · Bug Hunter
+
+"What if the list is empty, though?"
+
+### 🟠 High — `currentToolId` goes blind once the tool-run turn ages out of the 100-turn snapshot window
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopThread.tsx:31-40` — In a single-tool conversation exactly ONE turn in the whole thread carries `toolId` (the first tool-run user turn; follow-up assistant turns have `toolId: undefined`). `getSnapshot()` ships only the last 100 turns — so once a thread crosses 100 turns and the webview reloads, that one toolId-bearing turn falls outside the window. `currentToolId` never seeds, and two things break silently: the quick-action bar stops rendering for every visible turn (indistinguishable from "nothing to suggest"), and variation Copy/Save flows `toolId=null` into `toolNameForResult` → saved dialogue variations written under the generic `editor-` prefix. The fix is sitting unused one prop away: `session.selectedToolId` is the windowless, reload-safe authoritative selection.
+
+### 🟡 Standard — Saving a variation always fires two overlapping, differently-worded toasts [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:134-135` — `SAVE_RESULT_SUCCESS` posts before the `openFileInEditor` await, the `'Saved result to …'` STATUS after it: every "Save to notes" click renders a toast, then silently swaps it for a textually different one. 100% reproducible on the shipped happy path; final state accurate; reads as a bug.
+
+### 🟡 Standard — A repeated "Variation N" heading collides on the React key *and* the visible label [🎯 Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx:117` — Slicing is positional, so content stays correct, but both cards render the identical "Variation 1" header — the user can't tell which card's Copy/Save maps to which content. Requires the model to deviate from the requested numbering (plausible, not default).
+
+> *"Turns out the empty-list case wasn't the trap here — it was the 'list has exactly one tool-tagged turn, and reload just walked past it' case, and it quietly rewires both the quick-action bar and the save filename at the same time."* — Sam
+
+---
+
+## 📖 Parker · Code Quality
+
+"Code is Communication, Not Instruction"
+
+### 🟠 High — Save produces two competing toasts, wired through a prose-sniffing string match [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:132` — `handleSaveResultSuccess` already owns the save toast honestly via the typed message; the `text.includes('Saved result')` STATUS branch clobbers it a beat later. The copy branch is worse from the other direction: no `COPY_RESULT_SUCCESS` exists, so the toast's only signal is `text.includes('copied')` against `'Result copied to clipboard.'` — a hardcoded English sentence in a different file with no compile-time link and no test. Delete the `'Saved result'` branch; add a `COPY_RESULT_SUCCESS` mirroring the save contract (or at minimum share the status string as a constant).
+
+### 🟠 High — `makeActions` infers prompt intent from button text instead of reading config [🎯 Consensus]
+
+`packages/core/src/shared/constants/workshopQuickActions.ts:43` — `label.toLowerCase().includes('variation')` → variation template. For the seven bespoke tools the branch is provably dead (explicit `prompts[label]` overrides exist); for the seven fallback tools it is load-bearing: rename `'Generate 3 variations'` to `'Generate three options'` and those tools silently stop producing the `### Variation N` markdown the cards need — no type error, no test. `FALLBACK_LABELS` is a fixed 4-element array; give it an explicit prompts map like every other tool and delete the inference ternary.
+
+### 🟡 Standard — Empty-state quick starts are a second, uncommented tool-id list that can drift from the rail
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:460` — `RAIL_TOOL_IDS` is named and heavily commented ("the APPROVED Direction B prototype… PR #66 review, Bria"); the empty-state list `['dialogue', 'gestures', 'choreography', 'cliche']` is inline, unexplained, and re-does the `.find` lookup per item in JSX. (Bria cross-checked: the four tools *do* match the prototype's `welcome()` exactly — the gap is the missing name and rationale, not the choice.) Hoist as `EMPTY_STATE_TOOL_IDS` with a one-line why.
+
+> *"The save toast literally changes its mind mid-air — that's not polish, that's two code paths that don't know about each other, and the next person to touch either one won't find out until a user files a 'flickering toast' bug."* — Parker
+
+---
+
+## 🧪 Cal · Test Coverage & Quality
+
+"Confidence Levels, Not Coverage Numbers"
+
+### 🟡 Standard — `parseVariations` has zero coverage for the exact markdown contract it depends on
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx:41-45` — Searched the diff and `__tests__` — no test touches `parseVariations`, `WorkshopTurnBubble`, or `WorkshopThread`. The three shipped tests cover the prompt/state *plumbing*; the *rendering* the sprint headline depends on is unverified: the happy 3-variation path, the fallback for ordinary responses, malformed output (1 variation, mixed heading depths, whitespace-only sections — note `.filter(v => v.content.length > 0)` can shrink 2 matches below the threshold). A prompt-template tweak or model drift would silently degrade variation cards, and nothing would fail. Cheapest: a unit test file over `parseVariations` (0/1/2/3 matches, mixed levels) + one component test asserting card count and Copy/Save wiring.
+
+### 🟡 Standard — `UIHandler.handleOpenWorkshop`: both branches untested, despite being a Sprint-04 acceptance criterion [🎯 Consensus]
+
+`packages/core/src/application/handlers/domain/UIHandler.ts:230-236` — The route-registration test's `handlerCount >= 4` silently tolerates the new route. Neither path — injected callback invoked, or `ERROR` with `source: 'ui.workshop'` when absent — is asserted. A regression leaves the sidebar Workshop button doing nothing with no test and no crash. Two cheap cases in the existing describe block cover it.
+
+### 🟡 Standard — The quick-actions map has no invariant tests, and its label routing is a silent substring match [🎯 Consensus]
+
+`packages/core/src/shared/constants/workshopQuickActions.ts:33-47` — Nothing asserts: every one of the 14 tools resolves to a non-empty action list (7 fall through to `FALLBACK_LABELS` silently), exactly one `primary` per list, and `workshopQuickActionPrompt` returns `undefined` for unknown labels but a real prompt for every actual label. Riskiest untested piece: a future label like "Show variation in pacing" silently matching `.includes('variation')` and shipping the wrong template — a silent-wrong-prompt bug no typecheck or existing test catches. A table-driven test over `WORKSHOP_TOOL_CATALOG` locks all three invariants.
+
+> *"Three tests shipped, five new components and a dispatch table didn't — that's not 'focused,' that's a confidence gap wearing a passing test suite as a disguise."* — Cal
+
+---
+
+## 🗂️ Stan · Codebase Standards
+
+"He Has Every Pattern Memorized"
+
+### 🟠 High — The `uiActions` callback bag duplicates the pre-existing `prose-minion.openWorkshop` command and bypasses the established seam [🎯 Consensus]
+
+`apps/vscode-extension/src/extension.ts:178` — `extension.ts` already registers `vscode.commands.registerCommand('prose-minion.openWorkshop', () => workshopPanelProvider?.openOrReveal())` — the *exact same call* — for the command palette. The PR builds a second, parallel injection mechanism (`uiActions` bag → `MessageHandler` → `UIHandler` positional param) to the same effect, with no precedent in `MessageHandler`'s pre-PR constructor. Compare `openSettings`'s established sibling shape in `ProseToolsViewProvider.ts:125-135`: one seam both callers invoke. If `openOrReveal`'s contract changes, it's easy to update one path and miss the other.
+
+### 🟡 Standard — `WorkshopToolsModal` skips the codebase's `open`-prop contract for modals
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopToolsModal.tsx:13` — Both existing modals — `AllToolsModal` (`tabs/AllToolsModal.tsx:51-58`) and `ModelBrowserModal` (`shared/ModelBrowserModal.tsx:7-15`, rendered by the very `ModelSelector` this file uses) — take `open: boolean` and self-guard with `if (!open) return null;`. `WorkshopToolsModal` is conditionally mounted instead. Harmless today (no internal state), but it breaks the contract the next dev will assume when they add search state the way `ModelBrowserModal` has.
+
+### 🟡 Standard — New workshop components skip the file-header doc-comment convention
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopToolsModal.tsx:1` — `ExcerptPanel`, `WorkshopComposer`, `WorkshopThread`, `WorkshopTurnBubble` all open with a `/** ComponentName — WHY … */` header. All three new components jump straight into imports — three-for-three, right as the pattern was supposed to be the default. `WorkshopToolsModal` in particular is a near-verbatim port of `AllToolsModal`, whose own 9-line header ("no invented tools") is exactly the provenance note now missing.
+
+> *"We already registered a VS Code command that does this exact thing three lines down — we just built a second bridge to the same island instead of using the one that's already there."* — Stan
+
+---
+
+## ⚡ Tim · Performance
+
+"O(n²) at Scale is an Incident Waiting to Happen"
+
+### 🟡 Standard — `quickActionsDisabled` punches a hole in the documented token-clock memo boundary — twice per run, not per token
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:489` — `WorkshopThread` was built (PR #67 #6/#11) so `turns.map(...)` skips STREAM_CHUNK renders. `!workshop.canFollowUp` flips twice per run (session-state broadcasts, never mid-stream), but as a shared prop it forces every rendered `WorkshopTurnBubble` through a failed shallow-compare, re-running uncached `parseVariations()` for unchanged turns; `saveVariation`'s `[vscode, workshop.excerpt]` dep destabilizes `onSaveVariation` on the same cadence. Math: N turns × O(content) regex, 2×/run — low single-digit milliseconds today, and `MarkdownRenderer`'s own `useMemo` on the content string means no markdown re-parse. Doesn't matter now; matters if sessions become long-lived. `useMemo(() => parseVariations(turn.content), [turn.content])` is cheap insurance.
+
+### 🟢 Praise — The suspected token-clock regression isn't real — traced it, the memo boundary holds
+
+`packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts:173` — `useVSCodeApi()` is a `useMemo` singleton, so `post`/`quickAction`/`copyVariation` are stable for the component's lifetime; `turns` never changes identity mid-stream; `streamingContent` is debounced to 100ms by the pre-existing `useStreaming`. Per-token cost of this PR's additions on the thread: zero.
+
+### 🟢 Nit — `WORKSHOP_QUICK_ACTIONS_BY_TOOL`: built once at module load, O(1) lookups — confirmed fine, no action needed.
+
+> *"Someone already fought this exact battle in PR #67 and left a memo boundary with a docstring explaining itself — this PR mostly respects it, and the one crack lets microseconds through, not the token clock."* — Tim
+
+---
+
+## 🛡️ Patricia · Security
+
+"She Reads Code Like an Attacker Would"
+
+### 🟡 Standard — `SAVE_RESULT`'s `toolName` still reaches an unvalidated path-join — contained today only by CSP, not by an allowlist
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:269` — `handleSaveResult` destructures `toolName` straight from the payload; an unmatched `writing_tools_*` name falls to the `` `${toolName.replace(/_/g, '-')}-` `` prefix and into `path.join`. Verified live: `writing-tools-../../../../tmp/pwned-1.md` resolves outside the target dir — a genuine write-outside primitive. Under the sanctioned UI flow `toolName` can never be attacker-chosen (`toolNameForResult` is closed over host-validated `WorkshopToolId`s), and the CSP (`script-src` nonce, no `unsafe-inline`) blocks the classic webview-compromise route — hence STANDARD, not HIGH. But `FileOperationsHandler` is the one handler in this chain without `WorkshopHandler`'s allowlist discipline; if the CSP or sanitization assumption ever regresses, this becomes a silent arbitrary file write.
+
+### 🟢 Praise — Quick-action labels are matched against a closed, host-owned map — the model never gets to invent a prompt
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:301` — The webview sends only `{ toolId, label }`; the handler validates `toolId` via `isWorkshopToolId` and resolves the label against the static code-owned table, rejecting anything unrecognized before `continueConversation` is called — with a test pinning the rejection. The "model never invents a UI affordance" guarantee holds at the boundary, not just in the UI layer.
+
+> *"A closed map stopped the label; an open path.join is still waiting on the same discipline."* — Patricia
+
+---
+
+## 🌙 Oliver · Observability & Debuggability
+
+"Would This Failure Leave a Trail at 2am?"
+
+### 🟠 High — A Workshop save/copy failure has no trace anywhere after the toast fades
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:146-147` — This PR is the first time `file_ops.*` errors can originate from the Workshop surface. When a save throws (disk full, no workspace), `FileOperationsHandler.sendError` — unlike `WorkshopHandler.sendError` — never writes to the output channel; the webview's persistent `pm-ws-error` banner drops the message (`useWorkshop` guards on `source.startsWith('workshop')`); and the error toast self-destructs after 2200ms. No log line, no banner, toast gone. A user who steps away mid-save gets a failure with nothing a bug report can point to. The sidebar, by contrast, surfaces every error source through its generic handler.
+
+### 🟡 Standard — Copy-success toast has exactly one signal path, and it's a substring match on prose [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:132-133` — Save has the structured `SAVE_RESULT_SUCCESS` as a wording-independent second signal; copy has nothing but `text.includes('copied')` against `'Result copied to clipboard.'`. A wording pass silently kills the toast — the copy still works, it just goes from "confirmed" to "did that even do anything?" with zero code signal of the drift, and no test references the string.
+
+> *"The save failed, the toast faded, and the output channel never heard a thing — see you in the incident retro."* — Oliver
+
+---
+
+## 🎯 Bria · Domain Logic & Business Correctness
+
+"Does This Code Actually Do What the Ticket Asked?"
+
+### 🟠 High — A quick-action chip on a stale turn sends its old tool's prompt into whatever conversation is currently live
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopThread.tsx:40` — The acceptance criterion says "each assistant turn shows the **correct** per-tool quick-action chips; clicking one runs a templated follow-up in the same conversation." But `quickActionsDisabled` is one global flag, not scoped to the live turn. Run `dialogue`, then run `gestures` (which discards the old conversation and retains a new one) — the old dialogue chip stays clickable, and clicking it resolves the dialogue-lens prompt ("…stay in the Dialogue & Beats lens") into the *gestures*-primed conversation. Neither `handleQuickAction` nor `executeFollowUp` validates the chip's `toolId` against the conversation's origin tool. Is "any chip from any turn is always live" the intent, or should stale-turn bars disable once the conversation moves on?
+
+### 🟡 Standard — Save-to-notes filenames are only "curated" for half the tools the new Save action exposes [🎯 Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:91` — `FILE_PREFIX_MAP` recognizes 8 names; `gestures`/`choreography` — two of the four empty-state quick-start tools this PR ships — fall to the generic `writing-tools-gestures-1.md` fallback while `dialogue`/`cliche` get polished `excerpt-assistant-dialog-beats-1.md` / `cliche-analysis-1.md` names. Sprint 04 is the first time Save-to-notes runs from *every* tool's cards: was extending the map in scope, or is the inconsistency an accepted gap?
+
+### 🟡 Standard — Completion notes claim a "strict" variation format; the parser is deliberately looser than what's demanded
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx:41` — Prompts demand exactly `### Variation N - [label]`; the regex accepts `##`–`####` and `-` or `:` (or neither). The permissiveness is probably the right engineering call (tolerates model drift) — but "strict" in the completion notes doesn't describe the code. Imprecise phrasing, or was a format-matching parser the intent?
+
+> *"The chips all look correct on screen — it's only the conversation quietly listening on the other end that might be a completely different tool."* — Bria
+
+---
+
+## 🎓 Sensei · The Teacher
+
+"The Review Is the Lesson. The Code Is the Practice."
+
+### Lesson 1 — Prose Is Not Protocol
+
+Illuminated by: Parker, Blake, Sam, Oliver, Cal, Bria (ledger #1, #2, #15, #16)
+
+Text written for human eyes is the most rewrite-prone material in any codebase — and in a tool built *for writers*, it will be polished relentlessly. When code dispatches on a display label, matches an English sentence from another file, or keys React children on model-supplied numbering, it has quietly promoted decoration to load-bearing structure, and nothing will announce the promotion when the words change. The trap is perceptual: a string that is visible right there *feels* like stable data, but visibility is the opposite of stability — visible words attract editors.
+
+→ Carry forward: Every time you write `.includes(` or `===` against something a human will read, pause and ask: "what is the identifier underneath this sentence?" Ship the identifier alongside the words, so the words stay free to change.
+
+### Lesson 2 — Ask the Owner, Not the Neighborhood
+
+Illuminated by: Sam, Bria, Marcus (ledger #4, #6, #9)
+
+These bugs share one move — reconstructing a fact from surrounding circumstance (walking turns to find the one carrying `toolId`, assuming a chip belongs to whatever conversation is current, fabricating an identity when `toolId` is null) when the authoritative owner of that fact was one prop away. We write code in the present tense, where the context is obviously right there; the code runs in the future tense, after windows slide, conversations are replaced, and sessions reload. Truth derived from proximity expires with the moment; truth carried as explicit provenance survives it.
+
+→ Carry forward: For any derived value, ask: "Who *owns* this fact, and will my derivation survive a reload, a replacement, or a sliding window?" If not, stamp provenance on the data when it is born, not when it is needed.
+
+### Lesson 3 — The Second Bridge
+
+Illuminated by: Marcus, Stan, Bria, Parker (ledger #3, #9, #11)
+
+An anonymous inline capability three lines from an existing command doing the same thing; a wire contract declared in three files; a tool list hand-copied beside its heavily-documented original — each is a second bridge built beside a first one, agreeing with it only by coincidence. The mechanism is fluency: we go looking for existing abstractions when we feel confused, and sprint momentum is precisely the state in which we feel least confused and declare fastest. Duplicated knowledge is nearly invisible in a diff, because every copy looks complete on its own.
+
+→ Carry forward: Before creating any cross-boundary shape — message type, capability, constant list — spend two minutes on one question: "Who already crosses this boundary, and who else already knows this fact?" If someone does, extend or name their crossing rather than pouring a new footing.
+
+### Lesson 4 — Success Is Designed; Failure Is Inherited
+
+Illuminated by: Oliver, Marcus, Cal, Patricia (ledger #5, #7, #8, #10)
+
+The sprint's happy paths received real craftsmanship — chips, cards, toasts, a ticker — while its failure paths received whatever the defaults happened to be: an unlogged error, a banner that filters it out, evidence that evaporates in 2.2 seconds, the one handler without its siblings' validation, the headline parser with no tests. This is not carelessness; it is optics. A demo exercises success, so success feels verified — failure stays invisible until a user is standing inside it, and in a polish sprint, "polish" quietly narrows to what the happy user sees.
+
+→ Carry forward: For every new affordance, narrate the failure story aloud: "The save fails at 4:03 — what does the user see at 4:03, and what can *we* see at 4:13?" If either answer is "nothing," that is unfinished design, not an edge case.
+
+### Lesson 5 — Culture Remembers; Only Structure Protects
+
+Illuminated by: Parker, Patricia, Stan, Tim — read against the panel's praise (ledger #2, #10, #12, #13, #14)
+
+This codebase has a rare, genuine review culture — comments cite prior findings by reviewer and number, and old lessons are visibly absorbed. Yet the PR #67 memo boundary got punched through, one handler missed the validation discipline its siblings model, and new components skipped conventions every neighbor follows — because those lessons live in memory and prose, transmitted by copying whichever sibling happened to be open, and osmosis fails at sprint speed. A lesson is not fully learned until it lives somewhere that can say no without you: an invariant test on the label map, a type that refuses to compile, a named constant with its rationale attached.
+
+→ Carry forward: When a review lesson lands, ask one more question: "Where does this lesson live besides our memory?" Then promote it — from citation to fixture, from folklore to something that can fail a build.
+
+> *"A sentence can be beautiful and still not be load-bearing — the craft is knowing which of your words are for people, and which ones the machine is quietly standing on."* — Sensei
+
+---
+
+## The Closer
+
+### 🔮 Fortune cookie
+
+*Your greatest fragility lives in the string you matched instead of the message you owned.*
+
+---
+
+## Summary
+
+**Nearly there — no blockers, merge after the seams are tightened.** The correctness core of Sprint 04 is genuinely solid: Blake traced the riskiest path (label-vs-prompt through conversation history) and praised it, Patricia confirmed the quick-action boundary holds, and Tim verified the token-clock discipline from PR #67 survived intact. What the panel found instead is a consistent pattern: informal seams (string-matched toasts, label-sniffed prompt routing, a three-shape anonymous injection bag beside an existing command) and a verification gap around the sprint's headline rendering path (`parseVariations`, `handleOpenWorkshop`, the quick-actions map). One product-semantics question needs an explicit decision before the epic lands on `main`: what a stale turn's quick-action chip should do. All of it is tractable within the branch; none of it should page anyone.
+
+---
+
+*Reviewed by: Marcus 🏛️ · Blake 🔥 · Sam 🔍 · Parker 📖 · Cal 🧪 · Stan 🗂️ · Tim ⚡ · Patricia 🛡️ · Oliver 🌙 · Bria 🎯 · Sensei 🎓*

--- a/packages/core/src/__tests__/application/handlers/domain/FileOperationsHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/FileOperationsHandler.test.ts
@@ -15,16 +15,22 @@ import {
 describe('FileOperationsHandler', () => {
   let handler: FileOperationsHandler;
   let router: MessageRouter;
+  let mockPostMessage: jest.Mock;
+  let appendLine: jest.Mock;
 
   beforeEach(() => {
-    const mockPostMessage = jest.fn().mockResolvedValue(undefined);
+    mockPostMessage = jest.fn().mockResolvedValue(undefined);
+    appendLine = jest.fn();
 
     handler = new FileOperationsHandler(
       mockPostMessage,
       createFakeFileSystem(),
-      createFakeWorkspace(),
+      createFakeWorkspace({
+        workspaceFolders: () => [{ path: '/workspace', name: 'workspace', uriString: 'file:///workspace' }],
+        asRelativePath: (p) => p.replace('/workspace/', '')
+      }),
       createFakeShellService(),
-      { appendLine: jest.fn() } as any // outputChannel (LogSink)
+      { appendLine } as any // outputChannel (LogSink)
     );
     router = new MessageRouter();
   });
@@ -37,7 +43,65 @@ describe('FileOperationsHandler', () => {
 
     it('should register at least 1 route', () => {
       handler.registerRoutes(router);
-      expect(router.handlerCount).toBeGreaterThanOrEqual(1);
+      expect(router.handlerCount).toBe(2);
+    });
+  });
+
+  describe('copy_result', () => {
+    it('posts structured copy success instead of requiring status prose parsing', async () => {
+      handler.registerRoutes(router);
+
+      await router.route({
+        type: MessageType.COPY_RESULT,
+        source: 'webview.workshop',
+        payload: {
+          toolName: 'dialogue_analysis',
+          content: 'Copied text'
+        },
+        timestamp: 0
+      } as any);
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.COPY_RESULT_SUCCESS,
+          source: 'extension.file_ops',
+          payload: { toolName: 'dialogue_analysis' }
+        })
+      );
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.STATUS,
+          payload: expect.objectContaining({ message: 'Result copied to clipboard.' })
+        })
+      );
+    });
+  });
+
+  describe('save_result', () => {
+    it('rejects unsupported assistant tool names before they become file prefixes', async () => {
+      handler.registerRoutes(router);
+
+      await router.route({
+        type: MessageType.SAVE_RESULT,
+        source: 'webview.workshop',
+        payload: {
+          toolName: 'writing_tools_../../../../tmp/pwned',
+          content: 'Bad path'
+        },
+        timestamp: 0
+      } as any);
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          payload: expect.objectContaining({
+            source: 'file_ops.save',
+            message: 'Failed to save result',
+            details: expect.stringContaining('not supported')
+          })
+        })
+      );
+      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('[FileOpsHandler] ERROR file_ops.save'));
     });
   });
 });

--- a/packages/core/src/__tests__/application/handlers/domain/UIHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/UIHandler.test.ts
@@ -16,12 +16,14 @@ import {
 describe('UIHandler', () => {
   let handler: UIHandler;
   let router: MessageRouter;
+  let postMessage: jest.Mock;
   let appendLine: jest.Mock;
 
   beforeEach(() => {
+    postMessage = jest.fn().mockResolvedValue(undefined);
     appendLine = jest.fn();
     handler = new UIHandler(
-      jest.fn().mockResolvedValue(undefined) as any, // postMessage
+      postMessage as any, // postMessage
       { appendLine } as any, // outputChannel (LogSink)
       createFakeFileSystem(),
       createFakeWorkspace(),
@@ -39,7 +41,8 @@ describe('UIHandler', () => {
         MessageType.TAB_CHANGED,
         MessageType.OPEN_GUIDE_FILE,
         MessageType.OPEN_RESOURCE,
-        MessageType.REQUEST_SELECTION
+        MessageType.REQUEST_SELECTION,
+        MessageType.OPEN_WORKSHOP
       ];
 
       expectedRoutes.forEach(route => {
@@ -49,7 +52,54 @@ describe('UIHandler', () => {
 
     it('should register at least 4 routes', () => {
       handler.registerRoutes(router);
-      expect(router.handlerCount).toBeGreaterThanOrEqual(4);
+      expect(router.handlerCount).toBe(7);
+    });
+  });
+
+  describe('open_workshop', () => {
+    it('delegates to the injected Workshop UI action', async () => {
+      const openWorkshop = jest.fn();
+      handler = new UIHandler(
+        postMessage as any,
+        { appendLine } as any,
+        createFakeFileSystem(),
+        createFakeWorkspace(),
+        createFakeShellService(),
+        createFakeEditorContext(),
+        { openWorkshop }
+      );
+      handler.registerRoutes(router);
+
+      await router.route({
+        type: MessageType.OPEN_WORKSHOP,
+        source: 'webview.analysis',
+        payload: {},
+        timestamp: 0,
+      } as any);
+
+      expect(openWorkshop).toHaveBeenCalledTimes(1);
+      expect(postMessage).not.toHaveBeenCalled();
+    });
+
+    it('reports a ui.workshop error when no Workshop action is available', async () => {
+      handler.registerRoutes(router);
+
+      await router.route({
+        type: MessageType.OPEN_WORKSHOP,
+        source: 'webview.analysis',
+        payload: {},
+        timestamp: 0,
+      } as any);
+
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          payload: expect.objectContaining({
+            source: 'ui.workshop',
+            message: 'Workshop is not available from this surface.'
+          })
+        })
+      );
     });
   });
 

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -81,18 +81,19 @@ describe('WorkshopHandler', () => {
   });
 
   describe('routing, excerpt pins, tool runs, and session controls', () => {
-  it('registers the seven workshop routes', () => {
+  it('registers the eight workshop routes', () => {
     const router = new MessageRouter();
     handler.registerRoutes(router);
 
     expect(router.hasHandler(MessageType.WORKSHOP_RUN_TOOL)).toBe(true);
+    expect(router.hasHandler(MessageType.WORKSHOP_QUICK_ACTION)).toBe(true);
     expect(router.hasHandler(MessageType.WORKSHOP_SEND_MESSAGE)).toBe(true);
     expect(router.hasHandler(MessageType.WORKSHOP_SET_EXCERPT)).toBe(true);
     expect(router.hasHandler(MessageType.WORKSHOP_PICK_EXCERPT_FILE)).toBe(true);
     expect(router.hasHandler(MessageType.WORKSHOP_RESET_SESSION)).toBe(true);
     expect(router.hasHandler(MessageType.WORKSHOP_REQUEST_SESSION)).toBe(true);
     expect(router.hasHandler(MessageType.CANCEL_WORKSHOP_REQUEST)).toBe(true);
-    expect(router.handlerCount).toBe(7);
+    expect(router.handlerCount).toBe(8);
   });
 
   it('pins an excerpt and broadcasts the session snapshot', async () => {
@@ -647,6 +648,51 @@ describe('WorkshopHandler', () => {
       MessageType.WORKSHOP_SESSION_STATE,
       MessageType.STATUS // final '' clear
     ]);
+  });
+
+  it('a quick action resolves to a deterministic prompt and displays the clicked label', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+    await runToolToCompletion('dialogue', 'conv-1');
+    postMessage.mockClear();
+
+    mockService.continueConversation.mockResolvedValue(analysisResult('three variations') as any);
+
+    await handler.handleQuickAction(
+      message(MessageType.WORKSHOP_QUICK_ACTION, {
+        toolId: 'dialogue',
+        label: 'Generate 3 tighter variations'
+      }) as any
+    );
+
+    expect(mockService.continueConversation).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Return exactly three options'),
+      expect.objectContaining({ signal: expect.anything(), onToken: expect.any(Function) })
+    );
+    expect(mockService.continueConversation.mock.calls[0][1]).toContain('Dialogue & Beats lens');
+
+    const turnMessages = postedOf(MessageType.WORKSHOP_TURN);
+    expect(turnMessages[0].payload.turn.content).toBe('Generate 3 tighter variations');
+    expect(turnMessages[0].payload.turn.kind).toBe('message');
+    expect(turnMessages[1].payload.turn.content).toBe('three variations');
+  });
+
+  it('rejects an unknown quick action label before continuing the conversation', async () => {
+    session.setExcerpt({ text: 'Some prose.' });
+    await runToolToCompletion('dialogue', 'conv-1');
+    postMessage.mockClear();
+
+    await handler.handleQuickAction(
+      message(MessageType.WORKSHOP_QUICK_ACTION, {
+        toolId: 'dialogue',
+        label: 'Invent a brand-new button'
+      }) as any
+    );
+
+    const [error] = postedOf(MessageType.ERROR);
+    expect(error.payload.source).toBe('workshop.quick_action');
+    expect(error.payload.message).toMatch(/Unknown Workshop quick action/);
+    expect(mockService.continueConversation).not.toHaveBeenCalled();
   });
 
   it('a lost conversation surfaces honestly: clears the reference, no silent restart', async () => {

--- a/packages/core/src/__tests__/application/services/WorkshopSessionService.test.ts
+++ b/packages/core/src/__tests__/application/services/WorkshopSessionService.test.ts
@@ -82,11 +82,13 @@ describe('WorkshopSessionService', () => {
     service.beginToolRun('cliche', 'req-1');
 
     let snapshot = service.getSnapshot();
+    expect(snapshot.selectedToolId).toBe('cliche');
     expect(snapshot.activeToolId).toBe('cliche');
     expect(snapshot.activeRequestId).toBe('req-1');
 
     service.completeRun('req-1', 'done');
     snapshot = service.getSnapshot();
+    expect(snapshot.selectedToolId).toBe('cliche');
     expect(snapshot.activeToolId).toBeUndefined();
     expect(snapshot.activeRequestId).toBeUndefined();
   });
@@ -128,6 +130,7 @@ describe('WorkshopSessionService', () => {
 
     const snapshot = service.getSnapshot();
     expect(snapshot.turns).toEqual([]);
+    expect(snapshot.selectedToolId).toBeUndefined();
     expect(snapshot.activeToolId).toBeUndefined();
     expect(snapshot.activeRequestId).toBeUndefined();
     expect(snapshot.excerpt).toEqual(excerpt);
@@ -200,6 +203,22 @@ describe('WorkshopSessionService', () => {
     expect(assistantTurn?.toolLabel).toBeUndefined();
     // The conversation id is stable across the follow-up.
     expect(service.getConversationId()).toBe('conv-1');
+  });
+
+  it('a message run can display a short label while sending a fuller prompt', () => {
+    pin();
+    service.beginToolRun('dialogue', 'req-1');
+    service.completeRun('req-1', 'analysis', undefined, false, 'conv-1');
+
+    const userTurn = service.beginMessageRun(
+      'Generate three options with the strict variation-card markdown format.',
+      'req-2',
+      'Generate 3 tighter variations'
+    );
+
+    expect(userTurn.content).toBe('Generate 3 tighter variations');
+    const turns = service.getSnapshot().turns;
+    expect(turns[turns.length - 1]?.content).toBe('Generate 3 tighter variations');
   });
 
   it('refuses a message run without a conversation to continue', () => {

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopThread.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopThread.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('marked', () => {
+  const marked = Object.assign(jest.fn((content: string) => content), {
+    setOptions: jest.fn()
+  });
+  return { marked };
+});
+
+import { WorkshopThread } from '@components/workshop/WorkshopThread';
+import { WorkshopTurn } from '@messages';
+
+const assistantTurn = (
+  id: string,
+  content: string,
+  toolId?: WorkshopTurn['toolId']
+): WorkshopTurn => ({
+  id,
+  role: 'assistant',
+  kind: toolId ? 'tool_run' : 'message',
+  toolId,
+  toolLabel: toolId,
+  content,
+  timestamp: 0
+});
+
+describe('WorkshopThread quick-action scope', () => {
+  const noop = jest.fn();
+
+  it('falls back to selectedToolId when the visible snapshot no longer carries a tool turn', () => {
+    render(
+      <WorkshopThread
+        turns={[assistantTurn('turn-1', 'Follow-up response')]}
+        selectedToolId="prose"
+        onQuickAction={noop}
+        onCopyVariation={noop}
+        onSaveVariation={noop}
+      />
+    );
+
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Rewrite for flow' }).disabled)
+      .toBe(false);
+  });
+
+  it('disables quick actions from stale tool turns after the session moves to another lens', () => {
+    render(
+      <WorkshopThread
+        turns={[
+          assistantTurn('turn-1', 'Old dialogue response', 'dialogue'),
+          assistantTurn('turn-2', 'Current gestures response', 'gestures')
+        ]}
+        selectedToolId="gestures"
+        onQuickAction={noop}
+        onCopyVariation={noop}
+        onSaveVariation={noop}
+      />
+    );
+
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Generate 3 tighter variations' }).disabled)
+      .toBe(true);
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Vary the gesture' }).disabled)
+      .toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopTurnBubble.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopTurnBubble.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock('marked', () => {
+  const marked = Object.assign(jest.fn((content: string) => content), {
+    setOptions: jest.fn()
+  });
+  return { marked };
+});
+
+import {
+  parseVariations,
+  WorkshopTurnBubble
+} from '@components/workshop/WorkshopTurnBubble';
+import { WorkshopTurn } from '@messages';
+
+const assistantTurn = (content: string): WorkshopTurn => ({
+  id: 'turn-1',
+  role: 'assistant',
+  kind: 'tool_run',
+  toolId: 'prose',
+  toolLabel: 'Prose',
+  content,
+  timestamp: 0
+});
+
+describe('parseVariations', () => {
+  it('parses the prompted three-variation markdown shape', () => {
+    const parsed = parseVariations(`Intro text.
+
+### Variation 1 - Sharper
+First version.
+
+### Variation 2 - Softer
+Second version.
+
+### Variation 3 - Stranger
+Third version.`);
+
+    expect(parsed?.intro).toBe('Intro text.');
+    expect(parsed?.variations).toEqual([
+      { number: '1', label: 'Sharper', content: 'First version.' },
+      { number: '2', label: 'Softer', content: 'Second version.' },
+      { number: '3', label: 'Stranger', content: 'Third version.' }
+    ]);
+  });
+
+  it('accepts small heading/label drift but requires at least two non-empty sections', () => {
+    expect(parseVariations(`## Variation 1: One\nA\n\n#### Variation 2\nB`)?.variations)
+      .toHaveLength(2);
+    expect(parseVariations('### Variation 1 - One\nA')).toBeNull();
+    expect(parseVariations('### Variation 1 - One\nA\n\n### Variation 2 - Two\n   ')).toBeNull();
+  });
+});
+
+describe('WorkshopTurnBubble variation cards', () => {
+  it('renders duplicate model numbers with stable positional labels and wires copy/save content', () => {
+    const onCopyVariation = jest.fn();
+    const onSaveVariation = jest.fn();
+
+    render(
+      <WorkshopTurnBubble
+        turn={assistantTurn(`### Variation 1 - First\nAlpha\n\n### Variation 1 - Second\nBeta`)}
+        quickActionToolId="prose"
+        quickActionsDisabled
+        onQuickAction={jest.fn()}
+        onCopyVariation={onCopyVariation}
+        onSaveVariation={onSaveVariation}
+      />
+    );
+
+    expect(screen.getByText('Variation 1')).toBeTruthy();
+    expect(screen.getByText('Variation 2')).toBeTruthy();
+
+    const copyButtons = screen.getAllByRole('button', { name: /copy/i });
+    const saveButtons = screen.getAllByRole('button', { name: /save to notes/i });
+
+    fireEvent.click(copyButtons[1]);
+    fireEvent.click(saveButtons[0]);
+
+    expect(onCopyVariation).toHaveBeenCalledWith('Beta', 'prose');
+    expect(onSaveVariation).toHaveBeenCalledWith('Alpha', 'prose');
+  });
+});

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
@@ -145,6 +145,26 @@ describe('useWorkshop', () => {
     expect(result.current.isRunning).toBe(false);
   });
 
+  it('restores the selected tool separately from the in-flight run', () => {
+    const { result } = renderHook(() => useWorkshop());
+
+    act(() => {
+      result.current.handleSessionState(
+        sessionState({
+          excerpt: { text: 'Pinned prose.', pinnedAt: 1 },
+          turns: [makeTurn({ id: 't1', toolId: 'gestures', toolLabel: 'Gestures' })],
+          selectedToolId: 'gestures',
+          hasConversation: true
+        })
+      );
+    });
+
+    expect(result.current.selectedToolId).toBe('gestures');
+    expect(result.current.activeToolId).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.canFollowUp).toBe(true);
+  });
+
   it('adopts a mid-run request from the snapshot so post-reload chunks attach', () => {
     const { result } = renderHook(() => useWorkshop());
 
@@ -333,6 +353,7 @@ describe('useWorkshop', () => {
     act(() => {
       result.current.pinExcerpt('Some prose.', 'file:///ch1.md', 'ch1.md');
       result.current.runTool('gestures');
+      result.current.quickAction('gestures', '3 variations');
       result.current.resetSession();
       result.current.sendMessage('Now tighten variation two.');
       result.current.pinFromFile();
@@ -341,6 +362,10 @@ describe('useWorkshop', () => {
     const pin = posted(MessageType.WORKSHOP_SET_EXCERPT)[0];
     expect(pin.payload).toEqual({ text: 'Some prose.', sourceUri: 'file:///ch1.md', relativePath: 'ch1.md' });
     expect(posted(MessageType.WORKSHOP_RUN_TOOL)[0].payload).toEqual({ toolId: 'gestures' });
+    expect(posted(MessageType.WORKSHOP_QUICK_ACTION)[0].payload).toEqual({
+      toolId: 'gestures',
+      label: '3 variations'
+    });
     expect(posted(MessageType.WORKSHOP_RESET_SESSION)).toHaveLength(1);
     expect(posted(MessageType.WORKSHOP_SEND_MESSAGE)[0].payload).toEqual({
       text: 'Now tighten variation two.'

--- a/packages/core/src/__tests__/presentation/webview/hooks/useAppMessageRouter.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/useAppMessageRouter.test.ts
@@ -38,6 +38,7 @@ const EXPECTED_ROUTES: MessageType[] = [
   MessageType.TOKEN_USAGE_UPDATE,
   MessageType.ACCOUNT_BALANCE_DATA,
   MessageType.CLEAR_TRANSIENT_API_KEY_WARNING,
+  MessageType.COPY_RESULT_SUCCESS,
   MessageType.SAVE_RESULT_SUCCESS,
   MessageType.ERROR,
 ];

--- a/packages/core/src/__tests__/shared/workshopQuickActions.test.ts
+++ b/packages/core/src/__tests__/shared/workshopQuickActions.test.ts
@@ -1,0 +1,40 @@
+import {
+  workshopQuickActionPrompt,
+  workshopQuickActionsForTool
+} from '@shared/constants/workshopQuickActions';
+import { WORKSHOP_TOOL_CATALOG } from '@shared/constants/workshopTools';
+
+describe('workshopQuickActions', () => {
+  it('defines non-empty actions with exactly one primary action for every Workshop tool', () => {
+    for (const tool of WORKSHOP_TOOL_CATALOG) {
+      const actions = workshopQuickActionsForTool(tool.id);
+
+      expect(actions.length).toBeGreaterThan(0);
+      expect(actions.filter((action) => action.primary)).toHaveLength(1);
+      for (const action of actions) {
+        expect(action.label).toEqual(expect.any(String));
+        expect(action.prompt).toEqual(expect.any(String));
+        expect(action.prompt.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('resolves every configured label to a prompt and rejects unknown labels', () => {
+    for (const tool of WORKSHOP_TOOL_CATALOG) {
+      for (const action of workshopQuickActionsForTool(tool.id)) {
+        expect(workshopQuickActionPrompt(tool.id, action.label)).toBe(action.prompt);
+      }
+      expect(workshopQuickActionPrompt(tool.id, 'Generate another variation maybe')).toBeUndefined();
+    }
+  });
+
+  it('keeps fallback variation prompts explicit instead of inferred from label text', () => {
+    const fallbackOnlyTool = 'decision-points';
+    expect(workshopQuickActionPrompt(fallbackOnlyTool, 'Generate 3 variations')).toContain(
+      'Return exactly three options'
+    );
+    expect(workshopQuickActionPrompt(fallbackOnlyTool, 'Try another angle')).not.toContain(
+      'Return exactly three options'
+    );
+  });
+});

--- a/packages/core/src/application/handlers/MessageHandler.ts
+++ b/packages/core/src/application/handlers/MessageHandler.ts
@@ -25,7 +25,8 @@ import {
 import {
   CoreServices,
   MessageTransport,
-  ResultCache
+  ResultCache,
+  WorkshopUiActions
 } from '@handlers/MessageHandlerContracts';
 
 // Message routing
@@ -150,7 +151,7 @@ export class MessageHandler {
     private readonly transport: MessageTransport,
     private readonly platform: Platform,
     private readonly outputChannel: LogSink,
-    private readonly uiActions: { openWorkshop?: () => void } = {}
+    private readonly uiActions: WorkshopUiActions = {}
   ) {
     const {
       assistantToolService,
@@ -261,7 +262,7 @@ export class MessageHandler {
       this.platform.workspace,
       this.platform.shell,
       this.platform.editor,
-      this.uiActions.openWorkshop
+      this.uiActions
     );
 
     this.fileOperationsHandler = new FileOperationsHandler(

--- a/packages/core/src/application/handlers/MessageHandler.ts
+++ b/packages/core/src/application/handlers/MessageHandler.ts
@@ -149,7 +149,8 @@ export class MessageHandler {
     // distinct name is deliberate so the unwrapped one isn't grabbed by accident.
     private readonly transport: MessageTransport,
     private readonly platform: Platform,
-    private readonly outputChannel: LogSink
+    private readonly outputChannel: LogSink,
+    private readonly uiActions: { openWorkshop?: () => void } = {}
   ) {
     const {
       assistantToolService,
@@ -259,7 +260,8 @@ export class MessageHandler {
       this.platform.fileSystem,
       this.platform.workspace,
       this.platform.shell,
-      this.platform.editor
+      this.platform.editor,
+      this.uiActions.openWorkshop
     );
 
     this.fileOperationsHandler = new FileOperationsHandler(

--- a/packages/core/src/application/handlers/MessageHandlerContracts.ts
+++ b/packages/core/src/application/handlers/MessageHandlerContracts.ts
@@ -43,6 +43,15 @@ export type MessageTransport = (
   message: ExtensionToWebviewMessage
 ) => PromiseLike<unknown>;
 
+/**
+ * UI capabilities owned by the host shell and exposed to core message handlers.
+ * Kept named so new cross-surface actions extend one contract instead of
+ * growing anonymous callback bags at each boundary.
+ */
+export interface WorkshopUiActions {
+  openWorkshop?: () => void;
+}
+
 /** Per-MessageHandler replay cache. Never share this across webview lifetimes. */
 export interface ResultCache {
   analysis?: AnalysisResultMessage;

--- a/packages/core/src/application/handlers/domain/FileOperationsHandler.ts
+++ b/packages/core/src/application/handlers/domain/FileOperationsHandler.ts
@@ -6,6 +6,7 @@
 import * as path from 'path';
 import { FileSystem, FileType, LogSink, ShellService, Workspace } from '@/platform';
 import {
+  CopyResultSuccessMessage,
   CopyResultMessage,
   SaveResultMessage,
   SaveResultSuccessMessage,
@@ -16,22 +17,8 @@ import {
   StatusMessage
 } from '@messages';
 import { MessageTransport } from '@handlers/MessageHandlerContracts';
+import { assistantResultFilePrefix } from '@shared/constants/resultToolNames';
 import { MessageRouter } from '../MessageRouter';
-
-/**
- * File prefix mapping for assistant tools (Strategy pattern - Open/Closed Principle)
- * Adding new tools only requires a new map entry, not code changes
- */
-const FILE_PREFIX_MAP: Record<string, string> = {
-  'prose_analysis': 'excerpt-assistant-prose-',
-  'dialogue_analysis': 'excerpt-assistant-dialog-beats-',
-  'writing_tools_cliche': 'cliche-analysis-',
-  'writing_tools_continuity': 'continuity-check-',
-  'writing_tools_style': 'style-consistency-',
-  'writing_tools_editor': 'editor-',
-  'writing_tools_fresh': 'engagement-check-',
-  'writing_tools_repetition': 'repetition-analysis-'
-};
 
 export class FileOperationsHandler {
   constructor(
@@ -66,6 +53,9 @@ export class FileOperationsHandler {
   }
 
   private sendError(source: ErrorSource, message: string, details?: string): void {
+    this.outputChannel.appendLine(
+      `[FileOpsHandler] ERROR ${source}: ${message}${details ? ` — ${details}` : ''}`
+    );
     const errorMessage: ErrorMessage = {
       type: MessageType.ERROR,
       source: 'extension.file_ops',
@@ -99,6 +89,13 @@ export class FileOperationsHandler {
       }
 
       await this.shell.copyToClipboard(text);
+      const successMessage: CopyResultSuccessMessage = {
+        type: MessageType.COPY_RESULT_SUCCESS,
+        source: 'extension.file_ops',
+        payload: { toolName },
+        timestamp: Date.now()
+      };
+      this.postMessage(successMessage);
       this.sendStatus('Result copied to clipboard.');
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -181,12 +178,15 @@ export class FileOperationsHandler {
       await this.fileSystem.createDirectory(targetDir);
       fileName = `${sanitizedWord}.md`;
       fileContent = content.trim();
-    } else if (toolName === 'prose_analysis' || toolName === 'dialogue_analysis' || toolName.startsWith('writing_tools_')) {
+    } else if (assistantResultFilePrefix(toolName)) {
       targetDir = path.join(rootPath, 'prose-minion', 'assistant');
       await this.fileSystem.createDirectory(targetDir);
 
-      // Map tool names to file prefixes (Strategy pattern)
-      const prefix = FILE_PREFIX_MAP[toolName] ?? `${toolName.replace(/_/g, '-')}-`;
+      // Closed allowlist: webview toolName values must not become path pieces.
+      const prefix = assistantResultFilePrefix(toolName);
+      if (!prefix) {
+        throw new Error(`Saving results for tool "${toolName}" is not supported yet.`);
+      }
 
       const nextCount = await this.getNextSequentialNumber(targetDir, prefix);
       fileName = `${prefix}${nextCount}.md`;

--- a/packages/core/src/application/handlers/domain/UIHandler.ts
+++ b/packages/core/src/application/handlers/domain/UIHandler.ts
@@ -30,7 +30,8 @@ export class UIHandler {
     private readonly fileSystem: FileSystem,
     private readonly workspace: Workspace,
     private readonly shell: ShellService,
-    private readonly editor: EditorContext
+    private readonly editor: EditorContext,
+    private readonly openWorkshop?: () => void
   ) {}
 
   /**
@@ -42,6 +43,7 @@ export class UIHandler {
     router.register(MessageType.OPEN_RESOURCE, this.handleOpenResource.bind(this));
     router.register(MessageType.REQUEST_SELECTION, this.handleSelectionRequest.bind(this));
     router.register(MessageType.WEBVIEW_ERROR, this.handleWebviewError.bind(this));
+    router.register(MessageType.OPEN_WORKSHOP, this.handleOpenWorkshop.bind(this));
     router.register(MessageType.TAB_CHANGED, async () => {}); // No-op handler for tab changes
   }
 
@@ -223,6 +225,14 @@ export class UIHandler {
         errorMsg
       );
     }
+  }
+
+  async handleOpenWorkshop(): Promise<void> {
+    if (!this.openWorkshop) {
+      this.sendError('ui.workshop', 'Workshop is not available from this surface.');
+      return;
+    }
+    this.openWorkshop();
   }
 
   async handleSelectionRequest(message: RequestSelectionMessage): Promise<void> {

--- a/packages/core/src/application/handlers/domain/UIHandler.ts
+++ b/packages/core/src/application/handlers/domain/UIHandler.ts
@@ -19,7 +19,7 @@ import {
   WebviewErrorMessage,
   coerceWebviewErrorText
 } from '@messages';
-import { MessageTransport } from '@handlers/MessageHandlerContracts';
+import { MessageTransport, WorkshopUiActions } from '@handlers/MessageHandlerContracts';
 
 import { MessageRouter } from '../MessageRouter';
 
@@ -31,7 +31,7 @@ export class UIHandler {
     private readonly workspace: Workspace,
     private readonly shell: ShellService,
     private readonly editor: EditorContext,
-    private readonly openWorkshop?: () => void
+    private readonly workshopUiActions: WorkshopUiActions = {}
   ) {}
 
   /**
@@ -228,11 +228,11 @@ export class UIHandler {
   }
 
   async handleOpenWorkshop(): Promise<void> {
-    if (!this.openWorkshop) {
+    if (!this.workshopUiActions.openWorkshop) {
       this.sendError('ui.workshop', 'Workshop is not available from this surface.');
       return;
     }
-    this.openWorkshop();
+    this.workshopUiActions.openWorkshop();
   }
 
   async handleSelectionRequest(message: RequestSelectionMessage): Promise<void> {

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -26,6 +26,7 @@ import { FileSystem, FileType, LogSink, ShellService, Workspace } from '@/platfo
 import { AssistantToolService } from '@services/analysis/AssistantToolService';
 import { WorkshopSessionService } from '@/application/services/WorkshopSessionService';
 import { isWorkshopToolId, workshopToolLabel } from '@shared/constants/workshopTools';
+import { workshopQuickActionPrompt } from '@shared/constants/workshopQuickActions';
 import { countWords, trimToWordLimit } from '@/utils/textUtils';
 import {
   MessageType,
@@ -42,6 +43,7 @@ import {
   WorkshopPickExcerptFileMessage,
   WorkshopRequestSessionMessage,
   WorkshopResetSessionMessage,
+  WorkshopQuickActionMessage,
   WorkshopRunToolMessage,
   WorkshopSendMessageMessage,
   WorkshopSetExcerptMessage,
@@ -128,6 +130,7 @@ export class WorkshopHandler {
    */
   registerRoutes(router: MessageRouter): void {
     router.register(MessageType.WORKSHOP_RUN_TOOL, this.handleRunTool.bind(this));
+    router.register(MessageType.WORKSHOP_QUICK_ACTION, this.handleQuickAction.bind(this));
     router.register(MessageType.WORKSHOP_SEND_MESSAGE, this.handleSendMessage.bind(this));
     router.register(MessageType.WORKSHOP_SET_EXCERPT, this.handleSetExcerpt.bind(this));
     router.register(MessageType.WORKSHOP_PICK_EXCERPT_FILE, this.handlePickExcerptFile.bind(this));
@@ -283,6 +286,37 @@ export class WorkshopHandler {
       return;
     }
 
+    await this.executeFollowUp(text);
+  }
+
+  /**
+   * Deterministic Sprint 4 quick action: resolve the clicked label to a static
+   * prompt template, then run the SAME retained-conversation path as a typed
+   * free-text follow-up. Labels/prompts live in code; the model never invents
+   * UI affordances.
+   */
+  async handleQuickAction(message: WorkshopQuickActionMessage): Promise<void> {
+    const { toolId, label } = message.payload;
+
+    if (!isWorkshopToolId(toolId)) {
+      this.sendError('workshop.quick_action', `Unknown Workshop tool: ${String(toolId)}`);
+      return;
+    }
+
+    const actionLabel = typeof label === 'string' ? label.trim() : '';
+    const prompt = actionLabel ? workshopQuickActionPrompt(toolId, actionLabel) : undefined;
+    if (!prompt) {
+      this.sendError(
+        'workshop.quick_action',
+        `Unknown Workshop quick action for ${workshopToolLabel(toolId)}: ${actionLabel || '(empty)'}`
+      );
+      return;
+    }
+
+    await this.executeFollowUp(prompt, actionLabel);
+  }
+
+  private async executeFollowUp(text: string, displayText = text): Promise<void> {
     const conversationId = this.session.getConversationId();
     if (!conversationId) {
       this.sendError(
@@ -299,7 +333,7 @@ export class WorkshopHandler {
     const controller = new AbortController();
     this.activeRun = { requestId, label: FOLLOW_UP_LABEL, controller };
 
-    const userTurn = this.session.beginMessageRun(text, requestId);
+    const userTurn = this.session.beginMessageRun(text, requestId, displayText);
     this.postTurn(userTurn);
     this.postSessionState();
     this.sendStreamStarted(requestId);

--- a/packages/core/src/application/services/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/WorkshopSessionService.ts
@@ -63,6 +63,7 @@ export class WorkshopSessionService {
   private turns: WorkshopTurn[] = [];
   private activeRun?: ActiveRun;
   private conversationId?: string;
+  private selectedToolId?: WorkshopToolId;
   private turnCounter = 0;
 
   constructor(private readonly now: () => number = Date.now) {}
@@ -109,6 +110,7 @@ export class WorkshopSessionService {
       throw new Error('Cannot run a Workshop tool without a pinned excerpt');
     }
     const toolLabel = workshopToolLabel(toolId);
+    this.selectedToolId = toolId;
     const turn: WorkshopTurn = {
       id: this.nextTurnId('user'),
       role: 'user',
@@ -128,7 +130,7 @@ export class WorkshopSessionService {
    * turn and marks the run active. Throws without a retained conversation —
    * a follow-up needs something to follow.
    */
-  beginMessageRun(text: string, requestId: string): WorkshopTurn {
+  beginMessageRun(text: string, requestId: string, displayText = text): WorkshopTurn {
     if (!this.conversationId) {
       throw new Error('Cannot send a Workshop follow-up without an active conversation');
     }
@@ -136,7 +138,7 @@ export class WorkshopSessionService {
       id: this.nextTurnId('user'),
       role: 'user',
       kind: 'message',
-      content: text,
+      content: displayText,
       timestamp: this.now()
     };
     this.turns.push(turn);
@@ -206,6 +208,7 @@ export class WorkshopSessionService {
     this.turns = [];
     this.activeRun = undefined;
     this.contextBrief = undefined;
+    this.selectedToolId = undefined;
     return this.clearConversation();
   }
 
@@ -224,6 +227,7 @@ export class WorkshopSessionService {
       totalTurns: this.turns.length,
       truncatedTurns: this.turns.length - windowed.length,
       hasConversation: this.conversationId !== undefined,
+      selectedToolId: this.selectedToolId,
       activeToolId: this.activeRun?.toolId,
       activeRequestId: this.activeRun?.requestId
     };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,7 +30,8 @@ export type {
   CoreServices,
   MessageTransport,
   ResultCache,
-  SecretsPort
+  SecretsPort,
+  WorkshopUiActions
 } from '@/application/handlers/MessageHandlerContracts';
 
 // --- Application: Workshop session aggregate (ADR 2026-07-03) ---

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -26,11 +26,19 @@ import { ErrorBoundary } from './components/shared/ErrorBoundary';
 import { TabErrorFallback } from './components/shared/TabErrorFallback';
 import { StreamingContent } from './components/shared/StreamingContent';
 import { MessageType } from '@shared/types';
-import { ApiKeyStatusMessage, WorkshopToolId } from '@messages';
+import {
+  ApiKeyStatusMessage,
+  ErrorMessage,
+  SaveResultSuccessMessage,
+  StatusMessage,
+  WorkshopToolId
+} from '@messages';
 import { ModelSelector } from './components/shared/ModelSelector';
 import { ExcerptPanel } from './components/workshop/ExcerptPanel';
 import { WorkshopComposer } from './components/workshop/WorkshopComposer';
 import { WorkshopThread } from './components/workshop/WorkshopThread';
+import { WorkshopToolsModal } from './components/workshop/WorkshopToolsModal';
+import { WorkshopToast, WorkshopToastState } from './components/workshop/WorkshopToast';
 import { WORKSHOP_TOOL_ICONS } from './components/workshop/workshopToolIcons';
 import {
   WORKSHOP_TOOL_CATALOG,
@@ -80,9 +88,10 @@ const RAIL_TOOLS: readonly WorkshopTool[] = RAIL_TOOL_IDS.flatMap((id) => {
   return tool ? [tool] : [];
 });
 
-const countWords = (text: string): number => {
-  const trimmed = text.trim();
-  return trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+const toolNameForResult = (toolId: WorkshopToolId | null): string => {
+  if (toolId === 'dialogue') {return 'dialogue_analysis';}
+  if (toolId === 'prose') {return 'prose_analysis';}
+  return toolId ? `writing_tools_${toolId}` : 'writing_tools_editor';
 };
 
 export const WorkshopApp: React.FC = () => {
@@ -95,11 +104,58 @@ export const WorkshopApp: React.FC = () => {
   const modelsSettings = useModelsSettings();
   const tokenTracking = useTokenTracking();
   const [hasSavedKey, setHasSavedKey] = React.useState(false);
+  const [toolsModalOpen, setToolsModalOpen] = React.useState(false);
+  const [toast, setToast] = React.useState<WorkshopToastState | null>(null);
   const accountBalance = useAccountBalance({ apiKeyConfigured: hasSavedKey });
+
+  const showToast = React.useCallback((next: WorkshopToastState) => {
+    setToast(next);
+  }, []);
+
+  React.useEffect(() => {
+    if (!toast) {
+      return undefined;
+    }
+    const timer = window.setTimeout(() => setToast(null), 2200);
+    return () => window.clearTimeout(timer);
+  }, [toast]);
 
   const handleApiKeyStatus = React.useCallback((message: ApiKeyStatusMessage) => {
     setHasSavedKey(!!message.payload?.hasSavedKey);
   }, []);
+
+  const handleStatusMessage = React.useCallback(
+    (message: StatusMessage) => {
+      workshop.handleStatusMessage(message);
+      if (message.source === 'extension.file_ops') {
+        const text = message.payload?.message ?? '';
+        if (text.includes('copied')) {
+          showToast({ message: 'Copied to clipboard', icon: 'copy' });
+        } else if (text.includes('Saved result')) {
+          showToast({ message: text, icon: 'save' });
+        }
+      }
+    },
+    [showToast, workshop.handleStatusMessage]
+  );
+
+  const handleErrorMessage = React.useCallback(
+    (message: ErrorMessage) => {
+      workshop.handleErrorMessage(message);
+      const source = message.payload?.source;
+      if (typeof source === 'string' && source.startsWith('file_ops')) {
+        showToast({ message: message.payload.message, icon: 'x', tone: 'error' });
+      }
+    },
+    [showToast, workshop.handleErrorMessage]
+  );
+
+  const handleSaveResultSuccess = React.useCallback(
+    (message: SaveResultSuccessMessage) => {
+      showToast({ message: `Saved to ${message.payload.filePath}`, icon: 'save' });
+    },
+    [showToast]
+  );
 
   useMessageRouter({
     [MessageType.WORKSHOP_SESSION_STATE]: workshop.handleSessionState,
@@ -107,13 +163,14 @@ export const WorkshopApp: React.FC = () => {
     [MessageType.STREAM_STARTED]: workshop.handleStreamStarted,
     [MessageType.STREAM_CHUNK]: workshop.handleStreamChunk,
     [MessageType.STREAM_COMPLETE]: workshop.handleStreamComplete,
-    [MessageType.STATUS]: workshop.handleStatusMessage,
-    [MessageType.ERROR]: workshop.handleErrorMessage,
+    [MessageType.STATUS]: handleStatusMessage,
+    [MessageType.ERROR]: handleErrorMessage,
     [MessageType.MODEL_DATA]: modelsSettings.handleModelData,
     [MessageType.SETTINGS_DATA]: modelsSettings.handleSettingsData,
     [MessageType.TOKEN_USAGE_UPDATE]: tokenTracking.handleTokenUsageUpdate,
     [MessageType.ACCOUNT_BALANCE_DATA]: accountBalance.handleAccountBalanceData,
     [MessageType.API_KEY_STATUS]: handleApiKeyStatus,
+    [MessageType.SAVE_RESULT_SUCCESS]: handleSaveResultSuccess,
   });
 
   usePersistence({
@@ -177,6 +234,52 @@ export const WorkshopApp: React.FC = () => {
 
   // Live run bubble: visible from run start until the assistant turn lands.
   const showLiveTurn = workshop.isRunning || workshop.isStreaming || workshop.streamingContent.length > 0;
+
+  const openToolsModal = React.useCallback(() => setToolsModalOpen(true), []);
+  const closeToolsModal = React.useCallback(() => setToolsModalOpen(false), []);
+  const selectTool = React.useCallback(
+    (toolId: WorkshopToolId) => {
+      setToolsModalOpen(false);
+      workshop.runTool(toolId);
+    },
+    [workshop.runTool]
+  );
+
+  const copyVariation = React.useCallback(
+    (content: string, toolId: WorkshopToolId | null) => {
+      vscode.postMessage({
+        type: MessageType.COPY_RESULT,
+        source: 'webview.workshop',
+        payload: {
+          toolName: toolNameForResult(toolId),
+          content
+        },
+        timestamp: Date.now(),
+      });
+    },
+    [vscode]
+  );
+
+  const saveVariation = React.useCallback(
+    (content: string, toolId: WorkshopToolId | null) => {
+      vscode.postMessage({
+        type: MessageType.SAVE_RESULT,
+        source: 'webview.workshop',
+        payload: {
+          toolName: toolNameForResult(toolId),
+          content,
+          metadata: {
+            excerpt: workshop.excerpt?.text,
+            relativePath: workshop.excerpt?.relativePath,
+            sourceFileUri: workshop.excerpt?.sourceUri,
+            timestamp: Date.now()
+          }
+        },
+        timestamp: Date.now(),
+      });
+    },
+    [vscode, workshop.excerpt]
+  );
 
   const openrouter = accountBalance.openrouter;
   const remaining = openrouter?.credits?.remaining;
@@ -289,7 +392,7 @@ export const WorkshopApp: React.FC = () => {
                   <button
                     key={tool.id}
                     className={`pm-ws-tool ${
-                      workshop.activeToolId === tool.id ? 'pm-ws-tool-active' : ''
+                      workshop.selectedToolId === tool.id ? 'pm-ws-tool-active' : ''
                     }`}
                     type="button"
                     role="listitem"
@@ -304,7 +407,13 @@ export const WorkshopApp: React.FC = () => {
                     <Icon name={tool.icon} size={15} /> {tool.label}
                   </button>
                 ))}
-                <button className="pm-ws-tool pm-ws-tool-ghost" type="button" role="listitem" disabled>
+                <button
+                  className="pm-ws-tool pm-ws-tool-ghost"
+                  type="button"
+                  role="listitem"
+                  disabled={!workshop.sessionReady}
+                  onClick={openToolsModal}
+                >
                   <Icon name="grid" size={15} /> All {WORKSHOP_TOOLS.length} tools…
                 </button>
               </div>
@@ -336,10 +445,35 @@ export const WorkshopApp: React.FC = () => {
               {workshop.turns.length === 0 && !showLiveTurn && (
                 <div className="pm-ws-thread-empty">
                   <Icon name="sparkle" size={22} />
-                  <p className="pm-ws-thread-empty-title">The thread starts when you run a tool.</p>
-                  <p className="pm-ws-thread-empty-sub">
-                    Pin an excerpt on the left, pick a tool, and the analysis streams in here.
+                  <p className="pm-ws-thread-empty-title">
+                    {workshop.excerpt
+                      ? 'Your excerpt is pinned. Pick a lens.'
+                      : 'Pin an excerpt to start the Workshop.'}
                   </p>
+                  <p className="pm-ws-thread-empty-sub">
+                    {workshop.excerpt
+                      ? 'Run a tool from the rail, open the full palette, or use one of these quick starts.'
+                      : 'Paste text or pin a file on the left. The excerpt stays fixed while the conversation grows here.'}
+                  </p>
+                  {workshop.excerpt && (
+                    <div className="pm-ws-empty-actions">
+                      {(['dialogue', 'gestures', 'choreography', 'cliche'] as const).map((toolId) => {
+                        const tool = WORKSHOP_TOOLS.find((entry) => entry.id === toolId);
+                        if (!tool) {return null;}
+                        return (
+                          <button
+                            key={tool.id}
+                            className="pm-ws-qa"
+                            type="button"
+                            disabled={!toolsEnabled}
+                            onClick={() => workshop.runTool(tool.id)}
+                          >
+                            {tool.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -350,7 +484,13 @@ export const WorkshopApp: React.FC = () => {
                   after reload.
                 </div>
               )}
-              <WorkshopThread turns={workshop.turns} />
+              <WorkshopThread
+                turns={workshop.turns}
+                quickActionsDisabled={!workshop.canFollowUp}
+                onQuickAction={workshop.quickAction}
+                onCopyVariation={copyVariation}
+                onSaveVariation={saveVariation}
+              />
 
               {showLiveTurn && (
                 <div className="pm-ws-turn pm-ws-turn-assistant pm-ws-turn-live">
@@ -386,10 +526,27 @@ export const WorkshopApp: React.FC = () => {
               sessionReady={workshop.sessionReady}
               onSend={workshop.sendMessage}
               onCancel={workshop.cancelRun}
+              onOpenTools={openToolsModal}
             />
+            {(workshop.tickerMessage || workshop.statusMessage) && (
+              <div className="pm-ws-status-ticker" role="status" aria-live="polite">
+                <Icon name="bolt" size={12} />
+                {workshop.tickerMessage || workshop.statusMessage}
+              </div>
+            )}
           </ErrorBoundary>
         </section>
       </div>
+
+      {toolsModalOpen && (
+        <WorkshopToolsModal
+          activeToolId={workshop.selectedToolId}
+          disabled={!toolsEnabled}
+          onClose={closeToolsModal}
+          onSelect={selectTool}
+        />
+      )}
+      <WorkshopToast toast={toast} />
     </div>
   );
 };

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -28,6 +28,7 @@ import { StreamingContent } from './components/shared/StreamingContent';
 import { MessageType } from '@shared/types';
 import {
   ApiKeyStatusMessage,
+  CopyResultSuccessMessage,
   ErrorMessage,
   SaveResultSuccessMessage,
   StatusMessage,
@@ -44,6 +45,7 @@ import {
   WORKSHOP_TOOL_CATALOG,
   WorkshopToolDescriptor
 } from '@shared/constants/workshopTools';
+import { resultToolNameForWorkshopTool } from '@shared/constants/resultToolNames';
 import { useVSCodeApi } from './hooks/useVSCodeApi';
 import { usePersistence } from './hooks/usePersistence';
 import { useMessageRouter } from './hooks/useMessageRouter';
@@ -88,11 +90,21 @@ const RAIL_TOOLS: readonly WorkshopTool[] = RAIL_TOOL_IDS.flatMap((id) => {
   return tool ? [tool] : [];
 });
 
-const toolNameForResult = (toolId: WorkshopToolId | null): string => {
-  if (toolId === 'dialogue') {return 'dialogue_analysis';}
-  if (toolId === 'prose') {return 'prose_analysis';}
-  return toolId ? `writing_tools_${toolId}` : 'writing_tools_editor';
-};
+/**
+ * Matches the approved Direction B welcome quick starts. Kept named beside the
+ * rail override so prototype provenance is visible at both repeated lists.
+ */
+const EMPTY_STATE_TOOL_IDS: readonly WorkshopToolId[] = [
+  'dialogue',
+  'gestures',
+  'choreography',
+  'cliche',
+];
+
+const EMPTY_STATE_TOOLS: readonly WorkshopTool[] = EMPTY_STATE_TOOL_IDS.flatMap((id) => {
+  const tool = WORKSHOP_TOOLS.find((entry) => entry.id === id);
+  return tool ? [tool] : [];
+});
 
 export const WorkshopApp: React.FC = () => {
   const vscode = useVSCodeApi();
@@ -127,16 +139,8 @@ export const WorkshopApp: React.FC = () => {
   const handleStatusMessage = React.useCallback(
     (message: StatusMessage) => {
       workshop.handleStatusMessage(message);
-      if (message.source === 'extension.file_ops') {
-        const text = message.payload?.message ?? '';
-        if (text.includes('copied')) {
-          showToast({ message: 'Copied to clipboard', icon: 'copy' });
-        } else if (text.includes('Saved result')) {
-          showToast({ message: text, icon: 'save' });
-        }
-      }
     },
-    [showToast, workshop.handleStatusMessage]
+    [workshop.handleStatusMessage]
   );
 
   const handleErrorMessage = React.useCallback(
@@ -157,6 +161,13 @@ export const WorkshopApp: React.FC = () => {
     [showToast]
   );
 
+  const handleCopyResultSuccess = React.useCallback(
+    (_message: CopyResultSuccessMessage) => {
+      showToast({ message: 'Copied to clipboard', icon: 'copy' });
+    },
+    [showToast]
+  );
+
   useMessageRouter({
     [MessageType.WORKSHOP_SESSION_STATE]: workshop.handleSessionState,
     [MessageType.WORKSHOP_TURN]: workshop.handleTurn,
@@ -170,6 +181,7 @@ export const WorkshopApp: React.FC = () => {
     [MessageType.TOKEN_USAGE_UPDATE]: tokenTracking.handleTokenUsageUpdate,
     [MessageType.ACCOUNT_BALANCE_DATA]: accountBalance.handleAccountBalanceData,
     [MessageType.API_KEY_STATUS]: handleApiKeyStatus,
+    [MessageType.COPY_RESULT_SUCCESS]: handleCopyResultSuccess,
     [MessageType.SAVE_RESULT_SUCCESS]: handleSaveResultSuccess,
   });
 
@@ -247,26 +259,34 @@ export const WorkshopApp: React.FC = () => {
 
   const copyVariation = React.useCallback(
     (content: string, toolId: WorkshopToolId | null) => {
+      if (!toolId) {
+        showToast({ message: 'Choose a Workshop tool before copying this variation', icon: 'x', tone: 'error' });
+        return;
+      }
       vscode.postMessage({
         type: MessageType.COPY_RESULT,
         source: 'webview.workshop',
         payload: {
-          toolName: toolNameForResult(toolId),
+          toolName: resultToolNameForWorkshopTool(toolId),
           content
         },
         timestamp: Date.now(),
       });
     },
-    [vscode]
+    [showToast, vscode]
   );
 
   const saveVariation = React.useCallback(
     (content: string, toolId: WorkshopToolId | null) => {
+      if (!toolId) {
+        showToast({ message: 'Choose a Workshop tool before saving this variation', icon: 'x', tone: 'error' });
+        return;
+      }
       vscode.postMessage({
         type: MessageType.SAVE_RESULT,
         source: 'webview.workshop',
         payload: {
-          toolName: toolNameForResult(toolId),
+          toolName: resultToolNameForWorkshopTool(toolId),
           content,
           metadata: {
             excerpt: workshop.excerpt?.text,
@@ -278,7 +298,7 @@ export const WorkshopApp: React.FC = () => {
         timestamp: Date.now(),
       });
     },
-    [vscode, workshop.excerpt]
+    [showToast, vscode, workshop.excerpt]
   );
 
   const openrouter = accountBalance.openrouter;
@@ -457,21 +477,17 @@ export const WorkshopApp: React.FC = () => {
                   </p>
                   {workshop.excerpt && (
                     <div className="pm-ws-empty-actions">
-                      {(['dialogue', 'gestures', 'choreography', 'cliche'] as const).map((toolId) => {
-                        const tool = WORKSHOP_TOOLS.find((entry) => entry.id === toolId);
-                        if (!tool) {return null;}
-                        return (
-                          <button
-                            key={tool.id}
-                            className="pm-ws-qa"
-                            type="button"
-                            disabled={!toolsEnabled}
-                            onClick={() => workshop.runTool(tool.id)}
-                          >
-                            {tool.label}
-                          </button>
-                        );
-                      })}
+                      {EMPTY_STATE_TOOLS.map((tool) => (
+                        <button
+                          key={tool.id}
+                          className="pm-ws-qa"
+                          type="button"
+                          disabled={!toolsEnabled}
+                          onClick={() => workshop.runTool(tool.id)}
+                        >
+                          {tool.label}
+                        </button>
+                      ))}
                     </div>
                   )}
                 </div>
@@ -486,6 +502,7 @@ export const WorkshopApp: React.FC = () => {
               )}
               <WorkshopThread
                 turns={workshop.turns}
+                selectedToolId={workshop.selectedToolId}
                 quickActionsDisabled={!workshop.canFollowUp}
                 onQuickAction={workshop.quickAction}
                 onCopyVariation={copyVariation}
@@ -538,14 +555,13 @@ export const WorkshopApp: React.FC = () => {
         </section>
       </div>
 
-      {toolsModalOpen && (
-        <WorkshopToolsModal
-          activeToolId={workshop.selectedToolId}
-          disabled={!toolsEnabled}
-          onClose={closeToolsModal}
-          onSelect={selectTool}
-        />
-      )}
+      <WorkshopToolsModal
+        open={toolsModalOpen}
+        activeToolId={workshop.selectedToolId}
+        disabled={!toolsEnabled}
+        onClose={closeToolsModal}
+        onSelect={selectTool}
+      />
       <WorkshopToast toast={toast} />
     </div>
   );

--- a/packages/core/src/presentation/webview/components/tabs/AnalysisTab.tsx
+++ b/packages/core/src/presentation/webview/components/tabs/AnalysisTab.tsx
@@ -171,6 +171,15 @@ export const AnalysisTab = React.memo<AnalysisTabProps>(({
     });
   };
 
+  const handleOpenWorkshop = () => {
+    vscode.postMessage({
+      type: MessageType.OPEN_WORKSHOP,
+      source: 'webview.analysis.tab',
+      payload: {},
+      timestamp: Date.now()
+    });
+  };
+
   const handleGenerateContext = () => {
     if (!text.trim() || context.loading) {
       return;
@@ -462,14 +471,23 @@ export const AnalysisTab = React.memo<AnalysisTabProps>(({
       <div className="analysis-buttons-section">
         <div className="analysis-buttons-head">
           <h4 className="analysis-section-header">Analyze &amp; Suggest Improvements</h4>
-          <button
-            className="btn ghost all-tools-button"
-            onClick={() => setShowAllTools(true)}
-            disabled={!text.trim() || analysis.loading || analysis.isStreaming}
-            title="Browse every writing tool"
-          >
-            <Icon name="grid" size={14} /> All tools
-          </button>
+          <div className="analysis-buttons-head-actions">
+            <button
+              className="btn ghost all-tools-button"
+              onClick={handleOpenWorkshop}
+              title="Open the Workshop editor tab"
+            >
+              <Icon name="panelRight" size={14} /> Workshop
+            </button>
+            <button
+              className="btn ghost all-tools-button"
+              onClick={() => setShowAllTools(true)}
+              disabled={!text.trim() || analysis.loading || analysis.isStreaming}
+              title="Browse every writing tool"
+            >
+              <Icon name="grid" size={14} /> All tools
+            </button>
+          </div>
         </div>
         <div className="primary-buttons">
           <button

--- a/packages/core/src/presentation/webview/components/tabs/AnalysisTab.tsx
+++ b/packages/core/src/presentation/webview/components/tabs/AnalysisTab.tsx
@@ -299,7 +299,16 @@ export const AnalysisTab = React.memo<AnalysisTabProps>(({
 
   return (
     <div className="tab-content">
-      <h2 className="text-lg font-semibold mb-4">Prose Excerpt Assistant</h2>
+      <div className="assistant-title-row">
+        <h2 className="text-lg font-semibold mb-4">Prose Excerpt Assistant</h2>
+        <button
+          className="btn btn-secondary workshop-launch-button"
+          onClick={handleOpenWorkshop}
+          title="Open the Workshop editor tab"
+        >
+          <Icon name="panelRight" size={14} /> Workshop
+        </button>
+      </div>
 
       <div className="input-container">
         <div className="input-header">
@@ -472,13 +481,6 @@ export const AnalysisTab = React.memo<AnalysisTabProps>(({
         <div className="analysis-buttons-head">
           <h4 className="analysis-section-header">Analyze &amp; Suggest Improvements</h4>
           <div className="analysis-buttons-head-actions">
-            <button
-              className="btn ghost all-tools-button"
-              onClick={handleOpenWorkshop}
-              title="Open the Workshop editor tab"
-            >
-              <Icon name="panelRight" size={14} /> Workshop
-            </button>
             <button
               className="btn ghost all-tools-button"
               onClick={() => setShowAllTools(true)}

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopComposer.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopComposer.tsx
@@ -9,8 +9,7 @@
  *
  * The draft is deliberately LOCAL state: it's unsent user input, not session
  * truth, so it doesn't belong in WorkshopSessionService (and losing it on a
- * webview reload is acceptable alpha behavior). The plus button and Tools
- * pill remain Sprint 4 placeholders.
+ * webview reload is acceptable alpha behavior).
  */
 
 import * as React from 'react';
@@ -27,6 +26,7 @@ interface WorkshopComposerProps {
   sessionReady: boolean;
   onSend: (text: string) => void;
   onCancel: () => void;
+  onOpenTools: () => void;
 }
 
 export const WorkshopComposer: React.FC<WorkshopComposerProps> = ({
@@ -35,7 +35,8 @@ export const WorkshopComposer: React.FC<WorkshopComposerProps> = ({
   isRunning,
   sessionReady,
   onSend,
-  onCancel
+  onCancel,
+  onOpenTools
 }) => {
   const [draft, setDraft] = React.useState('');
 
@@ -58,7 +59,13 @@ export const WorkshopComposer: React.FC<WorkshopComposerProps> = ({
   return (
     <div className="pm-ws-composer-wrap">
       <form className="pm-ws-composer" onSubmit={submit}>
-        <button className="pm-ws-comp-add" type="button" disabled title="Writing tools (Sprint 4)">
+        <button
+          className="pm-ws-comp-add"
+          type="button"
+          disabled={!sessionReady}
+          title="Writing tools"
+          onClick={onOpenTools}
+        >
           <Icon name="plus" size={18} />
         </button>
         <input
@@ -71,9 +78,14 @@ export const WorkshopComposer: React.FC<WorkshopComposerProps> = ({
           aria-label="Message the Workshop"
         />
         <div className="pm-ws-comp-right">
-          <span className="pm-ws-comp-pill">
+          <button
+            className="pm-ws-comp-pill"
+            type="button"
+            disabled={!sessionReady}
+            onClick={onOpenTools}
+          >
             <Icon name="grid" size={13} /> Tools
-          </span>
+          </button>
           {isRunning ? (
             <button
               className="pm-ws-comp-send pm-ws-comp-stop"

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopQuickActionBar.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopQuickActionBar.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Icon } from '@components/shared/Icon';
+import { WorkshopToolId } from '@messages';
+import { workshopQuickActionsForTool } from '@shared/constants/workshopQuickActions';
+import { workshopToolLabel } from '@shared/constants/workshopTools';
+
+interface WorkshopQuickActionBarProps {
+  toolId: WorkshopToolId;
+  disabled?: boolean;
+  onAction: (toolId: WorkshopToolId, label: string) => void;
+}
+
+export const WorkshopQuickActionBar: React.FC<WorkshopQuickActionBarProps> = ({
+  toolId,
+  disabled = false,
+  onAction
+}) => {
+  const actions = workshopQuickActionsForTool(toolId);
+
+  return (
+    <div className="pm-ws-qbar">
+      <div className="pm-ws-qbar-label">
+        <Icon name="sparkle" size={13} /> Next, for <b>{workshopToolLabel(toolId)}</b>
+      </div>
+      <div className="pm-ws-qbar-actions">
+        {actions.map((action) => (
+          <button
+            key={action.label}
+            className={`pm-ws-qa ${action.primary ? 'pm-ws-qa-primary' : ''}`}
+            type="button"
+            disabled={disabled}
+            onClick={() => onAction(toolId, action.label)}
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopQuickActionBar.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopQuickActionBar.tsx
@@ -1,3 +1,8 @@
+/**
+ * WorkshopQuickActionBar — deterministic follow-up chips owned by the static
+ * Workshop quick-action map, never by model output.
+ */
+
 import * as React from 'react';
 import { Icon } from '@components/shared/Icon';
 import { WorkshopToolId } from '@messages';

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopThread.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopThread.tsx
@@ -15,6 +15,7 @@ import { WorkshopTurnBubble } from './WorkshopTurnBubble';
 
 interface WorkshopThreadProps {
   turns: readonly WorkshopTurn[];
+  selectedToolId: WorkshopToolId | null;
   quickActionsDisabled?: boolean;
   onQuickAction: (toolId: WorkshopToolId, label: string) => void;
   onCopyVariation: (content: string, toolId: WorkshopToolId | null) => void;
@@ -23,6 +24,7 @@ interface WorkshopThreadProps {
 
 export const WorkshopThread: React.FC<WorkshopThreadProps> = React.memo(({
   turns,
+  selectedToolId,
   quickActionsDisabled = false,
   onQuickAction,
   onCopyVariation,
@@ -37,13 +39,17 @@ export const WorkshopThread: React.FC<WorkshopThreadProps> = React.memo(({
           currentToolId = turn.toolId;
         }
 
-        const actionToolId = turn.role === 'assistant' ? turn.toolId ?? currentToolId : null;
+        const actionToolId =
+          turn.role === 'assistant' ? turn.toolId ?? currentToolId ?? selectedToolId : null;
+        const turnActionsDisabled =
+          quickActionsDisabled ||
+          (actionToolId !== null && selectedToolId !== null && actionToolId !== selectedToolId);
         return (
           <WorkshopTurnBubble
             key={turn.id}
             turn={turn}
             quickActionToolId={actionToolId}
-            quickActionsDisabled={quickActionsDisabled}
+            quickActionsDisabled={turnActionsDisabled}
             onQuickAction={onQuickAction}
             onCopyVariation={onCopyVariation}
             onSaveVariation={onSaveVariation}

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopThread.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopThread.tsx
@@ -10,19 +10,48 @@
  */
 
 import * as React from 'react';
-import { WorkshopTurn } from '@messages';
+import { WorkshopToolId, WorkshopTurn } from '@messages';
 import { WorkshopTurnBubble } from './WorkshopTurnBubble';
 
 interface WorkshopThreadProps {
   turns: readonly WorkshopTurn[];
+  quickActionsDisabled?: boolean;
+  onQuickAction: (toolId: WorkshopToolId, label: string) => void;
+  onCopyVariation: (content: string, toolId: WorkshopToolId | null) => void;
+  onSaveVariation: (content: string, toolId: WorkshopToolId | null) => void;
 }
 
-export const WorkshopThread: React.FC<WorkshopThreadProps> = React.memo(({ turns }) => (
-  <>
-    {turns.map((turn) => (
-      <WorkshopTurnBubble key={turn.id} turn={turn} />
-    ))}
-  </>
-));
+export const WorkshopThread: React.FC<WorkshopThreadProps> = React.memo(({
+  turns,
+  quickActionsDisabled = false,
+  onQuickAction,
+  onCopyVariation,
+  onSaveVariation
+}) => {
+  let currentToolId: WorkshopToolId | null = null;
+
+  return (
+    <>
+      {turns.map((turn) => {
+        if (turn.toolId) {
+          currentToolId = turn.toolId;
+        }
+
+        const actionToolId = turn.role === 'assistant' ? turn.toolId ?? currentToolId : null;
+        return (
+          <WorkshopTurnBubble
+            key={turn.id}
+            turn={turn}
+            quickActionToolId={actionToolId}
+            quickActionsDisabled={quickActionsDisabled}
+            onQuickAction={onQuickAction}
+            onCopyVariation={onCopyVariation}
+            onSaveVariation={onSaveVariation}
+          />
+        );
+      })}
+    </>
+  );
+});
 
 WorkshopThread.displayName = 'WorkshopThread';

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopToast.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopToast.tsx
@@ -1,3 +1,8 @@
+/**
+ * WorkshopToast — short-lived acknowledgements for Workshop copy/save/error
+ * actions. Durable error state stays in the thread banner or output log.
+ */
+
 import * as React from 'react';
 import { Icon, IconName } from '@components/shared/Icon';
 

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopToast.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopToast.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Icon, IconName } from '@components/shared/Icon';
+
+export interface WorkshopToastState {
+  message: string;
+  icon: IconName;
+  tone?: 'success' | 'error';
+}
+
+interface WorkshopToastProps {
+  toast: WorkshopToastState | null;
+}
+
+export const WorkshopToast: React.FC<WorkshopToastProps> = ({ toast }) => {
+  if (!toast) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`pm-ws-toast ${toast.tone === 'error' ? 'pm-ws-toast-error' : ''}`}
+      role="status"
+      aria-live="polite"
+    >
+      <Icon name={toast.icon} size={15} />
+      <span>{toast.message}</span>
+    </div>
+  );
+};

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopToolsModal.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopToolsModal.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Icon } from '@components/shared/Icon';
+import { WorkshopToolId } from '@messages';
+import {
+  WORKSHOP_TOOL_CATALOG,
+  WorkshopToolDescriptor,
+  WorkshopToolGroup
+} from '@shared/constants/workshopTools';
+import { WORKSHOP_TOOL_ICONS } from './workshopToolIcons';
+
+const TOOL_GROUPS: readonly WorkshopToolGroup[] = ['Primary', 'Craft & Voice', 'Technical'];
+
+interface WorkshopToolsModalProps {
+  activeToolId: WorkshopToolId | null;
+  disabled?: boolean;
+  onClose: () => void;
+  onSelect: (toolId: WorkshopToolId) => void;
+}
+
+const groupedTools = (group: WorkshopToolGroup): readonly WorkshopToolDescriptor[] =>
+  WORKSHOP_TOOL_CATALOG.filter((tool) => tool.group === group);
+
+export const WorkshopToolsModal: React.FC<WorkshopToolsModalProps> = ({
+  activeToolId,
+  disabled = false,
+  onClose,
+  onSelect
+}) => {
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="pm-ws-modal-backdrop" role="presentation" onMouseDown={handleBackdropClick}>
+      <div className="pm-ws-tools-modal" role="dialog" aria-modal="true" aria-labelledby="pm-ws-tools-title">
+        <div className="pm-ws-tools-modal-head">
+          <div>
+            <div className="pm-ws-eyebrow">Prose Excerpt Assistant</div>
+            <h2 id="pm-ws-tools-title">Writing Tools</h2>
+            <p>Pick an analysis. Each runs on your pinned excerpt with the context brief attached.</p>
+          </div>
+          <button className="pm-ws-modal-close" type="button" onClick={onClose} aria-label="Close tools">
+            <Icon name="x" size={16} />
+          </button>
+        </div>
+
+        {TOOL_GROUPS.map((group) => (
+          <section key={group} className="pm-ws-tools-modal-section">
+            <div className="pm-ws-tools-modal-rule">
+              <span className="pm-ws-eyebrow">{group}</span>
+              <hr />
+            </div>
+            <div className="pm-ws-tools-modal-grid">
+              {groupedTools(group).map((tool) => (
+                <button
+                  key={tool.id}
+                  className={`pm-ws-tools-card ${
+                    activeToolId === tool.id ? 'pm-ws-tools-card-active' : ''
+                  }`}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => onSelect(tool.id)}
+                >
+                  <span className="pm-ws-tools-card-icon">
+                    <Icon name={WORKSHOP_TOOL_ICONS[tool.id]} size={20} />
+                  </span>
+                  <span className="pm-ws-tools-card-name">{tool.label}</span>
+                  <span className="pm-ws-tools-card-desc">{tool.description}</span>
+                </button>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopToolsModal.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopToolsModal.tsx
@@ -1,3 +1,8 @@
+/**
+ * WorkshopToolsModal — the full 14-tool palette. Renders from the shared
+ * catalog so the modal cannot invent tools or drift from handler routing.
+ */
+
 import * as React from 'react';
 import { Icon } from '@components/shared/Icon';
 import { WorkshopToolId } from '@messages';
@@ -11,6 +16,7 @@ import { WORKSHOP_TOOL_ICONS } from './workshopToolIcons';
 const TOOL_GROUPS: readonly WorkshopToolGroup[] = ['Primary', 'Craft & Voice', 'Technical'];
 
 interface WorkshopToolsModalProps {
+  open: boolean;
   activeToolId: WorkshopToolId | null;
   disabled?: boolean;
   onClose: () => void;
@@ -21,18 +27,22 @@ const groupedTools = (group: WorkshopToolGroup): readonly WorkshopToolDescriptor
   WORKSHOP_TOOL_CATALOG.filter((tool) => tool.group === group);
 
 export const WorkshopToolsModal: React.FC<WorkshopToolsModalProps> = ({
+  open,
   activeToolId,
   disabled = false,
   onClose,
   onSelect
 }) => {
-  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleBackdropClick = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     if (event.target === event.currentTarget) {
       onClose();
     }
-  };
+  }, [onClose]);
 
   React.useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose();
@@ -40,7 +50,11 @@ export const WorkshopToolsModal: React.FC<WorkshopToolsModalProps> = ({
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  }, [onClose, open]);
+
+  if (!open) {
+    return null;
+  }
 
   return (
     <div className="pm-ws-modal-backdrop" role="presentation" onMouseDown={handleBackdropClick}>

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
@@ -40,7 +40,7 @@ interface ParsedVariations {
 
 const VARIATION_HEADING = /^#{2,4}\s*Variation\s+(\d+)(?:\s*[-:]\s*(.+))?\s*$/gim;
 
-const parseVariations = (content: string): ParsedVariations | null => {
+export const parseVariations = (content: string): ParsedVariations | null => {
   const matches = [...content.matchAll(VARIATION_HEADING)];
   if (matches.length < 2) {
     return null;
@@ -74,6 +74,8 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
   onCopyVariation,
   onSaveVariation
 }) => {
+  const parsedVariations = React.useMemo(() => parseVariations(turn.content), [turn.content]);
+
   if (turn.role === 'user') {
     if (turn.kind === 'message') {
       return (
@@ -90,8 +92,6 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
       </div>
     );
   }
-
-  const parsedVariations = parseVariations(turn.content);
 
   return (
     <>
@@ -113,10 +113,10 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
               <MarkdownRenderer content={parsedVariations.intro} className="pm-ws-turn-body" />
             )}
             <div className="pm-ws-var-stack">
-              {parsedVariations.variations.map((variation) => (
-                <div className="pm-ws-var-card" key={`${turn.id}-${variation.number}`}>
+              {parsedVariations.variations.map((variation, index) => (
+                <div className="pm-ws-var-card" key={`${turn.id}-${index}`}>
                   <div className="pm-ws-var-head">
-                    <span className="pm-ws-var-number">Variation {variation.number}</span>
+                    <span className="pm-ws-var-number">Variation {index + 1}</span>
                     <span className="pm-ws-pill">{variation.label}</span>
                   </div>
                   <MarkdownRenderer content={variation.content} className="pm-ws-var-text" />

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
@@ -14,14 +14,66 @@
 import * as React from 'react';
 import { Icon } from '@components/shared/Icon';
 import { MarkdownRenderer } from '@components/shared/MarkdownRenderer';
-import { WorkshopTurn } from '@messages';
+import { WorkshopToolId, WorkshopTurn } from '@messages';
+import { WorkshopQuickActionBar } from './WorkshopQuickActionBar';
 import { workshopToolIcon } from './workshopToolIcons';
 
 interface WorkshopTurnBubbleProps {
   turn: WorkshopTurn;
+  quickActionToolId: WorkshopToolId | null;
+  quickActionsDisabled?: boolean;
+  onQuickAction: (toolId: WorkshopToolId, label: string) => void;
+  onCopyVariation: (content: string, toolId: WorkshopToolId | null) => void;
+  onSaveVariation: (content: string, toolId: WorkshopToolId | null) => void;
 }
 
-export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(({ turn }) => {
+interface ParsedVariation {
+  number: string;
+  label: string;
+  content: string;
+}
+
+interface ParsedVariations {
+  intro: string;
+  variations: ParsedVariation[];
+}
+
+const VARIATION_HEADING = /^#{2,4}\s*Variation\s+(\d+)(?:\s*[-:]\s*(.+))?\s*$/gim;
+
+const parseVariations = (content: string): ParsedVariations | null => {
+  const matches = [...content.matchAll(VARIATION_HEADING)];
+  if (matches.length < 2) {
+    return null;
+  }
+
+  const variations = matches.map((match, index) => {
+    const start = (match.index ?? 0) + match[0].length;
+    const end = matches[index + 1]?.index ?? content.length;
+    return {
+      number: match[1],
+      label: match[2]?.trim() || `Option ${match[1]}`,
+      content: content.slice(start, end).trim()
+    };
+  }).filter((variation) => variation.content.length > 0);
+
+  if (variations.length < 2) {
+    return null;
+  }
+
+  return {
+    intro: content.slice(0, matches[0].index ?? 0).trim(),
+    variations
+  };
+};
+
+export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(({
+  turn,
+  quickActionToolId,
+  quickActionsDisabled = false,
+  onQuickAction,
+  onCopyVariation,
+  onSaveVariation
+}) => {
   if (turn.role === 'user') {
     if (turn.kind === 'message') {
       return (
@@ -39,21 +91,67 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
     );
   }
 
+  const parsedVariations = parseVariations(turn.content);
+
   return (
-    <div className="pm-ws-turn pm-ws-turn-assistant">
-      <div className="pm-ws-turn-head">
-        <span className="pm-ws-eyebrow">
-          <Icon name="sparkle" size={12} /> {turn.toolLabel ?? 'Follow-up'}
-        </span>
-        {turn.usage && (
-          <span className="pm-ws-turn-usage">{turn.usage.totalTokens.toLocaleString()} tokens</span>
+    <>
+      <div className="pm-ws-turn pm-ws-turn-assistant">
+        <div className="pm-ws-turn-head">
+          <span className="pm-ws-eyebrow">
+            <Icon name="sparkle" size={12} /> {turn.toolLabel ?? 'Follow-up'}
+          </span>
+          {turn.usage && (
+            <span className="pm-ws-turn-usage">{turn.usage.totalTokens.toLocaleString()} tokens</span>
+          )}
+        </div>
+        {turn.truncated && (
+          <p className="pm-ws-turn-truncated">Response hit the max-token limit and was truncated.</p>
+        )}
+        {parsedVariations ? (
+          <div className="pm-ws-turn-body">
+            {parsedVariations.intro && (
+              <MarkdownRenderer content={parsedVariations.intro} className="pm-ws-turn-body" />
+            )}
+            <div className="pm-ws-var-stack">
+              {parsedVariations.variations.map((variation) => (
+                <div className="pm-ws-var-card" key={`${turn.id}-${variation.number}`}>
+                  <div className="pm-ws-var-head">
+                    <span className="pm-ws-var-number">Variation {variation.number}</span>
+                    <span className="pm-ws-pill">{variation.label}</span>
+                  </div>
+                  <MarkdownRenderer content={variation.content} className="pm-ws-var-text" />
+                  <div className="pm-ws-var-actions">
+                    <button
+                      className="pm-ws-var-action"
+                      type="button"
+                      onClick={() => onCopyVariation(variation.content, quickActionToolId)}
+                    >
+                      <Icon name="copy" size={13} /> Copy
+                    </button>
+                    <button
+                      className="pm-ws-var-action"
+                      type="button"
+                      onClick={() => onSaveVariation(variation.content, quickActionToolId)}
+                    >
+                      <Icon name="save" size={13} /> Save to notes
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <MarkdownRenderer content={turn.content} className="pm-ws-turn-body" />
         )}
       </div>
-      {turn.truncated && (
-        <p className="pm-ws-turn-truncated">Response hit the max-token limit and was truncated.</p>
+      {quickActionToolId && (
+        <WorkshopQuickActionBar
+          toolId={quickActionToolId}
+          disabled={quickActionsDisabled}
+          onAction={onQuickAction}
+        />
       )}
-      <MarkdownRenderer content={turn.content} className="pm-ws-turn-body" />
-    </div>
+    </>
   );
 });
 

--- a/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
@@ -60,6 +60,8 @@ export interface WorkshopState {
   hasConversation: boolean;
   /** True when the composer can send right now. */
   canFollowUp: boolean;
+  /** Last selected tool/lens, retained after completion for reload restore. */
+  selectedToolId: WorkshopToolId | null;
   /** Tool of the in-flight run (host truth via session state / live events). */
   activeToolId: WorkshopToolId | null;
   /** True while a run is in flight (tool palette disables on this). */
@@ -82,6 +84,7 @@ export interface WorkshopActions {
   pinExcerpt: (text: string, sourceUri?: string, relativePath?: string) => void;
   pinFromFile: () => void;
   runTool: (toolId: WorkshopToolId) => void;
+  quickAction: (toolId: WorkshopToolId, label: string) => void;
   sendMessage: (text: string) => void;
   cancelRun: () => void;
   resetSession: () => void;
@@ -117,6 +120,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
   const [turns, setTurns] = React.useState<WorkshopTurn[]>([]);
   const [totalTurns, setTotalTurns] = React.useState(0);
   const [hasConversation, setHasConversation] = React.useState(false);
+  const [selectedToolId, setSelectedToolId] = React.useState<WorkshopToolId | null>(null);
   const [activeToolId, setActiveToolId] = React.useState<WorkshopToolId | null>(null);
   const [statusMessage, setStatusMessage] = React.useState('');
   const [tickerMessage, setTickerMessage] = React.useState('');
@@ -166,6 +170,14 @@ export const useWorkshop = (): UseWorkshopReturn => {
     [post]
   );
 
+  const quickAction = React.useCallback(
+    (toolId: WorkshopToolId, label: string) => {
+      setErrorMessage('');
+      post(MessageType.WORKSHOP_QUICK_ACTION, { toolId, label });
+    },
+    [post]
+  );
+
   const sendMessage = React.useCallback(
     (text: string) => {
       setErrorMessage('');
@@ -208,6 +220,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
       setExcerpt(session.excerpt ?? null);
       setTotalTurns(session.totalTurns);
       setHasConversation(session.hasConversation);
+      setSelectedToolId(session.selectedToolId ?? null);
       setActiveToolId(session.activeToolId ?? null);
       setTurns((prev) => {
         if (session.truncatedTurns === 0) {
@@ -332,6 +345,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
     hiddenTurns,
     hasConversation,
     canFollowUp,
+    selectedToolId,
     activeToolId,
     isRunning,
     statusMessage,
@@ -350,6 +364,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
     pinExcerpt,
     pinFromFile,
     runTool,
+    quickAction,
     sendMessage,
     cancelRun,
     resetSession,

--- a/packages/core/src/presentation/webview/hooks/useAppMessageRouter.ts
+++ b/packages/core/src/presentation/webview/hooks/useAppMessageRouter.ts
@@ -173,9 +173,10 @@ export const buildAppMessageRoutes = (deps: AppMessageRouterDeps): MessageHandle
       dictionary.handleClearTransientApiKeyWarning(msg);
       context.handleClearTransientApiKeyWarning(msg);
     },
-    // The save itself is the user-visible feedback; there's no webview action on
-    // success today. Intentionally received-and-ignored (was a stray console.log
-    // promoted into a permanent module by the App.tsx lift — see PR-60B review).
+    // Copy/save success are structured signals for surfaces that need them
+    // (Workshop toasts). The sidebar already reflects copy through STATUS and
+    // has no save action today. Intentionally received-and-ignored here.
+    [MessageType.COPY_RESULT_SUCCESS]: () => { /* no-op: sidebar copy success needs no webview action */ },
     [MessageType.SAVE_RESULT_SUCCESS]: () => { /* no-op: save success needs no webview action */ },
     [MessageType.ERROR]: (msg) => {
       const { source, message: errorMessage } = msg.payload;

--- a/packages/core/src/presentation/webview/index.css
+++ b/packages/core/src/presentation/webview/index.css
@@ -1993,6 +1993,12 @@ select:focus {
 .analysis-buttons-head .analysis-section-header {
   margin: 0;
 }
+.analysis-buttons-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
 .all-tools-button {
   padding: 6px 11px;
   font-size: 12px;

--- a/packages/core/src/presentation/webview/index.css
+++ b/packages/core/src/presentation/webview/index.css
@@ -582,6 +582,26 @@ body {
   margin: 6px 0 14px;
   color: var(--pm-text);
 }
+.assistant-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 6px 0 14px;
+}
+.assistant-title-row > h2 {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--pm-text);
+  min-width: 0;
+}
+.workshop-launch-button {
+  flex-shrink: 0;
+  padding: 7px 11px;
+  font-size: 12px;
+}
 .tab-content > h3 {
   font-size: 14px;
   font-weight: 700;

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -410,6 +410,13 @@
   line-height: 1.6;
   margin: 0;
 }
+[data-pm-surface="workshop"] .pm-ws-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 16px;
+}
 
 /* ---------- Excerpt editor (Sprint 2: rail-driven pinning) ---------- */
 [data-pm-surface="workshop"] .pm-ws-excerpt {
@@ -542,6 +549,102 @@
   border-color: var(--pm-border-2);
 }
 
+/* Quick actions */
+[data-pm-surface="workshop"] .pm-ws-qbar {
+  max-width: 860px;
+  margin-top: -14px;
+  padding: 0 2px 2px;
+}
+[data-pm-surface="workshop"] .pm-ws-qbar-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--pm-muted);
+  margin-bottom: 9px;
+}
+[data-pm-surface="workshop"] .pm-ws-qbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+[data-pm-surface="workshop"] .pm-ws-qa {
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-r-pill);
+  background: var(--pm-surface-2);
+  color: var(--pm-text-2);
+  font-family: var(--pm-sans);
+  font-size: 12px;
+  padding: 7px 11px;
+}
+[data-pm-surface="workshop"] .pm-ws-qa-primary {
+  color: #fff;
+  border-color: var(--pm-accent-lo);
+  background: linear-gradient(180deg, var(--pm-accent-hi), var(--pm-accent-lo));
+}
+[data-pm-surface="workshop"] .pm-ws-qa:not(:disabled):hover {
+  color: var(--pm-text);
+  border-color: var(--pm-border-2);
+  background: var(--pm-surface-3);
+}
+
+/* Variation cards */
+[data-pm-surface="workshop"] .pm-ws-var-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+[data-pm-surface="workshop"] .pm-ws-var-card {
+  background: var(--pm-inset);
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-r-tile);
+  padding: 12px;
+}
+[data-pm-surface="workshop"] .pm-ws-var-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+[data-pm-surface="workshop"] .pm-ws-var-number {
+  font-family: var(--pm-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pm-muted);
+}
+[data-pm-surface="workshop"] .pm-ws-var-text {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--pm-text-2);
+}
+[data-pm-surface="workshop"] .pm-ws-var-text p {
+  margin: 6px 0;
+}
+[data-pm-surface="workshop"] .pm-ws-var-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+[data-pm-surface="workshop"] .pm-ws-var-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-r-input);
+  background: var(--pm-surface-2);
+  color: var(--pm-muted);
+  font-family: var(--pm-sans);
+  font-size: 12px;
+  padding: 6px 9px;
+}
+[data-pm-surface="workshop"] .pm-ws-var-action:hover {
+  color: var(--pm-text);
+  border-color: var(--pm-border-2);
+}
+
 /* Error banner (dismissible, role=alert) */
 [data-pm-surface="workshop"] .pm-ws-error {
   display: flex;
@@ -636,9 +739,16 @@
   gap: 6px;
   font-size: 12px;
   color: var(--pm-muted);
+  font-family: var(--pm-sans);
+  background: transparent;
   border: 1px solid var(--pm-border);
   border-radius: var(--pm-r-pill);
   padding: 6px 11px;
+}
+[data-pm-surface="workshop"] .pm-ws-comp-pill:not(:disabled):hover,
+[data-pm-surface="workshop"] .pm-ws-comp-add:not(:disabled):hover {
+  color: var(--pm-text);
+  border-color: var(--pm-border-2);
 }
 [data-pm-surface="workshop"] .pm-ws-comp-send {
   width: 36px;
@@ -691,4 +801,133 @@
   border: 1px dashed var(--pm-border-2);
   border-radius: var(--pm-r-pill);
   padding: 5px 12px;
+}
+
+/* Tools modal */
+[data-pm-surface="workshop"] .pm-ws-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.48);
+}
+[data-pm-surface="workshop"] .pm-ws-tools-modal {
+  width: min(760px, 100%);
+  max-height: min(760px, 92vh);
+  overflow-y: auto;
+  background: var(--pm-surface);
+  border: 1px solid var(--pm-border-2);
+  border-radius: var(--pm-r-card);
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.55);
+  padding: 20px;
+}
+[data-pm-surface="workshop"] .pm-ws-tools-modal-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
+}
+[data-pm-surface="workshop"] .pm-ws-tools-modal-head h2 {
+  font-size: 20px;
+  line-height: 1.2;
+  margin: 7px 0 4px;
+}
+[data-pm-surface="workshop"] .pm-ws-tools-modal-head p {
+  color: var(--pm-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 0;
+}
+[data-pm-surface="workshop"] .pm-ws-modal-close {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-r-input);
+  background: transparent;
+  color: var(--pm-muted);
+}
+[data-pm-surface="workshop"] .pm-ws-tools-modal-rule {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 14px 0 9px;
+}
+[data-pm-surface="workshop"] .pm-ws-tools-modal-rule hr {
+  flex: 1;
+  border: 0;
+  border-top: 1px solid var(--pm-border);
+}
+[data-pm-surface="workshop"] .pm-ws-tools-modal-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+[data-pm-surface="workshop"] .pm-ws-tools-card {
+  min-height: 122px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  text-align: left;
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-r-tile);
+  background: var(--pm-surface-2);
+  color: var(--pm-text-2);
+  font-family: var(--pm-sans);
+  padding: 12px;
+}
+[data-pm-surface="workshop"] .pm-ws-tools-card:not(:disabled):hover,
+[data-pm-surface="workshop"] .pm-ws-tools-card-active {
+  color: var(--pm-text);
+  border-color: var(--pm-accent-lo);
+  background: var(--pm-accent-soft);
+}
+[data-pm-surface="workshop"] .pm-ws-tools-card-icon {
+  color: var(--pm-accent-hi);
+}
+[data-pm-surface="workshop"] .pm-ws-tools-card-name {
+  font-size: 13px;
+  font-weight: 700;
+}
+[data-pm-surface="workshop"] .pm-ws-tools-card-desc {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--pm-muted);
+}
+
+/* Status + toast */
+[data-pm-surface="workshop"] .pm-ws-status-ticker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 33px 12px;
+  margin-top: -12px;
+  color: var(--pm-muted);
+  font-family: var(--pm-mono);
+  font-size: 11px;
+}
+[data-pm-surface="workshop"] .pm-ws-toast {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(460px, calc(100vw - 48px));
+  color: var(--pm-text);
+  background: var(--pm-surface-3);
+  border: 1px solid var(--pm-border-2);
+  border-radius: var(--pm-r-pill);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.5);
+  padding: 9px 13px;
+  font-size: 12.5px;
+}
+[data-pm-surface="workshop"] .pm-ws-toast-error {
+  border-color: var(--pm-accent-lo);
+  background: #3a1c16;
 }

--- a/packages/core/src/shared/constants/resultToolNames.ts
+++ b/packages/core/src/shared/constants/resultToolNames.ts
@@ -1,0 +1,49 @@
+/**
+ * Result tool-name contracts for copy/save flows.
+ *
+ * These strings are wire values sent by webviews and interpreted by
+ * FileOperationsHandler. Keep the mapping here so Workshop variation actions
+ * and host-side file naming cannot drift independently.
+ */
+
+import { WorkshopToolId } from '../types/messages/workshop';
+import { WORKSHOP_TOOL_CATALOG } from './workshopTools';
+
+export const PROSE_RESULT_TOOL_NAME = 'prose_analysis';
+export const DIALOGUE_RESULT_TOOL_NAME = 'dialogue_analysis';
+
+export const WORKSHOP_RESULT_TOOL_NAMES: Readonly<Record<WorkshopToolId, string>> =
+  WORKSHOP_TOOL_CATALOG.reduce((toolNames, tool) => {
+    toolNames[tool.id] =
+      tool.id === 'dialogue'
+        ? DIALOGUE_RESULT_TOOL_NAME
+        : tool.id === 'prose'
+          ? PROSE_RESULT_TOOL_NAME
+          : `writing_tools_${tool.id}`;
+    return toolNames;
+  }, {} as Record<WorkshopToolId, string>);
+
+export const ASSISTANT_RESULT_FILE_PREFIXES: Readonly<Record<string, string>> = {
+  [PROSE_RESULT_TOOL_NAME]: 'excerpt-assistant-prose-',
+  [DIALOGUE_RESULT_TOOL_NAME]: 'excerpt-assistant-dialog-beats-',
+  [WORKSHOP_RESULT_TOOL_NAMES.cliche]: 'cliche-analysis-',
+  [WORKSHOP_RESULT_TOOL_NAMES.choreography]: 'choreography-analysis-',
+  [WORKSHOP_RESULT_TOOL_NAMES.continuity]: 'continuity-check-',
+  [WORKSHOP_RESULT_TOOL_NAMES['decision-points']]: 'decision-points-analysis-',
+  [WORKSHOP_RESULT_TOOL_NAMES.editor]: 'editor-',
+  [WORKSHOP_RESULT_TOOL_NAMES.fresh]: 'engagement-check-',
+  [WORKSHOP_RESULT_TOOL_NAMES.gestures]: 'gesture-analysis-',
+  [WORKSHOP_RESULT_TOOL_NAMES.placeholders]: 'placeholder-analysis-',
+  [WORKSHOP_RESULT_TOOL_NAMES.repetition]: 'repetition-analysis-',
+  [WORKSHOP_RESULT_TOOL_NAMES['show-and-tell']]: 'show-and-tell-analysis-',
+  [WORKSHOP_RESULT_TOOL_NAMES['stock-and-signature']]: 'stock-signature-analysis-',
+  [WORKSHOP_RESULT_TOOL_NAMES.style]: 'style-consistency-'
+};
+
+export function resultToolNameForWorkshopTool(toolId: WorkshopToolId): string {
+  return WORKSHOP_RESULT_TOOL_NAMES[toolId];
+}
+
+export function assistantResultFilePrefix(toolName: string): string | undefined {
+  return ASSISTANT_RESULT_FILE_PREFIXES[toolName];
+}

--- a/packages/core/src/shared/constants/workshopQuickActions.ts
+++ b/packages/core/src/shared/constants/workshopQuickActions.ts
@@ -40,11 +40,9 @@ const makeActions = (
     primary: index === 0,
     prompt:
       prompts[label] ??
-      (label.toLowerCase().includes('variation')
-        ? variationPrompt(toolId, label)
-        : label.toLowerCase() === 'keep as-is'
-          ? keepAsIsPrompt(toolId)
-          : `${label}. Stay in the ${workshopToolLabel(toolId)} lens and answer as a practical follow-up on the pinned excerpt.`)
+      (label === 'Keep as-is'
+        ? keepAsIsPrompt(toolId)
+        : `${label}. Stay in the ${workshopToolLabel(toolId)} lens and answer as a practical follow-up on the pinned excerpt.`)
   }));
 
 const SPECIFIC_ACTIONS: Partial<Record<WorkshopToolId, readonly WorkshopQuickAction[]>> = {
@@ -158,9 +156,19 @@ const SPECIFIC_ACTIONS: Partial<Record<WorkshopToolId, readonly WorkshopQuickAct
 
 const FALLBACK_LABELS = ['Generate 3 variations', 'Go deeper', 'Try another angle', 'Keep as-is'] as const;
 
+const fallbackPrompts = (toolId: WorkshopToolId): Record<typeof FALLBACK_LABELS[number], string> => ({
+  'Generate 3 variations': variationPrompt(toolId, 'Generate 3 variations'),
+  'Go deeper':
+    `Go deeper on the most important issue in this excerpt through the ${workshopToolLabel(toolId)} lens. Give one concrete revision path.`,
+  'Try another angle':
+    `Try another practical angle on this excerpt through the ${workshopToolLabel(toolId)} lens. Focus on a different craft move than your previous answer.`,
+  'Keep as-is': keepAsIsPrompt(toolId)
+});
+
 export const WORKSHOP_QUICK_ACTIONS_BY_TOOL: Readonly<Record<WorkshopToolId, readonly WorkshopQuickAction[]>> =
   WORKSHOP_TOOL_CATALOG.reduce((actionsByTool, tool) => {
-    actionsByTool[tool.id] = SPECIFIC_ACTIONS[tool.id] ?? makeActions(tool.id, FALLBACK_LABELS);
+    actionsByTool[tool.id] =
+      SPECIFIC_ACTIONS[tool.id] ?? makeActions(tool.id, FALLBACK_LABELS, fallbackPrompts(tool.id));
     return actionsByTool;
   }, {} as Record<WorkshopToolId, readonly WorkshopQuickAction[]>);
 

--- a/packages/core/src/shared/constants/workshopQuickActions.ts
+++ b/packages/core/src/shared/constants/workshopQuickActions.ts
@@ -1,0 +1,176 @@
+/**
+ * Deterministic Workshop quick actions, ported from the approved Direction B
+ * prototype (`docs/design/pm-direction-b.js` ASSIST table). Labels are UI
+ * copy, prompts are the follow-up text sent into the retained conversation.
+ */
+
+import { WorkshopToolId } from '../types/messages/workshop';
+import { WORKSHOP_TOOL_CATALOG, workshopToolLabel } from './workshopTools';
+
+export interface WorkshopQuickAction {
+  label: string;
+  prompt: string;
+  primary?: boolean;
+}
+
+const variationPrompt = (toolId: WorkshopToolId, label: string): string =>
+  `${label}. Return exactly three options in this markdown format:
+
+### Variation 1 - [short label]
+[the rewritten passage only]
+
+### Variation 2 - [short label]
+[the rewritten passage only]
+
+### Variation 3 - [short label]
+[the rewritten passage only]
+
+Keep the variations focused on the ${workshopToolLabel(toolId)} lens.`;
+
+const keepAsIsPrompt = (toolId: WorkshopToolId): string =>
+  `Keep this excerpt as-is for now. Briefly name what is already working through the ${workshopToolLabel(toolId)} lens, then stop.`;
+
+const makeActions = (
+  toolId: WorkshopToolId,
+  labels: readonly string[],
+  prompts: Partial<Record<string, string>> = {}
+): readonly WorkshopQuickAction[] =>
+  labels.map((label, index) => ({
+    label,
+    primary: index === 0,
+    prompt:
+      prompts[label] ??
+      (label.toLowerCase().includes('variation')
+        ? variationPrompt(toolId, label)
+        : label.toLowerCase() === 'keep as-is'
+          ? keepAsIsPrompt(toolId)
+          : `${label}. Stay in the ${workshopToolLabel(toolId)} lens and answer as a practical follow-up on the pinned excerpt.`)
+  }));
+
+const SPECIFIC_ACTIONS: Partial<Record<WorkshopToolId, readonly WorkshopQuickAction[]>> = {
+  dialogue: makeActions('dialogue', [
+    'Generate 3 tighter variations',
+    'Add a gesture beat',
+    'Show & Tell pass',
+    'Flag clichés',
+    'Keep as-is'
+  ], {
+    'Generate 3 tighter variations': variationPrompt('dialogue', 'Generate 3 tighter variations'),
+    'Add a gesture beat':
+      'Add one gesture beat that can replace or deepen the weakest dialogue beat. Keep it specific to the pinned excerpt.',
+    'Show & Tell pass':
+      'Run a Show & Tell pass on this same excerpt. Point out where the passage summarizes, where it dramatizes, and what one line-level change would improve the balance.',
+    'Flag clichés':
+      'Flag any cliches, stock gestures, or overfamiliar phrasing in this excerpt. Suggest fresher alternatives without flattening the voice.'
+  }),
+  prose: makeActions('prose', [
+    'Rewrite for flow',
+    'Strengthen the verbs',
+    '3 line-level variations',
+    'Tighten by 20%',
+    'Keep as-is'
+  ], {
+    '3 line-level variations': variationPrompt('prose', '3 line-level variations'),
+    'Rewrite for flow':
+      'Rewrite the excerpt for smoother sentence flow while preserving meaning, voice, and point of view.',
+    'Strengthen the verbs':
+      'Identify the softest verbs in the excerpt and suggest stronger replacements. Include a revised version using the best choices.',
+    'Tighten by 20%':
+      'Tighten the excerpt by roughly 20% while preserving the essential beat and character intent.'
+  }),
+  gestures: makeActions('gestures', [
+    'Vary the gesture',
+    'Make it subtler',
+    'Tie to voice guide',
+    '3 variations',
+    'Keep as-is'
+  ], {
+    '3 variations': variationPrompt('gestures', '3 variations'),
+    'Vary the gesture':
+      'Replace the weakest or most repeated gesture with a fresher physical beat. Explain why the new gesture carries the subtext better.',
+    'Make it subtler':
+      'Make the gesture work subtler and less explanatory while preserving the emotional signal.',
+    'Tie to voice guide':
+      'Reframe the gesture so it feels specific to the character voice implied by this excerpt, not a generic reaction.'
+  }),
+  choreography: makeActions('choreography', [
+    'Map the blocking',
+    'Fix the spatial jump',
+    'Slow the motion down',
+    '3 variations',
+    'Keep as-is'
+  ], {
+    '3 variations': variationPrompt('choreography', '3 variations'),
+    'Map the blocking':
+      'Map the physical blocking in the excerpt. Name where each person seems to be, what movement is implied, and what is unclear.',
+    'Fix the spatial jump':
+      'Revise the excerpt to fix any spatial jump or teleporting movement while keeping the scene momentum.',
+    'Slow the motion down':
+      'Slow the movement by one beat so the choreography reads clearly without overexplaining it.'
+  }),
+  cliche: makeActions('cliche', [
+    'Replace each flag',
+    'Suggest fresh images',
+    'Show only flagged lines',
+    'Keep voice intact',
+    'Keep as-is'
+  ], {
+    'Replace each flag':
+      'For each cliche, stock phrase, or overfamiliar beat you flagged, provide a fresher replacement and explain the improvement in one sentence.',
+    'Suggest fresh images':
+      'Suggest fresher images or physical details for this excerpt while preserving the intended mood and genre register.',
+    'Show only flagged lines':
+      'Show only the lines or phrases that deserve attention, with a concise reason beside each.',
+    'Keep voice intact':
+      'Revise the flagged phrasing while keeping the authorial voice intact. Avoid polishing away personality.'
+  }),
+  repetition: makeActions('repetition', [
+    'List all echoes',
+    'Rewrite to vary',
+    'Keep intentional repeats',
+    '3 variations',
+    'Keep as-is'
+  ], {
+    '3 variations': variationPrompt('repetition', '3 variations'),
+    'List all echoes':
+      'List repeated words, sentence structures, gestures, and rhythmic echoes in the excerpt. Separate intentional from accidental repetition.',
+    'Rewrite to vary':
+      'Rewrite the excerpt to reduce accidental repetition while preserving any repetition that feels intentional.',
+    'Keep intentional repeats':
+      'Name which repetitions are worth keeping and why, then suggest changes only for the accidental ones.'
+  }),
+  'show-and-tell': makeActions('show-and-tell', [
+    'Dramatize the summary',
+    'Find more tell',
+    'Balance the ratio',
+    '3 variations',
+    'Keep as-is'
+  ], {
+    '3 variations': variationPrompt('show-and-tell', '3 variations'),
+    'Dramatize the summary':
+      'Choose the most summarized beat in the excerpt and dramatize it on the page. Keep the rewrite compact.',
+    'Find more tell':
+      'Find any telling in the excerpt that might deserve dramatization. If telling is the right choice, say why.',
+    'Balance the ratio':
+      'Assess the show-versus-tell balance in the excerpt and recommend one targeted line-level adjustment.'
+  })
+};
+
+const FALLBACK_LABELS = ['Generate 3 variations', 'Go deeper', 'Try another angle', 'Keep as-is'] as const;
+
+export const WORKSHOP_QUICK_ACTIONS_BY_TOOL: Readonly<Record<WorkshopToolId, readonly WorkshopQuickAction[]>> =
+  WORKSHOP_TOOL_CATALOG.reduce((actionsByTool, tool) => {
+    actionsByTool[tool.id] = SPECIFIC_ACTIONS[tool.id] ?? makeActions(tool.id, FALLBACK_LABELS);
+    return actionsByTool;
+  }, {} as Record<WorkshopToolId, readonly WorkshopQuickAction[]>);
+
+export function workshopQuickActionsForTool(toolId: WorkshopToolId): readonly WorkshopQuickAction[] {
+  return WORKSHOP_QUICK_ACTIONS_BY_TOOL[toolId];
+}
+
+export function workshopQuickActionPrompt(
+  toolId: WorkshopToolId,
+  label: string
+): string | undefined {
+  return WORKSHOP_QUICK_ACTIONS_BY_TOOL[toolId].find((action) => action.label === label)?.prompt;
+}

--- a/packages/core/src/shared/constants/workshopTools.ts
+++ b/packages/core/src/shared/constants/workshopTools.ts
@@ -18,23 +18,24 @@ export interface WorkshopToolDescriptor {
   id: WorkshopToolId;
   label: string;
   group: WorkshopToolGroup;
+  description: string;
 }
 
 export const WORKSHOP_TOOL_CATALOG: readonly WorkshopToolDescriptor[] = [
-  { id: 'dialogue', label: 'Dialogue & Beats', group: 'Primary' },
-  { id: 'prose', label: 'Prose', group: 'Primary' },
-  { id: 'gestures', label: 'Gestures', group: 'Primary' },
-  { id: 'cliche', label: 'Cliché', group: 'Craft & Voice' },
-  { id: 'repetition', label: 'Repetition', group: 'Craft & Voice' },
-  { id: 'decision-points', label: 'Decision Points', group: 'Craft & Voice' },
-  { id: 'show-and-tell', label: 'Show & Tell', group: 'Craft & Voice' },
-  { id: 'choreography', label: 'Choreography', group: 'Craft & Voice' },
-  { id: 'stock-and-signature', label: 'Stock & Signature', group: 'Craft & Voice' },
-  { id: 'placeholders', label: 'Placeholders', group: 'Craft & Voice' },
-  { id: 'style', label: 'Style', group: 'Technical' },
-  { id: 'editor', label: 'Editor', group: 'Technical' },
-  { id: 'continuity', label: 'Continuity', group: 'Technical' },
-  { id: 'fresh', label: 'Fresh', group: 'Technical' },
+  { id: 'dialogue', label: 'Dialogue & Beats', group: 'Primary', description: 'Cadence, subtext, and the microbeats between lines.' },
+  { id: 'prose', label: 'Prose', group: 'Primary', description: 'Line-level rewrite suggestions for flow and clarity.' },
+  { id: 'gestures', label: 'Gestures', group: 'Primary', description: 'Body language — variety, repetition, and intent.' },
+  { id: 'cliche', label: 'Cliché', group: 'Craft & Voice', description: 'Surface tired phrasings and stock images.' },
+  { id: 'repetition', label: 'Repetition', group: 'Craft & Voice', description: 'Echoed words, structures, and tics across the passage.' },
+  { id: 'decision-points', label: 'Decision Points', group: 'Craft & Voice', description: 'Moments where a character chooses — and the stakes.' },
+  { id: 'show-and-tell', label: 'Show & Tell', group: 'Craft & Voice', description: 'Where you summarize vs. dramatize on the page.' },
+  { id: 'choreography', label: 'Choreography', group: 'Craft & Voice', description: 'Spatial logic of movement through a scene.' },
+  { id: 'stock-and-signature', label: 'Stock & Signature', group: 'Craft & Voice', description: 'Generic beats vs. your distinctive authorial moves.' },
+  { id: 'placeholders', label: 'Placeholders', group: 'Craft & Voice', description: 'Find TODOs, [brackets], and unfinished seams.' },
+  { id: 'style', label: 'Style', group: 'Technical', description: 'Weak verbs, adverbs, filler, and passive voice.' },
+  { id: 'editor', label: 'Editor', group: 'Technical', description: 'A holistic developmental editor pass.' },
+  { id: 'continuity', label: 'Continuity', group: 'Technical', description: 'Contradictions against characters and prior chapters.' },
+  { id: 'fresh', label: 'Fresh', group: 'Technical', description: 'Fresh-eyes reactions, as a first-time reader.' },
 ];
 
 const LABELS_BY_ID: ReadonlyMap<WorkshopToolId, string> = new Map(

--- a/packages/core/src/shared/types/messages/base.ts
+++ b/packages/core/src/shared/types/messages/base.ts
@@ -46,6 +46,7 @@ export enum MessageType {
   // UI state messages
   TAB_CHANGED = 'tab_changed',
   SELECTION_UPDATED = 'selection_updated',
+  OPEN_WORKSHOP = 'open_workshop',
 
   // Configuration messages
   REQUEST_MODEL_DATA = 'request_model_data',
@@ -105,6 +106,7 @@ export enum MessageType {
 
   // Workshop editor tab (ADR 2026-07-03; Sprint 2 session spine, Sprint 3 multi-turn)
   WORKSHOP_RUN_TOOL = 'workshop_run_tool',
+  WORKSHOP_QUICK_ACTION = 'workshop_quick_action',
   WORKSHOP_SEND_MESSAGE = 'workshop_send_message',
   WORKSHOP_SET_EXCERPT = 'workshop_set_excerpt',
   WORKSHOP_PICK_EXCERPT_FILE = 'workshop_pick_excerpt_file',

--- a/packages/core/src/shared/types/messages/base.ts
+++ b/packages/core/src/shared/types/messages/base.ts
@@ -38,6 +38,7 @@ export enum MessageType {
   SEARCH_RESULT = 'search_result',
   DICTIONARY_RESULT = 'dictionary_result',
   CONTEXT_RESULT = 'context_result',
+  COPY_RESULT_SUCCESS = 'copy_result_success',
   SAVE_RESULT_SUCCESS = 'save_result_success',
   SELECTION_DATA = 'selection_data',
   ERROR = 'error',

--- a/packages/core/src/shared/types/messages/error.ts
+++ b/packages/core/src/shared/types/messages/error.ts
@@ -56,6 +56,7 @@ export type ErrorSource =
   | 'ui.docs'
   | 'ui.resource'
   | 'ui.selection'
+  | 'ui.workshop'
 
   // File operations
   | 'file_ops.copy'
@@ -64,6 +65,7 @@ export type ErrorSource =
   // Workshop editor tab
   | 'workshop'
   | 'workshop.run_tool'
+  | 'workshop.quick_action'
   | 'workshop.send_message'
 
   // Unknown/legacy (fallback)

--- a/packages/core/src/shared/types/messages/index.ts
+++ b/packages/core/src/shared/types/messages/index.ts
@@ -95,6 +95,7 @@ import {
   SelectionUpdatedMessage,
   OpenSettingsMessage,
   OpenSettingsToggleMessage,
+  OpenWorkshopMessage,
   WebviewErrorMessage
 } from './ui';
 import { ErrorMessage } from './error';
@@ -121,6 +122,7 @@ import {
 } from './streaming';
 import {
   WorkshopRunToolMessage,
+  WorkshopQuickActionMessage,
   WorkshopSendMessageMessage,
   WorkshopSetExcerptMessage,
   WorkshopPickExcerptFileMessage,
@@ -164,6 +166,7 @@ export type WebviewToExtensionMessage =
   | UpdateApiKeyMessage
   | DeleteApiKeyMessage
   | WebviewErrorMessage
+  | OpenWorkshopMessage
   | FastGenerateDictionaryMessage
   | CancelAnalysisRequestMessage
   | CancelDictionaryRequestMessage
@@ -171,6 +174,7 @@ export type WebviewToExtensionMessage =
   | CancelCategorySearchRequestMessage
   | CancelWorkshopRequestMessage
   | WorkshopRunToolMessage
+  | WorkshopQuickActionMessage
   | WorkshopSendMessageMessage
   | WorkshopSetExcerptMessage
   | WorkshopPickExcerptFileMessage

--- a/packages/core/src/shared/types/messages/index.ts
+++ b/packages/core/src/shared/types/messages/index.ts
@@ -107,6 +107,7 @@ import {
 } from './accountBalance';
 import {
   CopyResultMessage,
+  CopyResultSuccessMessage,
   SaveResultMessage,
   SaveResultSuccessMessage
 } from './results';
@@ -188,6 +189,7 @@ export type ExtensionToWebviewMessage =
   | CategorySearchResultMessage
   | DictionaryResultMessage
   | ContextResultMessage
+  | CopyResultSuccessMessage
   | SaveResultSuccessMessage
   | SettingsDataMessage
   | OpenSettingsMessage

--- a/packages/core/src/shared/types/messages/results.ts
+++ b/packages/core/src/shared/types/messages/results.ts
@@ -31,6 +31,14 @@ export interface CopyResultMessage extends MessageEnvelope<CopyResultPayload> {
   type: MessageType.COPY_RESULT;
 }
 
+export interface CopyResultSuccessPayload {
+  toolName: string;
+}
+
+export interface CopyResultSuccessMessage extends MessageEnvelope<CopyResultSuccessPayload> {
+  type: MessageType.COPY_RESULT_SUCCESS;
+}
+
 export interface SaveResultPayload {
   toolName: string;
   content: string;

--- a/packages/core/src/shared/types/messages/ui.ts
+++ b/packages/core/src/shared/types/messages/ui.ts
@@ -95,6 +95,10 @@ export interface OpenSettingsToggleMessage extends MessageEnvelope<Record<string
   type: MessageType.OPEN_SETTINGS_TOGGLE;
 }
 
+export interface OpenWorkshopMessage extends MessageEnvelope<Record<string, never>> {
+  type: MessageType.OPEN_WORKSHOP;
+}
+
 // Webview diagnostics → extension output channel
 export interface WebviewErrorPayload {
   message: string;

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -103,6 +103,8 @@ export interface WorkshopSessionSnapshot {
    * continue — the composer's enablement signal.
    */
   hasConversation: boolean;
+  /** Last selected tool/lens, retained after a completed run for UI restore. */
+  selectedToolId?: WorkshopToolId;
   /** Tool currently running, if any. */
   activeToolId?: WorkshopToolId;
   /** Streaming requestId of the in-flight run, if any (stream reattach after reload). */
@@ -120,6 +122,22 @@ export interface WorkshopRunToolPayload {
 
 export interface WorkshopRunToolMessage extends MessageEnvelope<WorkshopRunToolPayload> {
   type: MessageType.WORKSHOP_RUN_TOOL;
+}
+
+export interface WorkshopQuickActionPayload {
+  /** Tool context that owns this deterministic action label. */
+  toolId: WorkshopToolId;
+  /** One of the static labels from WORKSHOP_QUICK_ACTIONS_BY_TOOL. */
+  label: string;
+}
+
+/**
+ * Deterministic quick action. The webview sends the label the user clicked;
+ * the handler resolves it to the static prompt template and runs the existing
+ * retained-conversation follow-up path.
+ */
+export interface WorkshopQuickActionMessage extends MessageEnvelope<WorkshopQuickActionPayload> {
+  type: MessageType.WORKSHOP_QUICK_ACTION;
 }
 
 /** Free-text follow-up: continues the session's retained conversation. */


### PR DESCRIPTION
## Sprint 04 — Actions & Polish

Epic: `.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md`  
Sprint doc: `.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/04-actions-polish.md`  
Base: `epic/workshop-editor-tab` ← head: `feat/workshop-s4-actions-polish`

This finishes the Workshop affordance layer from the approved Direction B prototype: deterministic quick actions, the all-tools palette, variation cards, toasts, empty state, status polish, reload/reopen hardening, and the sidebar entry point.

## What changed

- Added `WORKSHOP_QUICK_ACTION` and a deterministic shared quick-action map ported from the prototype's `ASSIST` table.
- Routed quick actions through the existing Sprint 03 retained-conversation continuation path. The thread displays the clicked label; the model receives the fuller static prompt template.
- Added contextual quick-action bars below assistant turns.
- Added the Workshop 14-tool modal/palette and wired the rail/composer placeholders to it.
- Added variation-card rendering for strict `### Variation N - Label` markdown, with Copy and Save to notes actions through existing file-ops messages.
- Added Workshop toasts for copy/save/error acknowledgements.
- Added a richer welcome/empty state and visible status ticker.
- Added `selectedToolId` to the host-side Workshop snapshot so reload/reopen restores the active lens without falsely marking a completed run as active.
- Added a sidebar Assistant-tab `Workshop` button via an injected UI action; concrete VS Code command execution remains in the adapter/composition-root side.
- Filed parked follow-ups for apply-to-draft, WebviewPanelSerializer, sidebar reskin, Workshop model browser, and branch board.

## Guardrails held

- `packages/core` stays VS Code-module-free.
- No new concrete service construction moved into handlers/providers.
- Quick-action labels/prompts are deterministic UI/code, not model-generated.
- Apply-to-draft remains out of scope; variation cards expose Copy + Save to notes only.

## Validation

- `npm test -- --runTestsByPath packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts packages/core/src/__tests__/application/services/WorkshopSessionService.test.ts packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts` — pass (72 tests)
- `npm run typecheck` — pass (core, webview, extension)
- `npm test` — pass (61 suites / 541 tests)
- `npm run build` — pass; includes `verify:bundle` pass
- `npm run lint` — pass with warnings only (0 errors; existing naming/curly warnings remain)
- `git diff --check` — pass

## Bundle delta

Against PR #68 / Sprint 03 baseline:

| Bundle | Before | After | Delta |
|---|---:|---:|---:|
| `webview.js` | 549,388 B | 568,879 B | +19,491 B (+3.55%) |
| `extension.js` | 2,250,949 B | 2,260,176 B | +9,227 B (+0.41%) |
