### PR TITLE
docs(workshop): align session design with T3 restore

### DIFF
--- a/.todo/epics/epic-conversation-widgets-2026-07-22/concepts/decisions-widget.md
+++ b/.todo/epics/epic-conversation-widgets-2026-07-22/concepts/decisions-widget.md
@@ -57,8 +57,9 @@ frame joins the delimiter neutralizer in the same change.
 
 The canonical decision record is a structured, stable-id artifact on the
 extension-owned Workshop turn. The same trusted frame is delivered into
-`ConversationManager` for the live conversation, but provider history is not
-its sole durable home: Sprint 10 intentionally does not serialize that history.
+`ConversationManager` for the live conversation. Sprint 10 now persists that
+history as part of T3 restore, but provider history is still not its sole
+durable home: the canonical typed payload belongs to the product session graph.
 **All decisions** is a projection produced by scanning the full session turn
 record; it is not another mutable decision collection in
 `WorkshopSessionService`.
@@ -69,13 +70,11 @@ That constraint has two consequences to settle before promotion:
    may be compacted around decision frames, but a retained decision record is
    copied verbatim into the compacted projection or explicitly superseded. A
    lossy summary must not become the source of truth for what was decided.
-2. **Restored-session behavior must be honest.** Sprint 10 persists the full
-   extension-owned turn record but not `ConversationManager` provider history.
-   Decision artifacts therefore round-trip with their originating turns and
-   remain available to the deterministic list projection after restore. A fresh
-   persona conversation receives the assembled list only through the closed
-   capability; no dead provider conversation is implied and no parallel
-   decision database is introduced.
+2. **Restored-session behavior must be honest.** Decision artifacts round-trip
+   in both the canonical extension-owned turn graph and the retained
+   conversation archive. The deterministic list still scans the canonical turn
+   graph, so degraded T2 recovery and later conversation compaction cannot erase
+   what was decided. No parallel mutable decision database is introduced.
 
 ## Likely UI
 

--- a/.todo/epics/epic-conversation-widgets-2026-07-22/epic-conversation-widgets-2026-07-22.md
+++ b/.todo/epics/epic-conversation-widgets-2026-07-22/epic-conversation-widgets-2026-07-22.md
@@ -77,25 +77,33 @@ These are the walls. Everything else is decoration that can move.
      `replaceWorkshopConversationBehavior`. Pre-commit tweaking is free; only the
      commit pays.
 
-5. **Config, not just output, is persisted by stable id in `WorkshopSessionService`.**
-   The chip re-hydrates the authoring UI, not a dead summary. Extends the
-   thread-artifact "addressable by stable id" pattern from one-shot payload to
-   re-openable payload-with-authoring-state.
+5. **Config, not just output, is session-owned and persisted by stable id.**
+   The chip re-hydrates the exact authoring UI, not a dead summary. VS Code
+   Settings may remember last-used values only to seed a *new* widget instance;
+   opening a session restores its committed configs and standing directives
+   without mutating those defaults.
 
-6. **New reserved frames register with the neutralizer.** Any widget frame must be
+6. **Occurrence, artifact, and authoring identity stay separate.** `turnId`
+   identifies the visible event, `artifactId` identifies what entered retained
+   history, and `widgetConfigId` identifies re-openable authoring state.
+   Clone-and-recommit mints all new identities (optionally linked by
+   `clonedFromConfigId`); standing edit-in-place retains its config/directive id
+   and increments a revision.
+
+7. **New reserved frames register with the neutralizer.** Any widget frame must be
    neutralized by `neutralizeReservedPersonaPromptDelimiters`
    (`utils/workshopPromptFrames.ts`) so a persona quoting a user's widget output
    cannot spoof/re-inject a frame. Ships in the same change as the frame, never
    after.
 
-7. **Deterministic scaffold vs. model call is an explicit seam inside each widget.**
+8. **Deterministic scaffold vs. model call is an explicit seam inside each widget.**
    POS tables, gradient buckets, sliders, punctuation counts — deterministic.
    Only semantic word-selection and phrase rewrites hit the model. Live iteration
    uses a fast/cheap model; the committed "full workup" may use a better one. The
    exploration UI is scaffolding thrown away at commit; what rides the rail is a
    compact, instruction-shaped directive — never the whole cloud.
 
-8. **Core stays host-agnostic.** The widget host, the registry, and every
+9. **Core stays host-agnostic.** The widget host, the registry, and every
    widget's logic live in `packages/core`. Only the composer's *mounting* touches
    `apps/vscode-extension`. No `vscode` import crosses into core.
 
@@ -183,8 +191,12 @@ with deeper, teachable style levers rather than a thin bank of sliders.
 - **Session state lives host-side** in `WorkshopSessionService`, never in the
   webview.
 - **Persistence remains complete and typed.** Widget state participates in
-  Sprint 10's serialize/hydrate contract and named-session browser restore;
-  provider `ConversationManager` history is never its only durable home.
+  Sprint 10's product-snapshot plus conversation-archive restore. Provider
+  history persists too, but it is never the only durable home for canonical
+  widget configuration or standing-directive state.
+- **Settings are defaults, sessions are historical truth.** Last-used values
+  may seed a new instance; an opened session restores its exact committed
+  configs without changing global Settings.
 - **`packages/core` never imports `vscode`.**
 - **Behavior changes only between runs.** Standing-widget commits inherit the
   active-run guard and serialization discipline already coordinated by

--- a/.todo/epics/epic-conversation-widgets-2026-07-22/sprints/01-widget-host-gesture-playground.md
+++ b/.todo/epics/epic-conversation-widgets-2026-07-22/sprints/01-widget-host-gesture-playground.md
@@ -63,17 +63,23 @@ persona "here are the gesture directions I want *here*."
 - **Commit** stages a one-shot thread-artifact: a compact directive ("gesture
   directions I want for '<phrase>': …selected items…") plus a visible composer
   message. It rides exactly one turn, then becomes ordinary history.
-- **Every commit persists its full `Draft` by stable id in
+- **Every commit persists its full `Draft` under a `widgetConfigId` in
   `WorkshopSessionService`** so the chip re-hydrates the authoring UI. The
-  typed config collection joins Sprint 10's complete session serializer and
-  shared ordered autosave-dirty seam; named-session and restart restore preserve
-  the id and exact draft.
+  typed config collection joins Sprint 10's complete product snapshot and
+  shared ordered autosave seam; named-session and restart restore preserve the
+  exact historical draft. Any Settings-backed last-used values seed only brand
+  new instances.
+- **Three identities, three jobs:** `turnId` is the visible transcript event,
+  `artifactId` is the trusted one-shot history occurrence, and
+  `widgetConfigId` is its re-openable authoring state.
 - **The thread chip is presentation-only.** Webview renders a clickable marker
   over the committed turn; the model never sees the chip. Clicking re-opens
   Gesture Playground seeded from the persisted `Draft`.
 - **Re-launch = clone-and-recommit.** Editing the past artifact in place is out
   of scope and, for one-shot artifacts, incorrect. The old chip persists as a
-  historical marker; re-launch seeds a fresh commit at the head.
+  historical marker; re-launch copies its exact Draft into a new
+  `widgetConfigId`, mints a new artifact and turn, and may record
+  `clonedFromConfigId`.
 - **Persona protocol (minimum viable):** support *recommend* (a soft chip in a
   persona message that opens the widget) and *prefill* (persona-supplied `seed`).
   *launch* falls out of *recommend*. *auto-commit* is out of scope this sprint.
@@ -101,7 +107,9 @@ persona "here are the gesture directions I want *here*."
 8. Frame neutralization coverage for any new reserved delimiter introduced.
 9. Tests: host registry + commit contract; thread-artifact payload shape;
    live and named-session persistence round-trip; chip re-hydration seeds the
-   exact Draft with the same stable id; neutralization guard.
+   exact Draft while clone-and-recommit mints new config/artifact/turn ids and
+   preserves lineage; Settings defaults never overwrite restored config;
+   neutralization guard.
 
 ## Out of Scope
 

--- a/.todo/epics/epic-conversation-widgets-2026-07-22/sprints/02-lexical-gravity-standing-rail.md
+++ b/.todo/epics/epic-conversation-widgets-2026-07-22/sprints/02-lexical-gravity-standing-rail.md
@@ -64,7 +64,13 @@ blending is Sprint 04.
   active Lexical Gravity directive on the passage. Clicking the chip edits the
   live directive; committing swaps the frame between runs and emits a "gravity
   shifted from X to Y" transition marker (mirroring
-  `<workshop-interaction-transition>`). Same cache cost class as a mode change.
+  `<workshop-interaction-transition>`). The directive/config id remains stable
+  and its revision increments. Same cache cost class as a mode change.
+- **The session owns the committed directive.** VS Code Settings may retain the
+  last-used Lexical Gravity values as defaults for a new directive, but opening
+  a session restores its exact normalized config without rewriting Settings.
+  Sprint 10 rebuilds the standing frame from that config; a serialized old
+  system message is never its source of truth.
 - **Pre-commit exploration is free.** The word cloud, gradient buckets, POS
   tables, before/after examples, weight slider, degrees-of-separation, and
   metaphor checkbox all live in the widget UI and touch no conversation state
@@ -100,14 +106,16 @@ blending is Sprint 04.
    control; metaphor-pull checkbox.
 4. **Live generation path** with debounce/recompute + caching, routed through
    core services on a fast model; final-workup generation option.
-5. **Commit path** onto the standing rail via the coordinator; persisted config
-   by stable id in `WorkshopSessionService`.
+5. **Commit path** onto the standing rail via the coordinator; normalized
+   session-owned config by stable id/revision in `WorkshopSessionService`,
+   distinct from any Settings-backed new-instance defaults.
 6. **Presentation-only chip** with **edit-in-place** re-launch + shift marker.
 7. **Active-directive indicator + one-click kill.**
 8. **Persona recommend/prefill** for Lexical Gravity (propose + seed).
 9. Tests: frame build + neutralization; coordinator serialization / active-run
    refusal / between-runs apply (mirroring the behavior-service tests);
-   edit-in-place shift marker; persistence round-trip; kill path; the
+   edit-in-place identity/revision + shift marker; T3 persistence and standing
+   frame reconstruction round-trip; Settings-default isolation; kill path; the
    deterministic scaffold functions (bucketing/gradient) in isolation.
 
 ## Out of Scope

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md
@@ -57,7 +57,7 @@ Each sprint is independently shippable behind the (initially unregistered)
 | 7 | `sprint/workshop-editor-tab-07-persona-capabilities` | [Persona-callable capabilities](sprints/07-persona-capabilities.md) | Personas autonomously invoke bounded Writer's Dictionary and analysis capabilities through the proven typed host boundary. |
 | 8 | `sprint/workshop-editor-tab-08-actionable-tool-todos` | [Actionable tool To-do List](sprints/08-actionable-tool-todos.md) | Writers promote attributable tool findings into a durable task list the persona can see as bounded evidence. |
 | 9 | `sprint/workshop-editor-tab-09-persona-guest-sidecars` | [Guest persona sidecars](sprints/09-persona-guest-sidecars.md) | Writers summon a bounded second-opinion persona seeded with a labeled transcript snapshot and cursor-based catch-up. |
-| 10 | `sprint/workshop-editor-tab-10-session-persistence` | [Session persistence, save, and browser](sprints/10-session-persistence.md) | The final persistence pass: sessions survive VS Code restarts as workspace JSON records; a session browser reopens prior sessions with the full record and honestly fresh room memory. |
+| 10 | `sprint/workshop-editor-tab-10-session-persistence` | [Seamless session persistence, save, and browser](sprints/10-session-persistence.md) | The final persistence pass: sessions survive restarts as workspace JSON records; retained persona histories are remapped into live conversations, with transcript-only restore reserved for degraded recovery. |
 | 11 | `sprint/workshop-editor-tab-11-persona-file-access` | [Persona file access](sprints/11-persona-file-access.md) | The host persona searches and reads allowlisted project resources through the Sprint 07 capability boundary — after the markdown-sanitization gate lands as its opening task. |
 | 11B | `sprint/workshop-editor-tab-11b-context-budget-visibility` | [Context budget visibility and inference telemetry](sprints/11b-context-budget-visibility.md) | Workshop shows the current retained context separately from multi-call and cumulative processed usage; the gauge follows the active host, guest, or tool conversation. |
 | 12 | `sprint/workshop-editor-tab-12-context-excerpt-intake` | [Excerpt & context intake rework + polish](sprints/12-context-excerpt-intake-polish.md) | Intent-button intake replaces "pinning"; context becomes multiple visible attachments; the live session shape and shared browser shell stabilize before persistence. |
@@ -72,9 +72,10 @@ and restore-time personal-context boundary once instead of manufacturing an
 immediate schema migration.
 
 Sprint 10 also establishes the additive, typed persistence seams future
-Conversation Widgets need—stable ids, a shared ordered autosave-dirty seam, and
-browser summaries decoupled from full payload hydration—without guessing a
-generic widget blob before the widget ADR is accepted.
+Conversation Widgets need—stable turn/artifact/config ids, exact session-owned
+configs and standing directives, logical conversation-history remapping, a
+shared ordered autosave seam, and browser summaries decoupled from full payload
+hydration—without guessing a generic widget blob.
 
 The shared markdown-sanitization gate moves forward into Sprint 11's opening
 tasks (persona file access sharpens that risk — see Known Risks). Final step

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/10-session-persistence.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/10-session-persistence.md
@@ -1,222 +1,212 @@
-# Sprint 10: Session Persistence, Save, and the Session Browser
+# Sprint 10: Seamless Session Persistence, Save, and Browser
 
-**Status**: Planned
-**Priority**: High (live pain point — restart loses the manuscript excerpt and context)
+**Status**: Planned — replanned 2026-07-23 for T3 continuity and approved design
+**Priority**: High (restart currently destroys the Workshop)
 **Branch**: `sprint/workshop-editor-tab-10-session-persistence` -> PR into `epic/workshop-editor-tab`
-**Estimated Effort**: 4-6 days
-**Execution order**: Runs last in the epic, after Sprints 11, 11B, and 12. The
-sprint number and branch name remain unchanged. Relational Depth and Writer
-Profile land before this sprint so the first persisted turn schema captures the
-final behavior shape and restore tests exercise the final prompt-assembly
-boundary.
-**Depends on**: Sprint 12, which completes the live session shape and extracts
-the shared browser-modal shell. This transitively includes Sprint 11's
-file-access artifact turns, Sprint 11B's context-telemetry lifecycle decisions,
-and Sprint 09's guest sidecars.
+**Estimated Effort**: 8-12 days
+**Execution order**: Runs last in the epic after Sprints 11, 11B, 12,
+Relational Depth, and Writer Profile, so the first persisted schema captures the
+final aggregate and prompt boundary.
+**Depends on**: Sprint 12 and its shared browser-modal shell; transitively
+includes file-access artifact turns, context telemetry, and guest sidecars.
 **ADRs**: [2026-07-14 — Workshop Session Persistence and the Session Browser](../../../../docs/adr/2026-07-14-workshop-session-persistence.md)
+**Design**: [Workshop editor tab](../../../../docs/design/Prose%20Minion%20-%20Assistant%20Tab.html)
 **Feature**: [feature-workshop-session-persistence](../../../features/feature-workshop-session-persistence/README.md)
-**Pre-persistence behavior features**: [Relational Depth](../../../features/feature-workshop-relational-depth/README.md) → [Writer Profile](../../../features/feature-workshop-writer-profile/README.md)
 
 ## Goal
 
-A VS Code restart no longer destroys the Workshop. The live working session
-always autosaves to `prose-minion/sessions/current.json` and restores whenever
-Workshop reopens; an explicit **Save session** writes a
-timestamped record; a **session browser** lists prior sessions and reopens
-them with the full transcript, todos, excerpt, and context attachments —
-honestly marked as restored history with fresh room memory.
+Reopening Workshop after a restart or from the session browser returns the
+writer to the conversation and workspace they left: excerpt, context,
+participants, todos, artifacts, widget state, transcript, and genuinely
+continuable persona histories. The design’s editable titles and full browser
+actions ship with this persistence boundary. T2 transcript-only restoration is
+a corruption/incompatibility fallback, not the normal experience.
 
-## Locked Decisions (from the ADR)
+## Locked Decisions
 
-- **JSON files in `prose-minion/sessions/`, via the existing `FileSystem`
-  port** — no Memento, no new platform port. One port extension:
-  `FileSystem.delete(path)`.
-- **One complete serializer**, `serialize()`/`hydrate()` on
-  `WorkshopSessionService` — full turn list (including file-access artifacts
-  and context event turns), todos, excerpt + `excerptSource`/`sourceUri`/version
-  counters, context attachments, participant identities. Never built from the
-  windowed `getSnapshot()` projection.
-- **Conversation ids are stripped by schema** — the snapshot type has no field
-  for them. Delivery cursors and pending host updates drop with them.
-- **Restore = tier T2**: excerpt/context attachments/todos live; transcript
-  read-only behind a divider turn ("Previous session restored — transcript preserved, room
-  memory not retained"); persona selection re-unlocked; first new turn starts
-  a fresh conversation. T3 (real cross-restart memory) stays deferred.
-- **Inference telemetry is never restored as live memory**: persisted snapshots
-  contain neither provider conversation ids nor context-budget readings. A T2
-  restore shows `Not measured yet` until a fresh provider request completes;
-  archived transcript token history is not a current model-context claim.
-- **Schema-versioned, tolerant-forward**: `schemaVersion` on every file;
-  malformed/unknown files skipped with a log line, never a crash.
-- Autosave and named saves share the serializer and differ only in filename
-  and trigger.
-- `current.json` is the rolling working-session checkpoint. Opening a named
-  save immediately promotes that hydrated session to `current.json`; the
-  writer does not need to make another edit or press Save to protect it.
-- Historical persona-directed turns retain their effective behavior stamp and
-  transition provenance. The active post-restore behavior comes from the
-  current validated global Conversation Settings value; opening an old session
-  never silently rewrites global settings.
-- Derived Carry Cues/attunement state and raw Writer Profile content are not
-  session data. A fresh post-restore persona conversation uses the current
-  enabled global Writer Profile and starts without inferred cue memory.
+- Workspace JSON under `prose-minion/sessions/`; `current.json` is ordered
+  autosave, named files are collision-safe checkpoints.
+- Editable `title` is metadata. Immutable `sessionId` and filename are storage
+  identity; rename does not move the file, duplicate creates a new identity.
+- Persistence is a coherent product snapshot plus a typed
+  `ConversationArchiveV1`; never serialize from windowed `getSnapshot()`.
+- Conversation archives use stable logical participant keys. Import mints fresh
+  runtime ids and reconnects the session participant graph.
+- Leading system messages are excluded and rebuilt from current persona
+  resources, current global behavior/profile, and session-owned standing
+  directives.
+- Only successful committed transactions persist. In-flight streams, partial
+  tool/widget commits, and uncommitted modal drafts do not.
+- T3 is the normal restore. Invalid conversation history degrades visibly to T2
+  while preserving the product session.
+- Time-awareness frames are deterministic, per persona conversation, queued on
+  first turn/resume/one-hour threshold, and marked delivered only after success.
+- Settings seed new widgets; the session owns exact committed one-shot and
+  standing configurations. Opening a session never rewrites Settings.
+- Browser scope follows the approved design: save title, search, date/excerpt
+  grouping, open, rename title, duplicate, reveal, and delete.
 
 ## Tasks
 
-### Platform and store
+### 1. Schema, ports, and store
 
-- [ ] Add `delete(path)` to the `FileSystem` port + `VsCodeFileSystem` adapter
-      (mirror `workspace.fs.delete` semantics); update the port doc header.
-- [ ] `WorkshopSessionStore` infrastructure service (core): resolve
-      `prose-minion/sessions/` under the workspace root via `Workspace`,
-      write/read/list/delete schema-stamped snapshots, deterministic
-      `YYYYMMDD-HHMM-<slug>.json` naming (slug from excerpt heading or opening
-      words), tolerant listing that skips unreadable files.
-- [ ] Construct in `extension.ts`, add to `CoreServices`, inject into
-      `WorkshopHandler` (architecture witness stays green — nothing `new`-ed
-      in the handler).
+- [ ] Define `WorkshopPersistedSessionV1` with identity/timestamps/timezone,
+      summary metadata, complete `WorkshopSessionSnapshotV1`, and
+      `ConversationArchiveV1`.
+- [ ] Inventory every aggregate field and monotonic counter, including excerpt
+      source/fingerprint/version/replacement count, full turns, todos,
+      attachments and pending committed delivery state, participants/cursors,
+      `turnCounter`, `todoCounter`, `attachmentCounter`,
+      `threadArtifactCounter`, and widget collections when present.
+- [ ] Extend the host boundary for delete and reveal-file without importing
+      `vscode` into core. Construct `WorkshopSessionStore` in `extension.ts` and
+      inject it through `CoreServices`.
+- [ ] Implement atomic/ordered `current.json` writes, collision-safe
+      `YYYYMMDD-HHMMSS-<initial-slug>.json` saves, tolerant reads, summary-only
+      listing, title updates, duplicate, delete, and reveal routing.
+- [ ] Define no-workspace and multi-root behavior explicitly; never guess which
+      manuscript workspace owns a session.
 
-### Serializer
+### 2. Product aggregate serialization
 
-- [ ] `WorkshopSessionSnapshotV1` type + `serialize()`/`hydrate()` on
-      `WorkshopSessionService`: full turns (including capability artifacts and
-      context event turns, behavior stamps, and behavior-transition
-      provenance), todos, excerpt text + `excerptSource` + `sourceUri` +
-      `excerptVersion`/`replacementCount`/`turnCounter`, ordered context
-      attachments, host/tool/guest participant identities. No conversation
-      ids, no cursors, no derived session attunement, and no Writer Profile.
-- [ ] Hydrate appends the restored-session divider turn, reports
-      `hasHostConversation() === false`, re-unlocks persona selection, and
-      preserves counters so new turn ids and excerpt versions never collide
-      with restored history.
-- [ ] Hydrate receives the current validated `WorkshopConversationBehavior`
-      from the composition/application boundary. Historical turns retain their
-      saved stamps, but an opened session never overwrites the user's current
-      global Conversation Settings value.
+- [ ] Add complete serialize/hydrate operations separate from
+      `getSnapshot()`. Round-trip every turn variant, artifact payload,
+      provenance stamp, participant, cursor, counter, todo, excerpt field, and
+      ordered attachment.
+- [ ] Persist session start/activity/time-notice state and add trusted visible
+      `session_start` / `session_resume` marker variants without pretending a
+      same-process webview reload is a resume.
+- [ ] Keep global Conversation Behavior and Writer Profile outside the session;
+      preserve historical behavior stamps and exclude derived Carry Cues.
+- [ ] Reconcile pending message attachments and delivery cursors so committed
+      work survives and in-flight work cannot reappear as half a transaction.
 
-### Autosave and save
+### 3. Conversation archive and prompt rebuild
 
-- [ ] Add one application-owned `markSessionDirty()` / autosave coordinator
-      seam, then call it after successful `WorkshopHandler` mutation paths
-      (excerpt set/replace, context attachment add/update/remove, turn
-      completion, todo mutations, guest lifecycle). It owns debounce and
-      write-order serialization; `reset()` checkpoints the fresh room with its
-      preserved excerpt and standing context instead of resurrecting the old
-      transcript. Future widget coordinators use this same seam rather than
-      inventing persistence calls.
-- [ ] `WORKSHOP_SAVE_SESSION` route: copy current state to a timestamped file;
-      deterministic status line names the saved file. Header affordance in
-      `WorkshopApp` (near New session).
-- [ ] On activation/panel open with no live session: hydrate from
-      `current.json` when present.
+- [ ] Add typed `ConversationManager.exportConversations()` /
+      `importConversations()` seams for committed non-system messages, logical
+      participant key, context sources, last activity, and
+      `nextArtifactNumber`.
+- [ ] On import, mint runtime ids, validate message/cursor shape, return the
+      logical-key map, and reconnect host/guest participants atomically.
+- [ ] Rebuild each leading system message from current persona resources,
+      current validated global behavior/profile, restored session context, and
+      normalized active standing directives. Never deserialize the old leading
+      system message.
+- [ ] Make a single malformed conversation degrade only the affected
+      participant to a visible fresh-memory fallback; never throw
+      `ConversationNotFoundError` from a successful hydrate.
+- [ ] Persist context-source state needed by the restored conversation but mark
+      derived context-budget telemetry unmeasured/stale until the next
+      successful provider response.
 
-### Session browser
+### 4. Trusted time awareness
 
-- [ ] Reuse the shared browser-modal shell extracted in Sprint 12; build the
-      session browser on it without introducing a persistence-specific modal
-      framework.
-- [ ] `WORKSHOP_LIST_SESSIONS` / `WORKSHOP_SESSIONS_DATA` /
-      `WORKSHOP_OPEN_SESSION` / `WORKSHOP_DELETE_SESSION` messages; listing
-      shows title, saved date, persona, turn count, excerpt word count,
-      newest first.
-- [ ] Opening a session replaces the current one behind the same confirmation
-      as "New session" and immediately writes the opened state to
-      `current.json`; delete confirms and removes the named file.
+- [ ] Add a deterministic time-frame builder with session start, current time,
+      timezone, elapsed interval, reason, and the explicit “do not infer the
+      writer’s gap” constraint.
+- [ ] Queue it for the first persona turn, after disk hydrate/open, and when
+      that persona’s last successful notice is at least one hour old.
+- [ ] Advance the per-conversation notice timestamp only after a successful
+      persona turn; cancellation/failure retries next turn. No background timer
+      or tool-sidecar model call.
 
-### Future widget compatibility
+### 5. Autosave and lifecycle
 
-- [ ] Keep the persisted aggregate additive through explicit, typed optional
-      fields with empty/default hydration. Do not add a generic
-      `extensions: Record<string, unknown>` bag and do not speculate the final
-      widget payload before the Conversation Widgets ADR is accepted.
-- [ ] Preserve stable turn, thread-artifact, and config ids byte-for-byte across
-      serialize/hydrate. Future re-openable widget chips depend on those ids.
-- [ ] Keep browser summary extraction independent of full session payload
-      hydration so later typed widget collections do not break session listing.
-- [ ] Document the future extension rule: widget authoring configs and standing
-      directives are aggregate-owned session state and must join the complete
-      serializer; provider-only `ConversationManager` history cannot be their
-      sole durable source of truth.
+- [ ] Build one application-owned dirty/autosave coordinator spanning aggregate
+      and conversation history. Serialize writes; flush safely on lifecycle
+      boundaries; prevent an older write from winning.
+- [ ] Mark dirty after every successful mutation: excerpt/context/todo/guest
+      changes, completed persona/tool turns, behavior/directive replacement,
+      and complete widget transactions.
+- [ ] Decide active-run behavior for Save/Open/Rename/Duplicate/New. Prefer
+      disabling state-replacing actions while a run is active rather than
+      snapshotting ambiguous partial work.
+- [ ] Hydrate `current.json` on activation/panel open and immediately promote an
+      opened named checkpoint to `current.json`.
+- [ ] Register `WebviewPanelSerializer`; it stores no duplicate state.
 
-### Panel serializer
+### 6. Save and browser UI
 
-- [ ] Register a Workshop `WebviewPanelSerializer` (resolves tech-debt
-      2026-07-07): restart reopens the tab and rehydrates via the standard
-      `WORKSHOP_REQUEST_SESSION` path from `current.json`. The serializer
-      itself stores nothing. *(Separable if the sprint runs long — manual
-      reopen still restores.)*
+- [ ] Implement Save dialog title input, filename/identity explanation, and the
+      “included in this snapshot” manifest from the approved design.
+- [ ] Add typed routes for list/save/open/rename/duplicate/reveal/delete and
+      explicit success/failure responses.
+- [ ] Build newest-first Recent and browser views with cancellable bounded
+      search across title/participants/excerpt/transcript and grouping by date
+      or stable excerpt identity.
+- [ ] Distinguish current from named checkpoints. Confirm state replacement and
+      delete; protect `current.json` from named-session actions.
+- [ ] Replace prototype T2 copy in implementation with seamless-restore
+      language; show the memory-not-retained warning only for degraded recovery.
 
-### Restore polish and verification
+### 7. Conversation Widget seam
 
-- [ ] Extension Development Host pass: divider prominence, restored context
-      attachment and capability-artifact rendering, disabled direct-tool/live
-      action chips, re-unlocked persona picker, first fresh turn, automatic tab
-      reopen, and manual-reopen fallback. Record the results in the feature
-      README or sprint completion notes.
+- [ ] Persist exact normalized widget configs and active standing directives as
+      typed session-owned collections even when Settings hold last-used
+      defaults.
+- [ ] Preserve distinct `turnId`, `artifactId`, and `widgetConfigId`.
+      Clone/recommit creates new ids plus optional `clonedFromConfigId`;
+      standing edits retain identity and increment revision.
+- [ ] Preserve both session `ta-N` and ConversationManager `art-N` counters.
+      Reconstruct standing system frames from normalized config on restore.
+- [ ] Autosave only after config + marker + system replacement + telemetry
+      invalidation commit together. Browser summaries ignore additive widget
+      fields.
 
-### Tests
+### 8. Verification
 
-- [ ] serialize → hydrate round-trip fidelity: turns, todos, counters,
-      excerpt provenance, context attachments, capability artifacts, and
-      context event turns, including behavior stamps/transitions; snapshot type
-      rejects conversation ids, Writer Profile, and derived attunement by shape.
-- [ ] Hydrated session: divider present, persona unlocked, no
-      `ConversationNotFoundError` reachable on first turn; new turn ids don't
-      collide with restored ones.
-- [ ] Restored artifact turns are inert: no direct-tool or other live action
-      depending on a dead provider conversation remains enabled.
-- [ ] Store: schema-mismatch skip, malformed-file skip, reset-deletes-blob,
-      naming determinism, list ordering.
-- [ ] Handler routes: save/list/open/delete registration + validation;
-      open-session confirmation flow.
-- [ ] Additive compatibility: absent future collections hydrate to empty;
-      browser summaries ignore additional typed payload fields; stable ids do
-      not change on round-trip.
-- [ ] Restore prompt boundary: the first fresh host/guest conversation uses the
-      current global Relational Depth and enabled Writer Profile without writing
-      raw profile content or inferred Carry Cues state into the session file.
+- [ ] Unit: product and conversation round trips, every counter, logical-id
+      remapping, prompt rebuild/exclusion, per-participant degradation, schema
+      mismatch, malformed file, ordering, collision resistance, and title
+      metadata rename.
+- [ ] Unit: time frame first/resume/hour boundary/timezone, successful delivery,
+      cancellation retry, and no false same-process resume.
+- [ ] Unit: current global behavior/profile applied without writing raw profile
+      content; historical behavior stamps preserved.
+- [ ] Unit: widget config/directive round trip, identity/revision rules, and no
+      half-transaction autosave.
+- [ ] Integration: save/list/search/group/open/rename/duplicate/reveal/delete,
+      active-run guards, `current.json` promotion, panel serializer, multi-root
+      handling, and T2 recovery UI.
+- [ ] Extension Development Host: quit mid-room, relaunch, continue host and
+      guest conversations, verify time notice and restored workspace, then
+      corrupt one archived history and verify graceful degraded recovery.
+- [ ] Run architecture, typecheck, lint, full tests, build, and bundle checks;
+      record bundle deltas.
 
 ## Acceptance Criteria
 
-- Quit VS Code mid-session; relaunch: the Workshop tab returns (or reopens
-  manually) with excerpt, context attachments, todos, and full transcript
-  restored, the divider visible, and the persona picker unlocked. The first
-  new message starts cleanly.
-- No explicit Save is required for restart recovery: every successfully
-  committed live mutation reaches the rolling `current.json` checkpoint through
-  the shared ordered autosave seam.
-- Save session → visible file in `prose-minion/sessions/`; browser lists it;
-  opening it from a *different* session restores it behind a confirmation.
-- Deleting a session removes the file; malformed JSON in the folder never
-  breaks the listing.
-- `reset()` replaces `current.json` with the fresh-room state: preserved
-  excerpt and standing context, but no prior transcript or retained model
-  conversations.
-- Core still imports no `vscode`; architecture and assembly tests green; lint,
-  typecheck, full tests, build, bundle verification pass. Record bundle deltas.
+- Quit VS Code after successful turns; relaunch; the Workshop returns with the
+  exact workspace and both host/guest conversations continue with retained
+  memory under fresh runtime ids.
+- The first resumed persona turn receives a trusted passage-of-time frame.
+  Another is sent only after that conversation crosses one hour since its last
+  successful notice.
+- A bad conversation archive cannot destroy the excerpt/transcript/todos. The
+  affected participant visibly falls back to fresh memory and remains usable.
+- No explicit Save is required for recovery. Named Save accepts a title and the
+  browser can search, group, open, rename, duplicate, reveal, and delete it.
+- Opening an old session restores its widget settings and standing directives
+  exactly without changing the user’s global last-used defaults.
+- Current global persona resources, behavior, and Writer Profile are used for
+  the next turn; old leading system prompts and raw profile values are absent
+  from disk.
+- Core imports no `vscode`; composition-root and architecture witnesses remain
+  green.
 
 ## Guardrails
 
-- Never serialize from `getSnapshot()` — the windowed projection resets
-  counters and drops provenance (the feature README's "windowed-snapshot trap").
-- No conversation id, cursor, or pending-update field may enter the snapshot
-  schema, even optionally "for later" — T3 gets its own schema version when
-  it earns an ADR.
-- Store calls live in the handler's mutation paths, not inside the aggregate —
-  `WorkshopSessionService` stays a pure aggregate (no I/O), and it is already
-  near the size threshold (tech-debt 2026-07-12).
-- `WorkshopSessionSnapshotV1` is the first shipped persisted schema and includes
-  Sprint 12's attachment model from the start. Do not build a pre-attachment
-  v1 or a v1 → v2 migration for a format that never shipped.
-- Prefer additive, typed optional fields with deterministic defaults for future
-  session-owned widget state. Do not reserve an untyped extension bag.
-- A Decisions or other structured widget artifact cannot live durably only in
-  provider conversation history because T2 intentionally does not serialize
-  `ConversationManager`. Its canonical structured payload must be reachable
-  from the extension-owned session turn/config graph without creating a second
-  mutable shadow log.
-- Restored transcript turns are read-only record; no restored artifact may
-  re-offer live actions that depend on a dead conversation (e.g. "Talk
-  directly to <Tool>" chips must render disabled/absent for restored sidecars).
-- Do not prompt for a session title in v1 — deterministic naming; renaming is
-  a file operation the writer already owns.
+- Never serialize from `getSnapshot()` and never persist an unresolved runtime
+  conversation id as durable identity.
+- Never persist the leading system message or raw Writer Profile.
+- Never treat transcript visibility as conversational continuity; either the
+  archive validates or the participant is explicitly degraded.
+- Never autosave an in-flight run or half a widget/behavior transaction.
+- Keep `WorkshopSessionService` pure; persistence and coordination remain
+  application/infrastructure concerns.
+- No untyped extension bag and no second mutable widget/artifact log.
+- Do not make filenames the user-facing identity. Title edits cannot invalidate
+  recents, open handles, or references.
+- Do not build a background time-notice timer. Time enters only at a
+  persona-turn boundary.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/11b-context-budget-visibility.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/11b-context-budget-visibility.md
@@ -169,8 +169,10 @@ Compression          Not applied
 - Cancellation and transport failure preserve the prior committed reading.
 - A model change leaves the old measured model attached until a new turn
   commits.
-- Sprint 10 restored T2 sessions begin `Not measured yet`; archived transcript
-  history is not live provider memory.
+- Sprint 10 restores retained histories, but the prior reading is not claimed as
+  live after hydrate because the leading system prompt and provider conditions
+  may have changed. Show `Not measured after restore` until the next successful
+  request commits a fresh reading.
 
 ## Tasks
 

--- a/.todo/features/feature-workshop-session-persistence/README.md
+++ b/.todo/features/feature-workshop-session-persistence/README.md
@@ -1,6 +1,6 @@
 # Feature: Workshop Session Persistence (Survive VS Code Restart)
 
-**Status**: ADR drafted ([2026-07-14 — Workshop Session Persistence and the Session Browser](../../../docs/adr/2026-07-14-workshop-session-persistence.md));
+**Status**: ADR accepted and amended 2026-07-23 ([2026-07-14 — Workshop Session Persistence and the Session Browser](../../../docs/adr/2026-07-14-workshop-session-persistence.md));
 scheduled as [Sprint 10](../../epics/epic-workshop-editor-tab-2026-07-03/sprints/10-session-persistence.md),
 but intentionally executed last after Sprints 11 and 12 plus Relational Depth
 and Writer Profile. Sprint numbers and branch names remain unchanged; current
@@ -9,7 +9,9 @@ The ADR supersedes this README's storage direction: **JSON files under
 `prose-minion/sessions/` via the existing `FileSystem` port** (plus a small
 `delete()` port extension), not a `workspaceState` Memento/`KeyValueStore`
 port — the session-browser requirement made file storage the better fit.
-Ship shape = T2 + explicit save + browser. The first persisted snapshot is
+Ship shape = **T3 seamless conversation restore + explicit save + the approved
+browser**, with T2 retained only as a visible per-conversation recovery
+fallback. The first persisted snapshot is
 defined only after the Workshop session shape stabilizes and includes the
 **todo list**, **guest participant identities/turns**, Sprint 11 capability
 artifacts, and Sprint 12's `excerptSource` + typed context attachments. The
@@ -26,13 +28,15 @@ Code restarts?" — investigation on `sprint/workshop-editor-tab-07-persona-capa
 (the "UI shows continuity the model no longer has" hazard is the *same* seam,
 here across a restart instead of an excerpt swap)
 
-The accepted implementation also treats `current.json` as the rolling working
+The accepted implementation treats `current.json` as the rolling working
 session: reopening Workshop restores it without requiring an explicit Save.
-Future Conversation Widgets extend the complete snapshot through typed optional
-aggregate fields and the shared ordered autosave-dirty seam; no untyped
-extension bag is reserved. Historical behavior stamps survive, while the
-current Writer Profile and derived Carry Cues state remain outside workspace
-session files.
+It coordinates a complete product snapshot with typed retained
+`ConversationManager` histories keyed by logical participant, then mints fresh
+runtime conversation ids on hydrate. Leading system messages are rebuilt from
+current persona resources, current global behavior/profile settings, and
+session-owned standing directives. Future Conversation Widgets extend the
+complete snapshot through typed aggregate fields and the shared ordered
+autosave seam; no untyped extension bag is reserved.
 
 ## Investigation Findings (2026-07-13)
 
@@ -106,13 +110,13 @@ model). The writer keeps the record; the persona still starts fresh. Requires a
 **complete** serialization (see "Windowed-snapshot trap" below), not the webview
 projection.
 
-### T3 — True cross-restart conversational continuity (deferred)
-Persist and rehydrate the `ConversationManager` histories too, so the persona
-actually remembers. Biggest cost (full message histories on disk, re-warm on
-load, a parallel serializer + port for ConversationManager) and an open product
-question: do writers *want* multi-day retained rooms, or is a fresh start with
-the transcript visible (T2) the better default? Gate behind that decision; T2 is
-the honest interim and the upgrade path is clean.
+### T3 — True cross-restart conversational continuity (selected 2026-07-23)
+Persist and rehydrate typed `ConversationManager` histories so the persona
+actually remembers. Runtime conversation ids remain ephemeral: histories are
+stored under logical participant keys, imported into fresh manager entries, and
+remapped into the product aggregate. The leading system message is reconstructed
+from current prompt/settings policy rather than replayed. T2 remains the honest
+fallback when an individual archived history cannot be validated.
 
 ## Historical Architecture Sketch (superseded by the ADR)
 
@@ -149,9 +153,10 @@ without it (rehydrate on the next manual open); it's a UX nicety, not a blocker.
   complete** serializer — reusing `getSnapshot()` would silently reset
   `turnCounter` (→ id collisions), `excerptVersion`, and delivery cursors on
   hydrate.
-- **Never persist a dangling conversation id in T1/T2.** Strip host + sidecar
-  `conversationId`s on the way out (or on hydrate) unless T3 also restores the
-  matching histories. This is the single correctness landmine.
+- **Never persist a dangling conversation id.** Durable archives use logical
+  participant keys. Hydrate imports validated histories, receives fresh runtime
+  ids, and reconnects the product aggregate atomically. An invalid archive
+  degrades that participant to T2 rather than retaining an unresolvable id.
 - **Scope = workspace, not global.** Excerpt is tied to a manuscript in the open
   workspace; `workspaceState` keys the blob per-workspace automatically.
 - **Schema-versioned + discard-on-mismatch.** Stamp a `schemaVersion`; on shape
@@ -196,14 +201,14 @@ without it (rehydrate on the next manual open); it's a UX nicety, not a blocker.
       session reports `hasHostConversation() === false` in T1/T2 (persona
       selection re-unlocks).
 
-## Open Questions
+## Resolved Questions
 
-- **T3 desirability.** Is a persona that remembers across days actually wanted,
-  or does it invite stale, confusing rooms? T2 (visible transcript, fresh
-  memory) may be the *correct* end state, not just the interim.
-- **Panel auto-reopen.** Register a `WebviewPanelSerializer` (VS Code reopens
-  the tab) or keep manual reopen? Serializer is required if we ever want the
-  window to come back exactly as left.
+- **T3 desirability:** yes. The Workshop restores the conversation and
+  workspace, not merely a readable transcript. Time-awareness frames make
+  multi-day continuity explicit without inviting the persona to invent what
+  happened during the gap.
+- **Panel auto-reopen:** register `WebviewPanelSerializer`; it owns no state and
+  reuses `current.json`.
 - **Multiple manuscripts / branch-board interplay.** If
   [feature-workshop-branch-board](../feature-workshop-branch-board/README.md)
   lands, "one session per workspace" may need to become "one per branch/excerpt

--- a/docs/adr/2026-07-14-workshop-session-persistence.md
+++ b/docs/adr/2026-07-14-workshop-session-persistence.md
@@ -1,236 +1,274 @@
 # ADR 2026-07-14: Workshop Session Persistence and the Session Browser
 
-**Status:** Accepted — implementation scheduled last in the Workshop epic after
-Relational Depth and Writer Profile stabilize the behavior and prompt boundary
+**Status:** Accepted; amended 2026-07-23 to make true cross-restart
+conversation continuity (T3) the normal restore path and to reconcile the
+approved Workshop design
 **Date:** 2026-07-14
+**Amended:** 2026-07-23
 **Extends:** [ADR 2026-07-09 — Workshop Persona Host, Tool Sidecars, and Capabilities](2026-07-09-workshop-persona-hosted-conversations.md); [ADR 2026-07-11 — Workshop Excerpt Revision and Room Memory](2026-07-11-workshop-excerpt-revision-and-room-memory.md); [ADR 2026-07-20 — Workshop Persona Interaction Modes and Expression Profiles](2026-07-20-workshop-persona-interaction-modes-and-expression-profiles.md)
 **Epic:** [Assistant as a Full Editor Tab](../../.todo/epics/epic-workshop-editor-tab-2026-07-03/epic-workshop-editor-tab-2026-07-03.md)
 **Feature investigation:** [.todo/features/feature-workshop-session-persistence](../../.todo/features/feature-workshop-session-persistence/README.md)
+**Approved interaction design:** [Workshop editor tab](../design/Prose%20Minion%20-%20Assistant%20Tab.html)
 
 ## Context
 
-The Workshop session is one in-memory aggregate (`WorkshopSessionService`) plus
-provider conversation histories in `ConversationManager`'s in-memory `Map`.
-Reload/reopen inside one VS Code window survives via host-side rehydration;
-a process restart loses everything: the excerpt, writer-supplied context, the
-transcript, the Sprint 08 todo list, and every retained conversation.
+The Workshop is one product session assembled from two in-memory owners:
 
-The feature investigation (2026-07-13) established the two facts that shape
-this decision:
+- `WorkshopSessionService` owns the writer-visible aggregate: excerpt, context
+  attachments, participants, transcript turns, todos, artifact/configuration
+  records, counters, and delivery state.
+- `ConversationManager` owns the retained host and guest message histories that
+  make a later turn genuinely continue the earlier conversation.
 
-1. **The webview snapshot is a lossy projection.** `getSnapshot()` windows to
-   the newest 100 turns and omits conversation ids, delivery cursors,
-   `turnCounter`, and `excerptVersion`. Persisting it would silently reset
-   counters and collide turn ids on hydrate. Persistence needs a **separate,
-   complete serializer**.
-2. **Provider conversations cannot be restored from the session.**
-   `ConversationManager.continueConversation` throws
-   `ConversationNotFoundError` on an unknown id. A rehydrated session holding
-   yesterday's `conversationId`s would throw on the first post-restart turn.
-   Conversational *memory* lives in a sibling in-memory Map that dies with the
-   process.
+A webview reload survives while the extension host remains alive. A process
+restart destroys both owners. Persisting only the webview projection would be
+incorrect: `getSnapshot()` windows the transcript and omits counters, cursors,
+pending delivery state, and retained histories.
 
-The product ask is larger than "survive a restart": an explicit **Save
-session**, a **session browser** that lists prior sessions and reopens them,
-and restoration of the full room record — thread, tool reports, guest
-exchanges, todos — not just the writer's inputs.
+The original 2026-07-14 decision chose tier T2: restore the visible record but
+start every persona with fresh memory. Product clarification on 2026-07-23
+rejected that as the normal experience. The Workshop is a room the writer
+returns to, not a transcript viewer. Reopening it must restore the conversation
+and workspace as one coherent session.
 
-The investigation proposed a `workspaceState` Memento behind a new
-`KeyValueStore` platform port. That shape fits a single autosave blob but
-fights the browser: Mementos have no natural enumeration story, are invisible
-to the writer, and multiple saved sessions × 10k-word excerpts is exactly the
-payload Mementos are not meant for.
-
-The sprint number remains Sprint 10, but implementation intentionally follows
-Sprints 11 and 12 plus the accepted Relational Depth and Writer Profile work.
-File-access capabilities add artifact-turn variants, the intake rework replaces
-the single brief with typed context attachments, and Relational Depth replaces
-the former binary reactivity field with the `relationalDepth` value now stamped
-onto persona turns. Building the persistence
-boundary last lets its first schema describe the completed aggregate instead of
-requiring an immediate migration.
+The approved design also adds editable session titles and a richer browser:
+search, grouping, rename, duplicate, reveal, and delete. Its “room memory not
+retained” copy and slug-only filename examples reflect the superseded T2
+contract. The design remains authoritative for layout and interaction; this ADR
+is authoritative for persistence semantics and storage identity.
 
 ## Decision
 
-### 1. Sessions persist as JSON files in the workspace, through the existing `FileSystem` port
+### 1. Sessions are schema-versioned workspace JSON files
 
-Sessions are written to **`prose-minion/sessions/`** in the workspace root as
-schema-versioned JSON, via the existing `FileSystem` platform port
-(`readFile`/`writeFile`/`readDirectory`/`stat`/`createDirectory` — writeFile
-already auto-creates parents). This follows the `prose-minion/reports/`
-precedent and buys, for free:
+Sessions live under **`prose-minion/sessions/`** through the existing
+host-agnostic `FileSystem` and `Workspace` ports. `FileSystem` gains the narrow
+operations required by the approved browser (`delete` and `reveal`; reveal may
+remain an adapter command rather than a core filesystem primitive if the final
+message boundary is cleaner).
 
-- **The browser is `readDirectory`.** No blob-enumeration protocol invented on
-  a key-value port.
-- **Writer visibility and ownership.** Sessions are ordinary files: inspectable,
-  deletable, committable or `.gitignore`-able at the writer's choice.
-- **Portability.** The desktop-shell host implements `FileSystem` anyway; no
-  VS Code-specific storage dependency
-  ([feature-desktop-shell-adapter](../../.todo/features/feature-desktop-shell-adapter/README.md)).
-- **No new platform port.** One small extension to `FileSystem` — a
-  `delete(path)` method mirroring `vscode.workspace.fs.delete` — supports the
-  browser's delete action. That is the entire platform surface change.
+The store owns two kinds of files:
 
-File naming: `YYYYMMDD-HHMM-<slug>.json` (memory-bank convention). The slug
-derives deterministically from the excerpt's first heading or opening words.
-The live autosave writes to a fixed name (`current.json`) so restart recovery
-never depends on the writer having pressed Save. Opening a named session
-immediately makes the hydrated state the new `current.json`; it is protected
-before the writer performs another mutation.
+- `current.json` is the ordered rolling checkpoint used for crash/restart
+  recovery.
+- Named checkpoints use
+  `YYYYMMDD-HHMMSS-<initial-title-slug>.json`.
 
-**Privacy note:** manuscript text at rest in the workspace — the same posture
-as the manuscript files themselves. Never global storage; nothing leaves the
-workspace folder.
+Every snapshot has an immutable `sessionId`, editable `title`, `startedAt`,
+`createdAt`, `updatedAt`, `savedAt`, and original IANA timezone. Changing a
+title updates metadata; it does not change `sessionId` or the filename.
+Duplicate creates a new session/checkpoint identity. This deliberately differs
+from the prototype’s slug-only path preview: titles are human labels, not
+storage keys.
 
-### 2. One serializer, two triggers: autosave and explicit save
+Files remain writer-owned, inspectable, committable, or `.gitignore`-able.
+Manuscript and conversation text therefore exist at rest in the workspace; they
+never move to global storage.
 
-`WorkshopSessionService` gains `serialize(): WorkshopSessionSnapshotV1` and
-`static hydrate(snapshot, now)`. This snapshot is **complete** — the full turn
-list (no 100-turn window), the todo list, excerpt text + `sourceUri` +
-`excerptSource` + `excerptVersion` + `replacementCount` + `turnCounter`, the
-ordered context attachments, all turn variants (including capability artifacts
-and context event turns), per-turn Conversation Behavior stamps and transition
-provenance, and participant *identities* (host persona id, tool sidecar ids,
-guest persona ids). It is a distinct type from the webview projection and must
-never be built from `getSnapshot()`.
+### 2. Persistence is a coordinated two-part snapshot
 
-- **Autosave** marks `current.json` dirty on every mutation seam —
-  `setExcerpt`/`replaceExcerpt`, context attachment add/update/remove, turn
-  completion, todo mutations, guest lifecycle — through one application-owned,
-  ordered autosave coordinator. It coalesces writes without letting an older
-  write win a race. `reset()` checkpoints the fresh-room state with the working
-  excerpt and standing context but without the old transcript, so stale room
-  memory cannot resurrect on next launch. Future widget mutation coordinators
-  use this same dirty seam.
-- **Save session** copies the current serialized state to a timestamped file
-  and reports the saved name as a deterministic status line. Saved files are
-  immutable records; continuing to work mutates only `current.json`.
+One persisted session contains two typed sections committed from one
+application-owned save boundary:
 
-A new infrastructure service, `WorkshopSessionStore` (core, consuming
-`FileSystem` + `Workspace`), owns pathing, naming, schema stamping, listing,
-and tolerant reads. It is constructed in `extension.ts`, added to
-`CoreServices`, and injected into `WorkshopHandler` — nothing is `new`-ed in
-the handler (ADR 2026-06-18).
+1. **Product aggregate.** A complete `WorkshopSessionSnapshotV1`, distinct from
+   `getSnapshot()`, includes the full turn ledger; excerpt provenance and every
+   monotonic counter; ordered context attachments; todos; participants;
+   delivery cursors and pending committed updates; widget configuration and
+   standing-directive collections when present; and historical behavior stamps
+   and transition provenance.
+2. **Conversation archive.** A typed `ConversationArchiveV1` contains each
+   continuable persona history, keyed by a stable logical participant key such
+   as `host`, `guest:<participantId>`, rather than by an ephemeral runtime
+   conversation id. It includes the committed non-system messages, context
+   sources, artifact counter, last activity, and other state required for the
+   next successful continuation.
 
-### 2A. Explicit behavior and personal-context boundary
+`ConversationManager` gains narrow typed export/import operations. Import mints
+fresh runtime conversation ids and returns the logical-key-to-runtime-id map;
+the session hydrator reconnects participants and validates all cursors against
+the imported histories. No restored participant may retain an id that the
+manager cannot resolve.
 
-The complete turn list preserves every persona-directed turn's effective
-Conversation Behavior and behavior-transition provenance. That is historical
-truth and includes the final `relationalDepth` shape accepted by the 2026-07-20
-ADR amendment.
+Only successfully committed conversation transactions are serializable.
+In-flight runs, partial streams, uncommitted widget drafts, and half-applied
+configuration changes are not durable state. Autosave occurs after the product
+aggregate and retained history have both reached the same successful commit.
 
-The session does not own the current global preference. Hydration receives the
-currently validated `WorkshopConversationBehavior` from the application
-boundary; opening an old named session never rewrites VS Code Settings. Older
-turns retain their historical stamps while the first fresh conversation uses
-the writer's current settings.
+### 3. Leading system prompts are rebuilt, not replayed
 
-Derived Carry Cues/session-attunement state is fresh-room memory and is not
-serialized. The Writer Profile is likewise global writer-owned settings data,
-not workspace session data. Raw preferred-address and bio strings never enter a
-session file. Fresh host/guest conversations assemble the currently enabled
-profile after restore.
+The leading system message is intentionally excluded from the conversation
+archive. It can contain old persona resources, global Writer Profile content,
+global Conversation Behavior, and standing directive renderings. Replaying it
+would silently freeze settings and prompt versions from the day a session was
+saved.
 
-### 3. Restored sessions are honest: full record, fresh memory (tier T2)
+On hydrate, the application rebuilds each leading system message from:
 
-Opening a session — via restart recovery or the browser — restores:
+- the current persona resources and expression profile;
+- the current validated global Conversation Behavior;
+- the currently enabled global Writer Profile;
+- the session-owned active standing directives, rendered from normalized
+  persisted payloads; and
+- the restored session/excerpt/context framing required by the current prompt
+  contract.
 
-- the excerpt (live, editable, version counters intact),
-- the context attachments (live),
-- the todo list (live — todos are writer-owned data, not model memory),
-- the **entire transcript as read-only history**, capped with the existing
-  divider-turn mechanism: *"Previous session restored — transcript preserved,
-  room memory not retained."*
+Historical turns keep their saved effective-behavior stamps. Opening a session
+never writes session values into global VS Code Settings and never serializes
+raw Writer Profile fields. Derived Carry Cues/attunement are not persisted;
+they are rebuilt only through future successful conversation.
 
-**Every provider conversation id is stripped at serialization.** Delivery
-cursors and pending host updates — which only have meaning relative to live
-provider conversations — are dropped with them. On hydrate,
-`hasHostConversation()` is false, persona selection re-unlocks, tool sidecars
-and guests appear only as their transcript record. The first post-restore
-turn starts a fresh conversation seeded by the normal join machinery. No
-restored session can ever throw `ConversationNotFoundError` — this is the
-single correctness invariant of the design, enforced by type (the snapshot
-schema has no field for conversation ids) rather than by discipline.
+### 4. T3 is normal; T2 is an explicit recovery fallback
 
-**Tier T3 (true cross-restart conversational memory) is explicitly deferred**,
-unchanged from the investigation: it requires persisting `ConversationManager`
-histories and answering the open product question of whether multi-day
-retained rooms are even desirable. T2 is the honest interim and the schema
-leaves room for it (a future `schemaVersion` bump).
+Opening `current.json` or a named session normally restores:
 
-### 4. Schema-versioned, tolerant-forward
+- the exact editable excerpt and context workspace;
+- todos, participants, artifacts, widget configs, and active standing
+  directives;
+- the full visible transcript; and
+- continuable host and guest conversations remapped to live runtime ids.
 
-Every file carries `schemaVersion`. Unknown or malformed files are skipped by
-the browser listing and ignored by restart recovery — surfaced as a log line,
-never a crash. `WorkshopSessionSnapshotV1` is implemented only after Sprint 12
-establishes the attachment-based session shape, so there is no pre-attachment
-v1 and no v1 → v2 migration. For future *named saves* (writer-created records),
-prefer additive fields and cheap tolerant reads over discard when the cost is
-small; the autosave blob may still reset on a breaking alpha schema change.
+Tool sidecars remain bounded/stateless according to their own ADRs; their
+visible reports and canonical structured artifacts still round-trip.
 
-Future session-owned state, including Conversation Widget authoring configs and
-standing directives, extends the snapshot through explicit typed optional
-fields with deterministic empty defaults. V1 does not reserve a generic
-`Record<string, unknown>` extension bag or guess widget payloads before their
-ADR. Stable turn/artifact/config ids survive round-trip unchanged, browser
-summary extraction ignores additive payloads, and provider conversation history
-can never be the sole durable source for a widget artifact under T2.
+If one or more conversation archives are malformed, incompatible, or cannot be
+validated, the store must not brick the rest of the writer’s session. It
+restores the product aggregate in **degraded T2 mode**, visibly marks the
+affected persona histories as non-continuable, and starts fresh histories for
+later turns. It logs structured diagnostics without exposing prompt contents.
+T2 is recovery behavior, not the default product promise.
 
-### 5. The session browser reuses the modal shell; the panel comes back on restart
+### 5. Time passage is trusted session context
 
-The browser lists `prose-minion/sessions/*.json` newest-first (title, saved
-date, persona, turn count, excerpt word count) with open and delete actions,
-built on the shared browser-modal shell extracted by Sprint 12 (which resolves
-tech-debt 2026-07-10-workshop-browser-modal-shell). Opening a session replaces
-the current one behind the same confirmation used by "New session".
+Sessions persist temporal state rather than asking the model to infer it:
 
-A `WebviewPanelSerializer` is registered for the Workshop panel (resolving
-tech-debt 2026-07-07): after a restart VS Code reopens the tab, and the
-provider rehydrates from `current.json` through the standard
-`WORKSHOP_REQUEST_SESSION` path. The serializer stores no state of its own —
-the JSON file is the single source of truth.
+- `startedAt` and the session’s original timezone;
+- `lastActivityAt`; and
+- the last successfully delivered time-notice timestamp per persona
+  conversation.
+
+The transcript receives a visible session-start marker. Reopening a persisted
+session adds a visible resume marker with the current local date/time and
+elapsed interval. A panel/webview reload in the same live extension-host
+session does not create a false resume event.
+
+The application queues a deterministic trusted time frame for the next
+persona-directed turn:
+
+- on the first persona turn in the session;
+- after a persisted session is resumed; and
+- whenever at least one hour has elapsed since that persona conversation last
+  received a successful time notice.
+
+The frame states session start, current time, elapsed duration, timezone, and
+reason. It explicitly forbids inferring what the writer did, thought, or felt
+during the gap. It is prepended by deterministic orchestration, not stored as a
+user-authored message and not produced by a background model call. Failed or
+cancelled turns do not advance the delivered timestamp, so the notice retries
+on the next attempt.
+
+### 6. Autosave and explicit save share one ordered coordinator
+
+`WorkshopSessionStore` owns paths, schema stamping, atomic/tolerant reads,
+summary extraction, and file operations. It is constructed in `extension.ts`
+and injected through `CoreServices`.
+
+One application-owned autosave coordinator marks `current.json` dirty after
+every successful mutation seam and serializes writes so an older write cannot
+win. It snapshots the aggregate and conversation archive as one logical
+revision. Future widget coordinators use the same seam and autosave only after
+their complete transaction: configuration, visible marker, system-message
+replacement, and telemetry invalidation.
+
+Explicit Save creates a named checkpoint from that same coherent snapshot.
+Opening a named checkpoint immediately promotes its hydrated state to
+`current.json`. New Session replaces `current.json` with a fresh-room snapshot
+after confirmation; stale conversation histories cannot resurrect.
+
+### 7. The browser adopts the approved interaction set
+
+The shared modal shell presents:
+
+- editable title in Save;
+- newest-first recent sessions;
+- search across title, participant metadata, excerpt, and transcript content;
+- grouping by date or excerpt identity;
+- open, rename-title, duplicate, reveal-file, and delete actions; and
+- clear distinction between the rolling current session and named checkpoints.
+
+Excerpt grouping uses persisted source identity when available and a stable
+excerpt fingerprint otherwise; the editable title is not the grouping key.
+Opening or deleting/replacing the current session confirms when unsaved
+committed changes would be displaced.
+
+Browser summaries are tolerant and independent of full hydration. Malformed or
+unknown-version files are skipped with diagnostics, never allowed to crash the
+browser.
+
+### 8. Widget configuration is session truth; Settings are defaults
+
+Conversation Widget values may also be stored in VS Code Settings as convenient
+last-used defaults. The ownership rule is:
+
+- Settings seed **new** widget instances.
+- The session snapshot owns the exact configuration of every committed
+  one-shot artifact and active standing directive.
+- Opening a session restores its saved configurations without mutating global
+  Settings.
+
+The persisted graph distinguishes `turnId`, `artifactId`, and
+`widgetConfigId`. Clone-and-recommit mints new identities and may record
+`clonedFromConfigId`; editing a standing directive preserves its config/directive
+identity and increments a revision. Both the session’s thread-artifact counter
+and each conversation archive’s artifact counter survive round-trip.
+
+No generic `Record<string, unknown>` extension bag is reserved. Widget
+collections are explicit typed optional fields with deterministic empty
+defaults. Conversation history is never the only durable home of canonical
+widget data, even though that history now also persists.
+
+### 9. Panel restoration has no second state store
+
+A Workshop `WebviewPanelSerializer` allows VS Code to reopen the editor tab.
+The serializer stores no Workshop state; it rehydrates from `current.json`
+through the normal request path. Manual reopen uses the same path.
 
 ## Consequences
 
 **Gains**
 
-- A restart or crash no longer destroys writer work; re-pasting the manuscript
-  and rebuilding context attachments — the sharpest papercut — is gone.
-- Sessions become durable, inspectable writer artifacts with a browsing UI.
-- The rolling working session restores without an explicit Save action; named
-  saves remain deliberate immutable checkpoints.
-- Zero new platform ports; one method added to `FileSystem`.
-- The dangling-conversation-id hazard is structurally impossible, not merely
-  avoided.
+- Restart, crash, and named-session restore return the writer to the actual
+  conversation and workspace they left.
+- Current prompt/profile/directive policy remains current without falsifying
+  historical turns.
+- Session-owned artifacts and future widgets have one typed durable graph.
+- Rich browser actions operate on stable identities rather than filenames
+  pretending to be domain objects.
+- Corrupt conversation history degrades locally instead of destroying the
+  manuscript/session record.
 
-**Costs / risks**
+**Costs and risks**
 
-- Manuscript text at rest under `prose-minion/sessions/` — document it; the
-  writer controls the folder.
-- Write-through on every mutation seam is a new cross-cutting concern on an
-  aggregate already near its size threshold (see tech-debt
-  2026-07-12-workshop-session-capability-artifact-extraction) — dirty marking
-  belongs at successful application mutation boundaries and ordered I/O in the
-  autosave coordinator, never inside the aggregate.
-- Serialized turn lists are unbounded (tech-debt
-  2026-07-11-workshop-session-turn-retention); acceptable now, and the file
-  format gives a natural place to window later.
-- A restored room *looks* continuous but the persona remembers nothing — the
-  divider turn is the mitigation, and it must be impossible to miss.
+- The sprint now crosses two state owners and needs an atomic application
+  boundary; this is materially larger than the former T2 serializer.
+- Full message histories increase file size and place conversation content at
+  rest in the workspace.
+- Rebuilt system prompts may differ from those used earlier. That is deliberate
+  current-policy behavior and must be test-visible.
+- Transcript and archive retention are unbounded in v1; later compaction must
+  preserve structured artifacts and stable identities.
+- Rich content search should start with a simple bounded scan and remain
+  cancellable; do not build an index until workspace scale proves it necessary.
 
-**Explicitly unchanged**
+## Explicitly unchanged
 
-- The webview persists nothing (`WorkshopPersistence = Record<string, never>`);
-  host-side state remains the only truth.
-- Tool sidecars stay stateless instruments; guests stay bounded (ADR
-  2026-07-11); no persistence tier grants anyone new memory.
-- `ConversationManager` is untouched — no provider-history serialization in
-  this ADR.
-- Writer Profile and derived Carry Cues state remain outside the session
-  snapshot; restoring visible history does not restore hidden personal memory.
+- The webview persists nothing; host-side state remains authoritative.
+- `WorkshopSessionService` remains a pure aggregate with no I/O.
+- Core imports no `vscode`; the extension app remains the only composition
+  root.
+- Tool sidecars do not gain open-ended persona memory.
+- Global Conversation Behavior and Writer Profile remain settings-owned.
 
 ## Implementation
 
-Sprint 10 of the Workshop epic, intentionally executed after Sprints 11 and 12,
-Relational Depth, and Writer Profile:
-[.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/10-session-persistence.md](../../.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/10-session-persistence.md).
+[Sprint 10: Session Persistence, Save, and the Session Browser](../../.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/10-session-persistence.md),
+executed after the Workshop aggregate and prompt boundary stabilize.

--- a/docs/adr/2026-07-16-inference-context-observability.md
+++ b/docs/adr/2026-07-16-inference-context-observability.md
@@ -143,11 +143,15 @@ The app never stores arbitrary router metadata, messages, or manuscript text as
 telemetry. Sprint 11B observes compression; it does not enable, disable, or
 replace it.
 
-### 6. Persistence does not resurrect live context
+### 6. Persistence restores history, not a live measurement
 
-Context snapshots are ephemeral conversation state. Sprint 10 persists neither
-conversation ids nor context-budget readings. A restored T2 session starts at
-`Not measured yet` until its fresh Workshop conversation completes a request.
+The 2026-07-23 persistence amendment restores retained message histories under
+logical participant keys and remaps them to fresh runtime conversation ids.
+The last context-budget reading may be retained as historical diagnostics, but
+it is never presented as a current measurement after hydrate: the leading
+system prompt is rebuilt and provider/model conditions may have changed. A
+restored conversation displays `Not measured after restore` until its next
+successful provider response commits a fresh reading.
 
 ## Consequences
 

--- a/docs/adr/2026-07-20-workshop-persona-interaction-modes-and-expression-profiles.md
+++ b/docs/adr/2026-07-20-workshop-persona-interaction-modes-and-expression-profiles.md
@@ -526,9 +526,10 @@ exposes the current object for the composer control and modal.
 
 Behavior-transition metadata is persisted with the next committed writer turn,
 not as a synthetic visible chat message. The retained message history and the
-extension-owned turn ledger keep their trusted frames; orchestration
-conversation ids remain ephemeral across persisted session restore even though
-an in-memory mode change preserves them.
+extension-owned turn ledger keep their trusted frames. Runtime orchestration
+conversation ids remain ephemeral across restore: Sprint 10 imports typed
+histories under logical participant keys, mints fresh ids, and rebuilds the
+leading system message from the current behavior/profile policy.
 
 If `carryCuesThroughSession` is enabled, the host may maintain a compact,
 structured attunement snapshot for the current Workshop session. Turning the

--- a/docs/design/Prose Minion - Assistant Tab (Direction B).html
+++ b/docs/design/Prose Minion - Assistant Tab (Direction B).html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Prose Minion — Assistant (Direction B)</title>
+<link rel="stylesheet" href="pm-mock.css">
+<link rel="stylesheet" href="pm-fulltab.css">
+<link rel="stylesheet" href="pm-direction-b.css">
+<template id="__bundler_thumbnail">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#15110d"/><rect x="30" y="30" width="40" height="40" rx="9" fill="#fff"/><circle cx="50" cy="46" r="11" fill="#e0673a"/><rect x="38" y="58" width="24" height="10" rx="2" fill="#3a1f2e"/></svg>
+</template>
+</head>
+<body>
+
+<div class="vscode fill">
+  <div class="vscode-tabbar">
+    <div class="vs-traffic"><i class="r"></i><i class="y"></i><i class="g"></i></div>
+    <div class="vs-tab active"><span class="ic" style="background:#fff"><img src="assets/prose-minion-book.png" style="width:13px;height:13px"></span> Prose Minion <span class="x" id="ignore-x"></span></div>
+    <div class="vs-tab" id="vt-md"><span class="x"></span> chapter-5.8-rewrite.md <span class="x"></span></div>
+  </div>
+
+  <div class="vscode-body">
+    <div class="ed-header">
+      <div class="pm-brand">
+        <div class="pm-logo"><img src="assets/prose-minion-book.png" alt=""></div>
+        <div>
+          <div class="pm-eyebrow" style="margin:0 0 4px">Prose Minion · Assistant</div>
+          <div class="pm-title" style="font-size:23px">Workshop — chapter 5.8</div>
+          <div class="pm-subtitle mono" style="font-size:12px"><span id="sub-icon"></span> Drafts/workshop/chapter-5.8-rewrite.md</div>
+        </div>
+      </div>
+      <div class="flex center gap12">
+        <button class="reset-btn" data-reset="1" title="Start a fresh session"><span id="reset-ic"></span> New session</button>
+        <div class="model-wrap">
+          <button class="model-btn" data-model-toggle="1"><span id="modelLabel">Claude Opus 4.8</span><span id="model-chev"></span></button>
+          <div class="model-menu" id="modelMenu">
+            <button data-model="Claude Opus 4.8">Claude Opus 4.8</button>
+            <button data-model="Claude Sonnet 4.6">Claude Sonnet 4.6</button>
+            <button data-model="GPT-5.2">GPT-5.2</button>
+            <button data-model="Gemini 3.5 Pro">Gemini 3.5 Pro</button>
+          </div>
+        </div>
+        <div class="pm-balance">
+          <div class="pm-balance-rows">
+            <div class="pm-balance-row"><span class="pm-dot blue"></span><span class="pm-balance-label">OpenRouter</span><span class="pm-balance-val">$12.40</span></div>
+            <div class="pm-balance-sub">Last request&nbsp; <b>$0.014</b></div>
+          </div>
+          <span class="pm-chev" id="bal-chev"></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="split fill">
+      <aside class="split-left" id="rail"></aside>
+      <section class="split-right">
+        <div id="thread"></div>
+        <div class="composer-wrap">
+          <div id="qbar"></div>
+          <div class="composer">
+            <button class="comp-add" id="composer-tools" title="Writing tools"><span id="add-ic"></span></button>
+            <input class="comp-input" id="composer-input" placeholder="Ask a follow-up, or pick a tool…" autocomplete="off">
+            <div class="comp-right">
+              <span class="comp-pill" id="composer-tools2" style="cursor:pointer"><span id="tools-ic"></span> Tools</span>
+              <button class="comp-send" id="composer-send"><span id="send-ic"></span></button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>
+
+<div class="modal-bd" id="modal"></div>
+<div id="toast"></div>
+
+<script src="icons.js"></script>
+<script src="pm-frames-fulltab.js"></script>
+<script src="pm-direction-b.js"></script>
+<script>
+  // fill static icon slots
+  document.getElementById('sub-icon').innerHTML = ICONS.doc({ size: 12 });
+  document.getElementById('reset-ic').innerHTML = ICONS.refresh({ size: 13 });
+  document.getElementById('model-chev').innerHTML = ICONS.chevDown({ size: 13 });
+  document.getElementById('bal-chev').innerHTML = ICONS.chevDown({ size: 14 });
+  document.getElementById('add-ic').innerHTML = ICONS.plus({ size: 18 });
+  document.getElementById('tools-ic').innerHTML = ICONS.grid({ size: 13 });
+  document.getElementById('send-ic').innerHTML = ICONS.send({ size: 16 });
+  document.getElementById('composer-tools2').addEventListener('click', () => document.getElementById('composer-tools').click());
+</script>
+</body>
+</html>

--- a/docs/design/Prose Minion - Assistant Tab.html
+++ b/docs/design/Prose Minion - Assistant Tab.html
@@ -3,90 +3,53 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Prose Minion — Assistant (Direction B)</title>
+<title>Prose Minion — Workshop</title>
 <link rel="stylesheet" href="pm-mock.css">
-<link rel="stylesheet" href="pm-fulltab.css">
-<link rel="stylesheet" href="pm-direction-b.css">
+<link rel="stylesheet" href="pm-widgets.css">
+<link rel="stylesheet" href="pm-workshop.css">
+<link rel="stylesheet" href="pm-wk-modals.css">
+<link rel="stylesheet" href="pm-sessions.css">
+<style>a{color:var(--accent-hi)}a:hover{color:var(--text)}</style>
 <template id="__bundler_thumbnail">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#15110d"/><rect x="30" y="30" width="40" height="40" rx="9" fill="#fff"/><circle cx="50" cy="46" r="11" fill="#e0673a"/><rect x="38" y="58" width="24" height="10" rx="2" fill="#3a1f2e"/></svg>
 </template>
 </head>
-<body>
+<body class="wk-body">
 
-<div class="vscode fill">
-  <div class="vscode-tabbar">
-    <div class="vs-traffic"><i class="r"></i><i class="y"></i><i class="g"></i></div>
-    <div class="vs-tab active"><span class="ic" style="background:#fff"><img src="assets/prose-minion-book.png" style="width:13px;height:13px"></span> Prose Minion <span class="x" id="ignore-x"></span></div>
-    <div class="vs-tab" id="vt-md"><span class="x"></span> chapter-5.8-rewrite.md <span class="x"></span></div>
+<div class="wk-app">
+  <div class="wk-topbar">
+    <div class="wk-tabs">
+      <div class="wk-tab"><span class="ic"><img src="assets/prose-minion-book.png" alt=""></span> Workshop <span class="x" id="wk-tabx"></span></div>
+    </div>
+    <div class="wk-topicons" id="wk-topicons"></div>
   </div>
 
-  <div class="vscode-body">
-    <div class="ed-header">
-      <div class="pm-brand">
-        <div class="pm-logo"><img src="assets/prose-minion-book.png" alt=""></div>
-        <div>
-          <div class="pm-eyebrow" style="margin:0 0 4px">Prose Minion · Assistant</div>
-          <div class="pm-title" style="font-size:23px">Workshop — chapter 5.8</div>
-          <div class="pm-subtitle mono" style="font-size:12px"><span id="sub-icon"></span> Drafts/workshop/chapter-5.8-rewrite.md</div>
-        </div>
-      </div>
-      <div class="flex center gap12">
-        <button class="reset-btn" data-reset="1" title="Start a fresh session"><span id="reset-ic"></span> New session</button>
-        <div class="model-wrap">
-          <button class="model-btn" data-model-toggle="1"><span id="modelLabel">Claude Opus 4.8</span><span id="model-chev"></span></button>
-          <div class="model-menu" id="modelMenu">
-            <button data-model="Claude Opus 4.8">Claude Opus 4.8</button>
-            <button data-model="Claude Sonnet 4.6">Claude Sonnet 4.6</button>
-            <button data-model="GPT-5.2">GPT-5.2</button>
-            <button data-model="Gemini 3.5 Pro">Gemini 3.5 Pro</button>
-          </div>
-        </div>
-        <div class="pm-balance">
-          <div class="pm-balance-rows">
-            <div class="pm-balance-row"><span class="pm-dot blue"></span><span class="pm-balance-label">OpenRouter</span><span class="pm-balance-val">$12.40</span></div>
-            <div class="pm-balance-sub">Last request&nbsp; <b>$0.014</b></div>
-          </div>
-          <span class="pm-chev" id="bal-chev"></span>
-        </div>
+  <header class="wk-header">
+    <div class="wk-brand">
+      <div class="wk-logo"><img src="assets/prose-minion-book.png" alt="Prose Minion"></div>
+      <div>
+        <div class="wk-eyebrow">Prose Minion · Assistant</div>
+        <h1 class="wk-title">Workshop</h1>
+        <div class="wk-sub" id="wk-sub"></div>
       </div>
     </div>
+    <div class="wk-hcluster" id="wk-hcluster"></div>
+  </header>
 
-    <div class="split fill">
-      <aside class="split-left" id="rail"></aside>
-      <section class="split-right">
-        <div id="thread"></div>
-        <div class="composer-wrap">
-          <div id="qbar"></div>
-          <div class="composer">
-            <button class="comp-add" id="composer-tools" title="Writing tools"><span id="add-ic"></span></button>
-            <input class="comp-input" id="composer-input" placeholder="Ask a follow-up, or pick a tool…" autocomplete="off">
-            <div class="comp-right">
-              <span class="comp-pill" id="composer-tools2" style="cursor:pointer"><span id="tools-ic"></span> Tools</span>
-              <button class="comp-send" id="composer-send"><span id="send-ic"></span></button>
-            </div>
-          </div>
-        </div>
-      </section>
-    </div>
+  <div class="wk-split">
+    <aside class="wk-rail" id="wk-rail"></aside>
+    <section class="wk-main">
+      <div class="wk-center" id="wk-center"></div>
+      <div class="wk-composer-wrap" id="wk-composer"></div>
+    </section>
   </div>
 </div>
 
-<div class="modal-bd" id="modal"></div>
-<div id="toast"></div>
+<div id="wk-toast"></div>
 
 <script src="icons.js"></script>
-<script src="pm-frames-fulltab.js"></script>
-<script src="pm-direction-b.js"></script>
-<script>
-  // fill static icon slots
-  document.getElementById('sub-icon').innerHTML = ICONS.doc({ size: 12 });
-  document.getElementById('reset-ic').innerHTML = ICONS.refresh({ size: 13 });
-  document.getElementById('model-chev').innerHTML = ICONS.chevDown({ size: 13 });
-  document.getElementById('bal-chev').innerHTML = ICONS.chevDown({ size: 14 });
-  document.getElementById('add-ic').innerHTML = ICONS.plus({ size: 18 });
-  document.getElementById('tools-ic').innerHTML = ICONS.grid({ size: 13 });
-  document.getElementById('send-ic').innerHTML = ICONS.send({ size: 16 });
-  document.getElementById('composer-tools2').addEventListener('click', () => document.getElementById('composer-tools').click());
-</script>
+<script src="pm-widgets.js"></script>
+<script src="pm-sessions.js"></script>
+<script src="pm-workshop.js"></script>
 </body>
 </html>

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -11,7 +11,8 @@ styles, scripts, and assets — no build step.
   `1219f905-e11d-4b1a-9fc9-f72634b10f4c` (owner: Okey Landers).
 - **Pulled via:** the `claude_design` MCP (`DesignSync` tool) + `/design-login`,
   2026-07-03; Workshop intake + context-bar comps re-pulled 2026-07-17; Persona
-  Schematic pulled 2026-07-21.
+  Schematic pulled 2026-07-21; **Workshop editor tab + session persistence
+  pulled 2026-07-23** (Sprint 10 interaction source of truth).
 - **Sync policy:** this folder is a snapshot, kept in sync by re-pulling from
   the design project (never hand-edit these files to change the design — edit
   in Claude Design, then re-pull). Local hand-edits are allowed only for
@@ -21,7 +22,8 @@ styles, scripts, and assets — no build step.
 
 | File | What it is | Status |
 |------|------------|--------|
-| `Prose Minion - Assistant Tab.html` | **Interactive prototype** of the full-tab Assistant, Direction B ("Split & pinned"): pinned excerpt + context rail on the left, chat thread with contextual quick-actions on the right, model dropdown, tools modal, toasts, localStorage-persisted thread. | **Approved direction — to implement** |
+| `Prose Minion - Assistant Tab.html` | **Interactive prototype** of the **Workshop editor tab** (Sprint 10 shape): full-viewport tab with the host/persona cluster, **Sessions menu** (New / Save / Open prior / Recent), model picker, pinned excerpt + context-budget rail, tools + widgets composer, and a restored-session state. Loads `pm-workshop.*` + `pm-sessions.*` + `pm-wk-modals.css` + `pm-widgets.*`. **Note:** this filename was repurposed from the old split-pane Assistant (now in `… (Direction B).html`). | **Approved interaction design** — persistence semantics are governed by the amended [ADR](../adr/2026-07-14-workshop-session-persistence.md) |
+| `Prose Minion - Assistant Tab (Direction B).html` | The earlier full-tab Assistant prototype, Direction B ("Split & pinned"): pinned excerpt + context rail, chat thread with contextual quick-actions, model dropdown, tools modal, localStorage-persisted thread. Superseded by the Workshop tab above; kept for reference (loads `pm-fulltab.css` + `pm-direction-b.*` + `pm-frames-fulltab.js`). | Reference / superseded |
 | `Prose Minion - Design Refresh.html` | The presentation canvas: Frame Minion design language applied to the sidebar chrome + all four tabs, the Writing Tools picker modal, and static comps of all three full-tab Assistant directions (A thread / B split / C branch board). | Reference / catalog |
 | `Prose Minion - Model Browser.html` | Sidebar-width model picker that replaces the model dropdown: search, By Provider / By Family pivots, filter chips, price + ctx badges, selected/offline states. | Designed, not implemented |
 | `Prose Minion - Intake Widgets.html` | **Interactive prototype** of the Sprint 12 excerpt & context intake: excerpt card (two-button empty state, verified paste provenance, locked-state `Update text…` / `Re-read from file`), context attachment pills + aggregate budget meter, and the category-grouped Context Selector modal with explore escape hatch. Self-contained (no `pm-*` support files). | **Approved — Sprint 12 source of truth** |
@@ -50,10 +52,67 @@ styles, scripts, and assets — no build step.
 - `pm-direction-b.js` — the interactive prototype logic for the Assistant Tab:
   per-tool analysis/action/variation content (`ASSIST`), streaming simulation,
   quick-action routing, tools modal, model menu, toasts, localStorage session.
+
+**Workshop editor tab (Sprint 10):**
+
+- `pm-workshop.css` / `pm-workshop.js` — **the Workshop tab** (`wk-` prefix,
+  `window.PMW`): app shell, header host/persona + model cluster, excerpt /
+  context-budget / tools / to-do rail, empty + restored-transcript center,
+  composer, toasts, and the host-picker / conversation-settings /
+  choose-from-project modals. Uses `pm-mock.css` tokens + the `pm-widgets.js`
+  modal shell.
+- `pm-sessions.css` / `pm-sessions.js` — **session persistence** UI
+  (`window.PMSessions`): the Sessions dropdown (New / Save / Open prior /
+  Recent), the **Save session** dialog (editable title, path preview, and
+  "included in this snapshot" manifest), and the **session browser** (search that greps
+  content, group by Date/Excerpt, per-row rename/duplicate/reveal/delete, and
+  the "memory not retained on restore" honesty note). Needs `pm-widgets.js` +
+  `pm-workshop.js`.
+- `pm-wk-modals.css` — shared Workshop modal chrome: sheet head,
+  conversation-settings segmented cards + toggles, host-picker grid,
+  choose-from-project file browser.
+- `pm-widgets.css` / `pm-widgets.js` — the **shared modal shell**
+  (`cwOpen`/`cwClose`/`cwXBtn` overlay) + the Conversation Widgets browser and
+  Gesture Playground. Load-bearing for both the Workshop session modals and the
+  next-epic widget spreads (see "Not pulled yet").
 - `assets/` — logo images. **Copied from
   [`apps/vscode-extension/assets/`](../../apps/vscode-extension/assets/)**
   (same files the extension ships) rather than pulled from the design project,
   to avoid duplicating binaries through the API.
+
+### Persistence reconciliation (2026-07-23)
+
+The synced prototype records the design state faithfully, including its
+“room memory not retained” restored divider and slug-only filename examples.
+Those two strings are **not** the implementation contract. Product planning now
+requires normal restore to continue retained persona conversations (T3), with
+the transcript-only treatment reserved for corrupt/incompatible-history
+recovery. Named files retain a collision-safe timestamped storage identity
+while the design's editable session name is stored as title metadata.
+
+The Save dialog, included-items manifest, Sessions menu, search, Date/Excerpt
+grouping, and rename/duplicate/reveal/delete browser actions are approved
+interaction scope. See the amended
+[session persistence ADR](../adr/2026-07-14-workshop-session-persistence.md)
+and [Sprint 10](../../.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/10-session-persistence.md)
+for behavioral truth. Do not hand-edit the synced prototype to erase this
+historical delta; update the remote design and re-pull when its copy catches up.
+
+## Present on remote, not pulled yet (next epic)
+
+The design project also holds the **Conversation Widgets** epic spreads — the
+epic that follows Workshop Editor Tab. They share only `pm-widgets.*` (already
+pulled above) and are deliberately left out of this snapshot until that epic
+starts. Re-pull with `DesignSync get_file` when it does:
+
+- `Prose Minion - Conversation Widgets.html` — Spread 01: the widget lifecycle
+  (play → commit → chip → clone-and-recommit), Gesture Playground live.
+- `Prose Minion - Lexical Gravity.html` + `pm-gravity.css` / `pm-gravity.js` —
+  Spread 02: the standing prose-directive rail.
+- `Prose Minion - Prose Controller.html` + `pm-controller.css` /
+  `pm-controller.js` — Spread 03: the seven-chapter craft control surface.
+- `Canvas.dc.html` + `support.js` — Claude Design's canvas-runtime scratch
+  frame, not a standalone prototype.
 
 ## Not pulled
 
@@ -73,7 +132,7 @@ Re-pull them with `DesignSync get_file` if ever needed.
 ## Viewing
 
 ```bash
-open "docs/design/Prose Minion - Assistant Tab.html"      # interactive prototype
+open "docs/design/Prose Minion - Assistant Tab.html"      # Workshop editor tab + session persistence
 open "docs/design/Prose Minion - Design Refresh.html"     # full design catalog
 open "docs/design/Prose Minion - Model Browser.html"      # model picker
 ```

--- a/docs/design/pm-sessions.css
+++ b/docs/design/pm-sessions.css
@@ -1,0 +1,70 @@
+/* ============================================================
+   Prose Minion — Session persistence: browser + save dialog
+   ============================================================ */
+/* ---------- session browser ---------- */
+.sb-toolbar{display:flex;align-items:center;gap:12px;padding:10px 26px 14px;flex:none}
+.sb-search{flex:1;display:flex;align-items:center;gap:11px;background:var(--inset);border:1px solid var(--border);border-radius:11px;padding:5px 12px 5px 14px}
+.sb-search .si{color:var(--dim);flex:none}
+.sb-search input{flex:1;background:none;border:0;outline:none;color:var(--text);font-size:13.5px;font-family:var(--sans);padding:8px 0}
+.sb-search input::placeholder{color:var(--faint)}
+.sb-search .grep{font-family:var(--mono);font-size:9.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--faint);border:1px solid var(--border-soft);border-radius:999px;padding:3px 8px;white-space:nowrap}
+.sb-group{display:flex;align-items:center;gap:8px;flex:none}
+.sb-group .lab{font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--dim)}
+.sb-seg{display:flex;background:var(--surface-2);border:1px solid var(--border);border-radius:9px;padding:3px}
+.sb-seg button{background:none;border:0;border-radius:7px;padding:6px 12px;font-size:12px;font-weight:600;color:var(--muted);cursor:pointer;font-family:var(--sans)}
+.sb-seg button.on{background:var(--surface-3);color:var(--text);box-shadow:0 0 0 1px rgba(224,103,58,.25)}
+
+.sb-body{overflow-y:auto;flex:1;min-height:0;padding:2px 20px 18px}
+.sb-gh{display:flex;align-items:baseline;gap:9px;padding:16px 6px 8px}
+.sb-gh .t{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);font-weight:600}
+.sb-gh .c{font-family:var(--mono);font-size:10px;color:var(--faint)}
+.sb-gh.first{padding-top:4px}
+
+.sb-row{position:relative;display:flex;align-items:flex-start;gap:14px;width:100%;text-align:left;background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:14px 15px;cursor:pointer;font-family:var(--sans);margin-bottom:9px;transition:border-color .12s,background .12s}
+.sb-row:hover{border-color:var(--border-2);background:var(--surface-2)}
+.sb-row.current{border-color:rgba(224,103,58,.45);background:var(--accent-soft)}
+.sb-host{flex:none;width:38px;height:38px;border-radius:10px;background:var(--surface-2);border:1px solid var(--border);display:grid;place-items:center;color:var(--accent-hi);position:relative}
+.sb-row.current .sb-host{background:rgba(224,103,58,.16);border-color:rgba(224,103,58,.4)}
+.sb-host .glyph{position:absolute;top:-3px;right:-4px;color:var(--accent-hi)}
+.sb-main{flex:1;min-width:0}
+.sb-titlerow{display:flex;align-items:center;gap:9px;margin-bottom:4px}
+.sb-title{font-size:14.5px;font-weight:700;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.sb-badge{font-family:var(--mono);font-size:9px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--accent-hi);border:1px solid rgba(224,103,58,.4);background:var(--accent-soft);border-radius:5px;padding:2px 7px;flex:none}
+.sb-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-family:var(--mono);font-size:11px;color:var(--muted);margin-bottom:6px}
+.sb-meta .dotsep{color:var(--faint)}
+.sb-meta .src{color:var(--dim)}
+.sb-meta .host{color:var(--accent-hi)}
+.sb-preview{font-size:12.5px;color:var(--dim);line-height:1.5;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.sb-preview .mk{color:var(--dim)}
+.sb-preview em{color:var(--amber);font-style:normal}
+.sb-note{display:inline-flex;align-items:center;gap:6px;margin-top:8px;font-size:11px;color:var(--amber);opacity:.9}
+.sb-note svg{flex:none}
+
+.sb-actions{position:absolute;top:11px;right:11px;display:flex;gap:5px;opacity:0;transition:opacity .12s}
+.sb-row:hover .sb-actions,.sb-row:focus-within .sb-actions{opacity:1}
+.sb-act{width:29px;height:29px;border-radius:8px;background:var(--surface-3);border:1px solid var(--border);color:var(--muted);display:grid;place-items:center;cursor:pointer}
+.sb-act:hover{color:var(--text);border-color:var(--border-2)}
+.sb-act.del:hover{color:#e8776b;border-color:rgba(224,90,78,.5);background:rgba(224,90,78,.08)}
+.sb-open{flex:none;align-self:center;display:flex;align-items:center;gap:6px;height:32px;padding:0 14px;border-radius:8px;background:var(--surface-3);border:1px solid var(--border-2);color:var(--text);font-size:12.5px;font-weight:600;cursor:pointer;font-family:var(--sans)}
+.sb-open:hover{background:#40301f}
+.sb-row.current .sb-open{background:linear-gradient(180deg,var(--accent-hi),var(--accent-lo));border-color:var(--accent-lo);color:#fff}
+.sb-rename{width:100%;box-sizing:border-box;background:var(--inset);border:1px solid var(--accent);border-radius:7px;color:var(--text);font-family:var(--sans);font-size:14px;font-weight:600;padding:5px 8px;outline:none;margin-bottom:4px}
+
+.sb-empty{text-align:center;color:var(--dim);font-size:13px;padding:48px 20px;line-height:1.6}
+.sb-empty svg{color:var(--faint);margin-bottom:10px}
+
+/* ---------- save dialog ---------- */
+.sv-body{padding:8px 26px 4px}
+.sv-field{margin-top:8px}
+.sv-label{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);margin-bottom:8px;display:block}
+.sv-input{width:100%;box-sizing:border-box;background:var(--inset);border:1px solid var(--border);border-radius:10px;color:var(--text);font-family:var(--sans);font-size:15px;font-weight:600;padding:12px 13px;outline:none}
+.sv-input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
+.sv-path{font-family:var(--mono);font-size:11.5px;color:var(--faint);margin-top:9px;display:flex;align-items:center;gap:7px}
+.sv-path b{color:var(--muted);font-weight:500}
+.sv-incl{margin-top:20px;border:1px solid var(--border-soft);background:var(--inset);border-radius:11px;padding:14px 15px}
+.sv-incl .h{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);margin-bottom:11px}
+.sv-inclrow{display:flex;align-items:center;gap:9px;font-size:12.5px;color:var(--text-2);padding:4px 0}
+.sv-inclrow svg{color:var(--green);flex:none}
+.sv-inclrow .m{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--faint)}
+.sv-note{display:flex;gap:9px;align-items:flex-start;font-size:11.5px;color:var(--muted);line-height:1.55;margin-top:16px}
+.sv-note svg{flex:none;color:var(--dim);margin-top:1px}

--- a/docs/design/pm-sessions.js
+++ b/docs/design/pm-sessions.js
@@ -1,0 +1,230 @@
+/* =========================================================================
+   Prose Minion — Session persistence UI. Needs pm-widgets.js (cwOpen/cwClose/
+   cwXBtn) + pm-workshop.js (window.PMW). Exposes window.PMSessions.
+   ========================================================================= */
+const PMSessions = (() => {
+  const esc = s => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  const trashIc = (o={}) => IC('<path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m2 0-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/>', Object.assign({sw:1.7}, o));
+  const P = () => window.PMW;
+
+  const EX = {
+    ch58: {title:'Pentecost', source:'Drafts/chapter-5.8.md', version:2, words:2015, text:`# Pentecost\n\nThey moved toward the auditorium as a group, but Nate felt himself floating slightly above the moment—in that hush before the brushstroke. The edge of something breaking.\n\nThe auditorium doors loomed ahead, heavy and dark.`},
+    ch6:  {title:'Blackout — the doors', source:'Drafts/chapter-6.md', version:1, words:2380, text:`# Blackout\n\nThe lights died all at once, and the gym became a throat. Kayla reached for a wall that had been there a second ago.\n\n"Nate?" Her voice went nowhere. "Nate, say something."`},
+    ch5:  {title:'Prom confrontation', source:'Drafts/chapter-5.md', version:3, words:1740, text:`# The gym floor\n\nRaven crossed the floor like she owned the deed to it. "You brought it here," she said. "To prom. Of all the nights."\n\nBradley didn't answer, which was its own kind of answer.`},
+    ch4:  {title:'Chapter 4 opening', source:'Drafts/chapter-4.md', version:1, words:3120, text:`# Chapter Four\n\nMorning came the way it always did in that town, gray and unhurried, indifferent to the thing they'd buried in the field the night before and the promises they'd made over the loose dirt.`},
+    raven:{title:'Raven voice study', source:'Characters/Raven/raven-voice-guide.md', version:1, words:980, text:`Raven — voice guide\n\nClipped. Sardonic when cornered. Never explains a joke. Trusts action over apology, and reads a room in the first three seconds she's in it.`},
+  };
+  const T = (...lines) => lines.map(l => ({who:l[0], text:l[1], by:l[2]}));
+
+  let SESSIONS = [
+    {id:'cur', current:true, title:'Pentecost — auditorium beat', host:'jill', turns:14, group:'today', rel:'autosaved · just now',
+     excerpt:{...EX.ch58}, key:'chapter-5.8.md',
+     preview:'Give one speaker a gesture instead of a word right before the group exit.',
+     context:[{kind:'text',label:'testing…',words:1},{kind:'file',label:'character-ava.md',words:2738},{kind:'file',label:'character-set-piece-moments.md',words:1908},{kind:'file',label:'character-chen.md',words:1252}],
+     todo:[{text:'Rework the exit beat — gesture, not a second monosyllable.',done:false},{text:'Check Micah is anchored before the door.',done:true}],
+     mode:'balanced', expr:'amplified',
+     transcript:T(['you','Look at the exit beat at the end of the Pentecost scene — does the dialogue land?'],['bot','The clipped <em>"Ya." / "Yep."</em> earns its terseness, but two bare monosyllables back-to-back flatten the rhythm right before the group exit. Let one speaker answer with a gesture instead of a word.'],['you','Do a tighter pass.'],['bot','Ava caught Raven\'s eye and winked. They moved for the door, Micah breaking the lead.'])},
+    {id:'s2', title:'Pentecost — dialogue pass', host:'dev', turns:9, group:'today', rel:'2h ago',
+     excerpt:{...EX.ch58, version:1}, key:'chapter-5.8.md',
+     preview:'Nate and Kayla read as one voice here — no tags, no distinct rhythm.',
+     context:[{kind:'file',label:'character-chen.md',words:1252}],
+     todo:[], mode:'analysis', expr:'full',
+     transcript:T(['you','Are Nate and Kayla distinct in this passage?'],['bot','Not yet — both speak in short declaratives with no tags. Give Kayla a hedge and Nate a clipped answer and they separate immediately.'])},
+    {id:'s3', title:'Kayla — blackout scene', host:'margot', turns:22, group:'week', rel:'Yesterday · 9:14 PM',
+     excerpt:{...EX.ch6}, key:'chapter-6.md',
+     preview:'Narration slips out of Kayla’s close third the moment the lights die.',
+     context:[{kind:'file',label:'character-kayla.md',words:1105},{kind:'file',label:'blackout-town.md',words:1480}],
+     todo:[{text:'Hold close-third through the blackout — no omniscient camera.',done:false}],
+     mode:'balanced', expr:'amplified', participants:['margot','penny'],
+     transcript:T(['you','Does the POV hold when the lights go out?'],['bot','It breaks — you cut to what the room looks like from <em>outside</em> Kayla. In pitch dark, close third should get only what she hears and touches.','margot'],['you','Penny, does that lose you?'],['bot','It does — the second the lights die I’m watching the gym instead of feeling the dark with her. Bring me back to her hands.','penny'])},
+    {id:'s4', title:'Prom confrontation', host:'edna', turns:6, group:'week', rel:'Yesterday · 2:03 PM',
+     excerpt:{...EX.ch5}, key:'chapter-5.md',
+     preview:'Raven reacts to the token before she could plausibly know about it.',
+     context:[], todo:[], mode:'analysis', expr:'full',
+     transcript:T(['you','Any logic breaks in the gym scene?'],['bot','One: Raven flinches at the marked token, but she hasn\'t been on-page since it appeared. Either move her earlier or cut the reaction.'])},
+    {id:'s5', title:'Chapter 4 opening', host:'felix', turns:17, group:'week', rel:'Mon · Jul 20',
+     excerpt:{...EX.ch4}, key:'chapter-4.md',
+     preview:'Three long sentences in a row — the open needs a short one to land.',
+     context:[{kind:'file',label:'chapter-4.md',words:3120}], todo:[], mode:'balanced', expr:'full',
+     transcript:T(['you','How\'s the rhythm of the opening?'],['bot','Dense — three long compound sentences stack before the reader gets a breath. One short sentence at the top would set the pace and let the third land.'])},
+    {id:'s6', title:'Raven voice study', host:'penny', turns:11, group:'earlier', rel:'Jul 14',
+     excerpt:{...EX.raven}, key:'raven-voice-guide.md',
+     preview:'As a reader I still don’t know why Raven trusts Nate this fast.',
+     context:[], todo:[], mode:'conversational', expr:'full',
+     transcript:T(['you','Read this as a first-timer — does Raven work?'],['bot','I like her, but I don\'t know why she trusts Nate so quickly. The page hasn\'t earned it yet — give me one beat where he proves it.'])},
+    {id:'s7', title:'Theme sweep — grief', host:'agnes', turns:28, group:'earlier', rel:'Jul 9',
+     excerpt:{...EX.ch58, version:1}, key:'chapter-5.8.md',
+     preview:'The brushstroke image carries the grief; the doorway does less.',
+     context:[{kind:'file',label:'thematic-structure.md',words:1150}], todo:[], mode:'balanced', expr:'amplified',
+     transcript:T(['you','Which images are actually pulling weight on grief here?'],['bot','The brushstroke — "the hush before the brushstroke" — is doing real thematic work. The looming doorway is a stock beat; make it specific to Nate or let the brushstroke stand alone.'])},
+  ];
+
+  const GROUPS = {today:'Today', week:'This week', earlier:'Earlier'};
+  const now = () => 'Jul 23';
+  const slug = s => s.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'').slice(0,42);
+
+  function sOpen(inner, cls){ cwOpen(inner); const m=document.querySelector('.cw-ov .cw-modal'); if(m&&cls) m.classList.add(...cls.split(' ')); return m; }
+  function hostChip(id, size){ return P().hostGlyphs(id, size); }
+
+  /* ---------- dropdown menu ---------- */
+  function renderMenu(el){
+    if (!el) return;
+    const recents = SESSIONS.filter(s=>!s.current).slice(0,3);
+    el.innerHTML = `
+      <div class="mh">Session</div>
+      <button class="wk-mitem" data-s-act="new">${ICONS.refresh({size:15,sw:1.7})} New session <span class="kbd">⌘⇧N</span></button>
+      <button class="wk-mitem" data-s-act="save">${ICONS.save({size:15,sw:1.7})} Save session… <span class="kbd">⌘S</span></button>
+      <hr>
+      <button class="wk-mitem" data-s-act="browse">${ICONS.cards({size:15,sw:1.7})} Open prior session…</button>
+      <div class="mh">Recent</div>
+      ${recents.map(s=>`<button class="wk-mrec" data-open="${s.id}"><span class="t">${esc(s.title)}</span><span class="m">${esc(P().hostName(s.host))} · ${esc(s.rel)}</span></button>`).join('')}
+      <hr>
+      <button class="wk-mitem" data-s-act="browse">${ICONS.search({size:15,sw:1.7})} Browse all sessions…</button>`;
+    el.onclick = e => {
+      const item = e.target.closest('[data-s-act],[data-open]');
+      if (!item) return;
+      el.classList.remove('open');
+      if (item.dataset.open){ const s=SESSIONS.find(x=>x.id===item.dataset.open); if(s) P().loadSession(s); return; }
+      const a = item.dataset.sAct;
+      if (a==='new') P().newSession();
+      if (a==='save') openSave();
+      if (a==='browse') openBrowser();
+    };
+  }
+
+  /* ---------- save dialog ---------- */
+  function openSave(){
+    const snap = P().currentSnapshot();
+    const exTitle = snap.excerpt ? snap.excerpt.title : 'Untitled session';
+    const autoName = `${exTitle} — ${snap.hostName} — ${now()}`;
+    const parts = snap.participants || [snap.host];
+    const guests = parts.filter(p=>p!==snap.host);
+    const partLabel = guests.length ? `${snap.hostName} + ${guests.length} guest${guests.length===1?'':'s'}` : `${snap.hostName} (host, solo)`;
+    const root = document.createElement('div'); root.className='cw-sheet-wrap';
+    root.appendChild(cwXBtn());
+    const incl = [
+      ['Excerpt', snap.excerpt ? `v${snap.excerpt.version} · ${P().fmt(snap.excerpt.words)} words` : 'none pinned yet'],
+      ['Transcript', `${snap.turns} turn${snap.turns===1?'':'s'} · complete`],
+      ['Participants', partLabel],
+      ['Context', `${snap.context.length} attachment${snap.context.length===1?'':'s'}`],
+      ['To-do list', `${snap.todo.length} item${snap.todo.length===1?'':'s'}`],
+      ['Room settings', `${P().MODES[snap.mode]} · ${snap.expr.charAt(0).toUpperCase()+snap.expr.slice(1)}`],
+    ];
+    root.insertAdjacentHTML('beforeend', `
+      <div class="wk-mhead"><div class="wk-mkicker">Workshop · Session</div><h2>Save session</h2><p class="wk-msub">Writes a complete snapshot you can reopen later. Your working room also autosaves on its own.</p></div>
+      <div class="wk-sheet-body"><div class="sv-body">
+        <div class="sv-field"><label class="sv-label">Session name</label><input class="sv-input" id="sv-name" value="${esc(autoName)}" autocomplete="off"><div class="sv-path">${ICONS.doc({size:12})}<span>prose-minion/sessions/<b id="sv-slug">${esc(slug(autoName))}</b>.json</span></div></div>
+        <div class="sv-incl"><div class="h">Included in this snapshot</div>${incl.map(r=>`<div class="sv-inclrow">${ICONS.check({size:13,sw:2.4})}<span>${r[0]}</span><span class="m">${r[1]}</span></div>`).join('')}</div>
+      </div></div>
+      <div class="wk-sheet-foot"><span class="note">Autosaves to <b style="color:var(--muted)">current.json</b>; this creates a named copy.</span><button class="mbtn" data-cancel>Cancel</button><button class="mbtn primary" data-save>Save session</button></div>`);
+    const name = root.querySelector('#sv-name'), slugEl = root.querySelector('#sv-slug');
+    name.addEventListener('input', ()=>{ slugEl.textContent = slug(name.value)||'untitled'; });
+    root.querySelector('[data-cancel]').addEventListener('click', cwClose);
+    root.querySelector('[data-save]').addEventListener('click', ()=>{
+      const nm = name.value.trim() || autoName;
+      const ns = {id:'saved-'+Date.now(), title:nm, host:snap.host, turns:snap.turns, group:'today', rel:'just now',
+        excerpt:snap.excerpt?{...snap.excerpt}:null, key:snap.excerpt?snap.excerpt.source.split('/').pop():'—',
+        preview:'Saved snapshot of the current working room.', context:snap.context.map(x=>({...x})), todo:snap.todo.map(x=>({...x})),
+        mode:snap.mode, expr:snap.expr, transcript:[]};
+      SESSIONS = SESSIONS.filter(s=>s.current).concat(ns, SESSIONS.filter(s=>!s.current));
+      P().setSessionName(nm); cwClose(); P().toast('Session saved — '+nm, 'save');
+    });
+    sOpen(root, 'sheet');
+    setTimeout(()=>{ name.focus(); name.select(); }, 40);
+  }
+
+  /* ---------- session browser ---------- */
+  function openBrowser(){
+    const view = {query:'', groupBy:'date', editingId:null, confirmDel:null};
+    const root = document.createElement('div'); root.className='cw-sheet-wrap';
+    root.appendChild(cwXBtn());
+    root.insertAdjacentHTML('beforeend', `
+      <div class="wk-mhead"><div class="wk-mkicker">Workshop · Sessions</div><h2>Open a prior session</h2><p class="wk-msub">Reopening restores the excerpt, context, and transcript. Room memory from a saved session isn't retained — the persona starts fresh.</p></div>
+      <div class="sb-toolbar">
+        <div class="sb-search"><span class="si">${ICONS.search({size:16})}</span><input id="sb-q" placeholder="Search names and session content…"><span class="grep">greps content</span></div>
+        <div class="sb-group"><span class="lab">Group by</span><div class="sb-seg"><button class="on" data-grp="date">Date</button><button data-grp="excerpt">Excerpt</button></div></div>
+      </div>
+      <div class="wk-sheet-body"><div class="sb-body" id="sb-body"></div></div>
+      <div class="wk-sheet-foot"><span class="note">Your working room autosaves to <b style="color:var(--muted)">current.json</b> and restores automatically when you reopen Workshop.</span><button class="mbtn" data-newses>${'New session'}</button></div>`);
+    const body = root.querySelector('#sb-body');
+    const q = root.querySelector('#sb-q');
+
+    const matches = s => {
+      if (!view.query) return true;
+      const hay = [s.title, s.excerpt&&s.excerpt.source, P().hostName(s.host), s.preview, ...(s.transcript||[]).map(t=>t.text)].join(' ').toLowerCase();
+      return hay.includes(view.query.toLowerCase());
+    };
+    const rowHTML = s => {
+      const badge = s.current ? `<span class="sb-badge">Current · autosaved</span>` : '';
+      const titleEl = view.editingId===s.id
+        ? `<input class="sb-rename" data-renameinput value="${esc(s.title)}">`
+        : `<span class="sb-title">${esc(s.title)}</span>`;
+      const src = s.excerpt ? s.excerpt.source : '—';
+      const note = `<span class="sb-note">${ICONS.bot({size:12,sw:1.6})} memory not retained on restore</span>`;
+      const delConfirm = view.confirmDel===s.id;
+      const actions = delConfirm
+        ? `<button class="sb-act del" data-del="${s.id}" title="Confirm delete">${ICONS.check({size:14,sw:2.2})}</button><button class="sb-act" data-delcancel title="Keep">${ICONS.x({size:13,sw:2})}</button>`
+        : `<button class="sb-act" data-rename="${s.id}" title="Rename">${ICONS.pen({size:13})}</button><button class="sb-act" data-dup="${s.id}" title="Duplicate">${ICONS.copy({size:13})}</button><button class="sb-act" data-reveal="${s.id}" title="Reveal file">${ICONS.doc({size:13})}</button><button class="sb-act del" data-del="${s.id}" title="Delete">${trashIc({size:14})}</button>`;
+      return `<div class="sb-row${s.current?' current':''}" data-open="${s.id}">
+        <div class="sb-host">${hostChip(s.host,22)}</div>
+        <div class="sb-main">
+          <div class="sb-titlerow">${titleEl}${badge}</div>
+          <div class="sb-meta"><span class="host">${esc(P().hostName(s.host))}</span><span class="dotsep">·</span><span>${s.turns} turns</span><span class="dotsep">·</span><span>${s.excerpt?P().fmt(s.excerpt.words)+' words':'no excerpt'}</span><span class="dotsep">·</span><span>${esc(s.rel)}</span><span class="dotsep">·</span><span class="src">${esc(src)}</span></div>
+          <div class="sb-preview">${esc(s.preview)}</div>
+          ${note}
+        </div>
+        <div class="sb-actions">${actions}</div>
+        <button class="sb-open" data-openbtn="${s.id}">Open</button>
+      </div>`;
+    };
+    const rebuild = () => {
+      const shown = SESSIONS.filter(matches);
+      if (!shown.length){ body.innerHTML = `<div class="sb-empty">${ICONS.search({size:22,sw:1.6})}<div>No sessions match “${esc(view.query)}”.</div></div>`; return; }
+      let html = '';
+      const cur = shown.find(s=>s.current);
+      if (cur) html += `<div class="sb-gh first"><span class="t">Current session</span><span class="c">restores automatically</span></div>` + rowHTML(cur);
+      const rest = shown.filter(s=>!s.current);
+      if (view.groupBy==='date'){
+        Object.keys(GROUPS).forEach(g=>{ const inG=rest.filter(s=>s.group===g); if(!inG.length) return;
+          html += `<div class="sb-gh"><span class="t">${GROUPS[g]}</span><span class="c">${inG.length}</span></div>` + inG.map(rowHTML).join(''); });
+      } else {
+        const keys=[]; rest.forEach(s=>{ if(!keys.includes(s.key)) keys.push(s.key); });
+        keys.forEach(k=>{ const inK=rest.filter(s=>s.key===k);
+          html += `<div class="sb-gh"><span class="t">${esc(k)}</span><span class="c">${inK.length}</span></div>` + inK.map(rowHTML).join(''); });
+      }
+      body.innerHTML = html;
+      if (view.editingId){ const inp=body.querySelector('[data-renameinput]'); if(inp){ inp.focus(); inp.select(); } }
+    };
+
+    const openSess = id => { const s=SESSIONS.find(x=>x.id===id); if(s){ cwClose(); P().loadSession(s); } };
+    body.addEventListener('click', e=>{
+      const r = a => e.target.closest('['+a+']');
+      let el;
+      if ((el=r('data-openbtn'))){ openSess(el.dataset.openbtn); return; }
+      if ((el=r('data-rename'))){ view.editingId=el.dataset.rename; view.confirmDel=null; rebuild(); return; }
+      if ((el=r('data-dup'))){ const s=SESSIONS.find(x=>x.id===el.dataset.dup); const c={...s, id:'dup-'+Date.now(), current:false, title:s.title+' (copy)', rel:'just now', group:'today'}; SESSIONS.splice(SESSIONS.indexOf(s)+1,0,c); P().toast('Duplicated — '+c.title,'copy'); rebuild(); return; }
+      if ((el=r('data-reveal'))){ const s=SESSIONS.find(x=>x.id===el.dataset.reveal); P().toast('Revealed prose-minion/sessions/'+slug(s.title)+'.json','doc'); return; }
+      if ((el=r('data-del'))){ const id=el.dataset.del; if(view.confirmDel===id){ SESSIONS=SESSIONS.filter(x=>x.id!==id); view.confirmDel=null; P().toast('Session deleted','check'); } else { view.confirmDel=id; } rebuild(); return; }
+      if (r('data-delcancel')){ view.confirmDel=null; rebuild(); return; }
+      // row body click = open (ignore when editing)
+      if (!view.editingId && e.target.closest('.sb-row') && !e.target.closest('.sb-actions')){ openSess(e.target.closest('.sb-row').dataset.open); }
+    });
+    body.addEventListener('keydown', e=>{
+      const inp = e.target.closest('[data-renameinput]'); if(!inp) return;
+      if (e.key==='Enter'){ const s=SESSIONS.find(x=>x.id===view.editingId); if(s) s.title=inp.value.trim()||s.title; view.editingId=null; P().toast('Renamed','pen'); rebuild(); }
+      if (e.key==='Escape'){ view.editingId=null; rebuild(); }
+    });
+    body.addEventListener('focusout', e=>{ const inp=e.target.closest('[data-renameinput]'); if(inp && view.editingId){ const s=SESSIONS.find(x=>x.id===view.editingId); if(s) s.title=inp.value.trim()||s.title; view.editingId=null; rebuild(); } });
+
+    q.addEventListener('input', ()=>{ view.query=q.value; view.editingId=null; view.confirmDel=null; rebuild(); });
+    root.querySelector('.sb-seg').addEventListener('click', e=>{ const b=e.target.closest('[data-grp]'); if(!b) return; view.groupBy=b.dataset.grp; root.querySelectorAll('.sb-seg button').forEach(x=>x.classList.toggle('on', x===b)); rebuild(); });
+    root.querySelector('[data-newses]').addEventListener('click', ()=>{ cwClose(); P().newSession(); });
+
+    sOpen(root, 'xwide sheet');
+    rebuild();
+    setTimeout(()=>q.focus(), 40);
+  }
+
+  return { renderMenu, openBrowser, openSave };
+})();
+window.PMSessions = PMSessions;

--- a/docs/design/pm-widgets.css
+++ b/docs/design/pm-widgets.css
@@ -1,0 +1,119 @@
+/* Conversation Widgets spread — cw- prefix, tokens from pm-mock.css */
+.cw-stage{width:640px;flex:none;background:#181310;border:1px solid var(--border-soft);border-radius:14px;padding:18px 18px 14px;box-shadow:0 20px 50px rgba(0,0,0,.35)}
+.cw-thread{display:flex;flex-direction:column;gap:16px;max-height:470px;overflow-y:auto;padding:2px 4px 14px;scroll-behavior:smooth}
+.cw-who{font-family:var(--mono);font-size:9.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);margin-bottom:5px;display:flex;align-items:center;gap:6px}
+.cw-who .dot{width:6px;height:6px;border-radius:50%;background:var(--accent)}
+.cw-msg.jill .cw-body{font-size:13px;line-height:1.65;color:var(--text-2);margin-right:36px}
+.cw-msg.you{margin-left:56px}
+.cw-msg.you .cw-who{justify-content:flex-end}
+.cw-msg.you .cw-body{background:var(--surface-2);border:1px solid var(--border);border-radius:10px;padding:9px 12px;font-size:13px;line-height:1.6;color:var(--text)}
+.cw-q{color:var(--accent-hi)}
+.cw-reco{display:inline-flex;align-items:center;gap:7px;margin-top:10px;padding:6px 12px;border-radius:999px;border:1px dashed rgba(224,103,58,.5);background:var(--accent-soft);color:var(--accent-hi);font-size:12px;font-weight:500;cursor:pointer}
+.cw-reco:hover{border-style:solid}
+.cw-reco .m{font-family:var(--mono);font-size:9.5px;color:var(--dim)}
+.cw-chipwrap{margin-top:8px;display:flex;justify-content:flex-end}
+.cw-chip{display:inline-flex;align-items:center;gap:8px;padding:6px 11px;border-radius:999px;border:1px solid rgba(224,103,58,.45);background:linear-gradient(180deg,rgba(224,103,58,.16),rgba(224,103,58,.06));color:var(--text-2);font-size:11.5px;font-weight:500;cursor:pointer}
+.cw-chip svg{color:var(--accent-hi)}
+.cw-chip .m{font-family:var(--mono);font-size:9.5px;color:var(--dim);border-left:1px solid var(--border);padding-left:8px}
+.cw-chip:hover{border-color:var(--accent);color:var(--text)}
+.cw-typing{display:flex;gap:4px;padding:6px 0 2px}
+.cw-typing i{width:6px;height:6px;border-radius:50%;background:var(--dim);animation:cwb 1s infinite}
+.cw-typing i:nth-child(2){animation-delay:.15s}.cw-typing i:nth-child(3){animation-delay:.3s}
+@keyframes cwb{0%,100%{opacity:.25}50%{opacity:1}}
+/* composer */
+.cw-composer{border:1px solid var(--border);background:#20180f;border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:12px;margin-top:4px}
+.cw-cinput{font-size:13px;color:var(--faint);padding:2px 4px;min-height:22px}
+.cw-crow{display:flex;align-items:center;gap:8px}
+.cw-sq{width:32px;height:32px;border-radius:9px;background:var(--surface-2);border:1px solid var(--border);display:grid;place-items:center;color:var(--muted);font-size:16px;cursor:pointer}
+.cw-acts{margin-left:auto;display:flex;align-items:center;gap:8px}
+.cw-abtn{display:flex;align-items:center;gap:7px;height:32px;padding:0 12px;border-radius:9px;background:var(--surface-2);border:1px solid var(--border);color:var(--text-2);font-size:12.5px;font-weight:500;cursor:pointer;font-family:var(--sans)}
+.cw-abtn svg{color:var(--muted)}
+.cw-abtn:hover{border-color:var(--border-2);color:var(--text)}
+.cw-abtn .sub{font-family:var(--mono);font-size:10px;color:var(--dim);border-left:1px solid var(--border);padding-left:7px;letter-spacing:.04em}
+.cw-wbtn{border-color:rgba(224,103,58,.45);background:rgba(224,103,58,.08)}
+.cw-wbtn svg{color:var(--accent-hi)}
+.cw-wbtn:hover{border-color:var(--accent)}
+.cw-send{width:32px;height:32px;border-radius:9px;background:linear-gradient(180deg,var(--accent-hi),var(--accent-lo));border:1px solid var(--accent-lo);display:grid;place-items:center;cursor:pointer;color:#fff}
+.cw-hint{text-align:center;font-size:11px;color:var(--faint);margin-top:9px}
+.cw-hint b{color:var(--accent-hi);font-weight:600}
+/* overlay + modal */
+.cw-ov{position:fixed;inset:0;background:rgba(10,7,5,.62);backdrop-filter:blur(2px);display:none;align-items:center;justify-content:center;z-index:60;padding:24px}
+.cw-ov.open{display:flex}
+.cw-modal{width:min(600px,100%);max-height:calc(100vh - 70px);overflow-y:auto;background:#1e1712;border:1px solid var(--border-2);border-radius:14px;box-shadow:0 40px 90px rgba(0,0,0,.6);position:relative}
+.cw-modal.narrow{width:min(460px,100%)}
+.cw-x{position:absolute;top:16px;right:16px;width:29px;height:29px;border-radius:8px;background:var(--surface-2);border:1px solid var(--border);color:var(--muted);display:grid;place-items:center;cursor:pointer;z-index:2}
+.cw-x:hover{color:var(--text);border-color:var(--border-2)}
+/* shared panel chrome */
+.cw-panel,.cw-browser{padding:22px 24px 18px}
+.cw-eyebrow{font-family:var(--mono);font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--dim);margin-bottom:8px;display:flex;gap:9px;align-items:center}
+.cw-panel h2,.cw-browser h3{font-size:18px;font-weight:650;margin:0 0 6px;letter-spacing:-.01em;display:flex;align-items:center;gap:9px;color:var(--text)}
+.cw-panel h2 svg{color:var(--accent-hi)}
+.cw-sub{font-size:12.5px;color:var(--muted);line-height:1.55;margin:0}
+.cw-sub b{color:var(--text-2)}
+.cw-banner{display:flex;gap:8px;align-items:flex-start;font-size:11.5px;line-height:1.55;border-radius:8px;padding:8px 11px;margin-top:14px}
+.cw-banner svg{flex:none;margin-top:1px}
+.cw-banner.seed{color:var(--accent-hi);border:1px solid rgba(224,103,58,.35);background:var(--accent-soft)}
+.cw-banner.clone{color:var(--amber);border:1px solid rgba(226,178,74,.35);background:rgba(226,178,74,.07)}
+/* fields */
+.cw-field{margin-top:13px}
+.cw-flabel{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);display:flex;gap:8px;align-items:center;margin-bottom:6px}
+.cw-flabel .src{color:var(--faint);border:1px solid var(--border-soft);border-radius:999px;padding:1px 7px;letter-spacing:.05em;text-transform:none;font-size:9.5px}
+.cw-in{width:100%;box-sizing:border-box;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;color:var(--text);font-family:var(--mono);font-size:12.5px;padding:8px 10px;outline:none}
+.cw-in:focus{border-color:var(--accent)}
+textarea.cw-in{resize:vertical;min-height:50px;line-height:1.55;font-family:var(--sans);font-size:12.5px}
+.cw-ctx{background:var(--inset);border:1px solid var(--border-soft);border-radius:8px;padding:9px 11px;font-family:var(--mono);font-size:11px;line-height:1.7;color:var(--muted)}
+.cw-ctx mark{background:var(--accent-soft);color:var(--accent-hi);border-radius:3px;padding:0 2px}
+/* generate */
+.cw-gen{margin-top:15px;width:100%;display:flex;align-items:center;justify-content:center;gap:8px;height:36px;border-radius:9px;background:linear-gradient(180deg,var(--accent-hi),var(--accent-lo));border:1px solid var(--accent-lo);color:#fff;font-size:12.5px;font-weight:600;cursor:pointer;font-family:var(--sans)}
+.cw-gen:hover{filter:brightness(1.06)}
+.cw-gen.busy{filter:saturate(.35) brightness(.8);cursor:wait}
+.cw-gen.ghost{width:auto;height:28px;padding:0 11px;margin:0;background:transparent;border:1px solid var(--border);color:var(--dim);font-weight:500;font-size:11.5px}
+.cw-gen.ghost:hover{color:var(--text-2);border-color:var(--border-2);filter:none}
+.cw-seam{font-family:var(--mono);font-size:10px;color:var(--faint);text-align:center;margin-top:7px}
+/* menu */
+.cw-mgh{display:flex;align-items:center;gap:10px;margin:16px 0 8px}
+.cw-mgh .t{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);font-weight:600;white-space:nowrap}
+.cw-mgh hr{flex:1;border:none;border-top:1px solid var(--border-soft);margin:0}
+.cw-opt{display:flex;gap:9px;align-items:flex-start;width:100%;box-sizing:border-box;text-align:left;background:var(--surface);border:1px solid var(--border);border-radius:9px;padding:8px 10px;cursor:pointer;color:var(--text-2);font-size:12.5px;line-height:1.5;font-family:var(--sans)}
+.cw-opt + .cw-opt{margin-top:6px}
+.cw-opt .bx{flex:none;width:15px;height:15px;border-radius:4px;border:1px solid var(--border-2);margin-top:2px;display:grid;place-items:center;color:transparent}
+.cw-opt:hover{border-color:var(--border-2)}
+.cw-opt.sel{background:var(--accent-soft);border-color:rgba(224,103,58,.5);color:var(--text)}
+.cw-opt.sel .bx{background:var(--accent);border-color:var(--accent-lo);color:#fff}
+/* footer */
+.cw-foot{display:flex;align-items:center;gap:10px;margin-top:20px;padding-top:14px;border-top:1px solid var(--border-soft)}
+.cw-fnote{flex:1;font-size:11px;color:var(--faint);line-height:1.5}
+.cw-fnote .cw-count{font-family:var(--mono);font-size:10.5px;color:var(--accent-hi)}
+.cw-btn{border:1px solid var(--border-2);background:var(--surface-3);color:var(--text);border-radius:9px;padding:8px 14px;font-size:12.5px;font-weight:600;cursor:pointer;font-family:var(--sans)}
+.cw-btn.ghost{background:transparent;border-color:transparent;color:var(--muted)}
+.cw-btn.primary{background:linear-gradient(180deg,var(--accent-hi),var(--accent-lo));border-color:var(--accent-lo);color:#fff}
+.cw-btn.primary:hover{filter:brightness(1.06)}
+.cw-btn.primary:disabled{filter:saturate(.3) brightness(.65);cursor:not-allowed}
+/* browser */
+.cw-browser p.bsub{font-size:12px;color:var(--muted);line-height:1.55;margin:0}
+.cw-brow{display:flex;gap:11px;width:100%;box-sizing:border-box;text-align:left;align-items:flex-start;background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:10px 11px;cursor:pointer;font-family:var(--sans)}
+.cw-brow + .cw-brow{margin-top:7px}
+.cw-brow .ic{flex:none;width:30px;height:30px;border-radius:8px;background:var(--surface-2);border:1px solid var(--border);display:grid;place-items:center;color:var(--accent-hi)}
+.cw-brow .bt{flex:1;min-width:0}
+.cw-brow .nm{font-size:13px;font-weight:600;color:var(--text);display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+.cw-brow .bl{font-size:11.5px;color:var(--dim);line-height:1.5;margin-top:3px}
+.cw-brow:hover{border-color:rgba(224,103,58,.5)}
+.cw-brow.dis{opacity:.55;cursor:not-allowed}
+.cw-brow.dis:hover{border-color:var(--border)}
+.cw-brow.dis .ic{color:var(--muted)}
+.cw-rail{font-family:var(--mono);font-size:9px;letter-spacing:.07em;text-transform:uppercase;border-radius:999px;padding:2px 7px;white-space:nowrap}
+.cw-rail.oneshot{color:var(--accent-hi);border:1px solid rgba(224,103,58,.4)}
+.cw-rail.standing{color:var(--amber);border:1px solid rgba(226,178,74,.35)}
+.cw-rail.resource{color:var(--blue);border:1px solid rgba(90,162,240,.35)}
+.cw-stag{font-family:var(--mono);font-size:9px;letter-spacing:.07em;text-transform:uppercase;color:var(--faint);border:1px solid var(--border-soft);border-radius:999px;padding:2px 7px;white-space:nowrap}
+/* framed (in-page) copies */
+.cw-framebox{width:560px;background:#1e1712;border:1px solid var(--border-2);border-radius:14px;box-shadow:0 20px 50px rgba(0,0,0,.35)}
+.cw-framebox.browser{width:430px}
+/* section 4 rail cards */
+.cw-railcard{width:470px;background:var(--surface);border:1px solid var(--border-soft);border-radius:14px;padding:16px 18px;box-shadow:0 20px 50px rgba(0,0,0,.35)}
+.cw-railcard .cap{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);font-weight:600;margin-bottom:11px;display:flex;align-items:center;gap:8px}
+.cw-code{background:var(--inset);border:1px solid var(--border-soft);border-radius:9px;padding:12px 14px;font-family:var(--mono);font-size:11px;line-height:1.75;color:var(--muted);white-space:pre-wrap;word-break:break-word}
+.cw-code .tag{color:var(--accent-hi)}
+.cw-code .k{color:var(--amber)}
+.cw-railcard .under{font-size:11.5px;color:var(--dim);line-height:1.6;margin:10px 0 0}
+.cw-chipdemo{display:flex;justify-content:center;padding:26px 0}

--- a/docs/design/pm-widgets.js
+++ b/docs/design/pm-widgets.js
@@ -1,0 +1,211 @@
+/* Conversation Widgets — spread logic. Needs icons.js (IC, ICONS). */
+const CWX = {
+  orbit: o=>IC('<circle cx="12" cy="12" r="3"/><circle cx="19" cy="5" r="2"/><circle cx="5" cy="19" r="2"/><path d="M10.4 21.9a10 10 0 0 0 9.9-15.4M13.6 2.1a10 10 0 0 0-9.9 15.4"/>',o),
+  sliders: o=>IC('<line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="2" y1="14" x2="6" y2="14"/><line x1="10" y1="8" x2="14" y2="8"/><line x1="18" y1="16" x2="22" y2="16"/>',o),
+  cap: o=>IC('<path d="M22 10 12 5 2 10l10 5z"/><path d="M6 12v5c3 3 9 3 12 0v-5"/>',o),
+  eye: o=>IC('<path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/>',o),
+};
+const cwIc = (n,o)=> (ICONS[n]||CWX[n])(o||{size:15,sw:1.7});
+const cwEsc = s=> s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+
+const CW_WIDGETS = [
+  {group:'Ready now', items:[
+    {id:'gesture',icon:'hand',name:'Gesture Playground',rail:'oneshot',railT:'one-shot',blurb:'One model call returns a menu of gesture directions for a phrase — keep the ones you want, commit them to the room.',tag:'Sprint 01',live:true}]},
+  {group:'Committed sprints', items:[
+    {id:'gravity',icon:'orbit',name:'Lexical Gravity',rail:'standing',railT:'standing',blurb:'Pull the passage’s lexis toward an interpretive lens — Photography, Mathematics, Music — with weight and reach.',tag:'Sprint 02'},
+    {id:'ctrl',icon:'sliders',name:'Prose Controller',rail:'standing',railT:'standing',blurb:'How the passage is made: diction, sentence architecture, rhythm, density, figurative texture, punctuation.',tag:'Sprint 03'},
+    {id:'blend',icon:'scale',name:'Gravity: Lens Blending',rail:'standing',railT:'standing',blurb:'Blend multiple lenses with explicit dominance weighting — never an unweighted average.',tag:'Sprint 04'}]},
+  {group:'Concept springs', items:[
+    {id:'decisions',icon:'stamp',name:'Decisions',rail:'oneshot',railT:'one-shot',blurb:'Append-only decision record; a deterministic scan assembles the running list.',tag:'concept'},
+    {id:'scratch',icon:'doc',name:'Project Scratch Pad',rail:'resource',railT:'resource',blurb:'Durable project notes; each append also leaves a visible thread event.',tag:'concept'},
+    {id:'learnen',icon:'cap',name:'Learner: English',rail:'oneshot',railT:'one-shot',blurb:'Lessons and drills; selected exercises commit as one-shot artifacts.',tag:'concept'},
+    {id:'learncraft',icon:'book',name:'Learner: Art of the Craft',rail:'oneshot',railT:'one-shot',blurb:'The Learner shell with a storytelling-craft curriculum pack.',tag:'concept'},
+    {id:'svt',icon:'eye',name:'Show vs. Tell Playground',rail:'oneshot',railT:'one-shot',blurb:'Recast a told beat as shown alternatives; keep the ones that land.',tag:'concept'}]}
+];
+
+const CW_MENU = [
+  {h:'The eyes', opts:['Her gaze snagged on him a half-second too long','She blinked once, slow, like a shutter on the wrong exposure','Her eyes went somewhere he couldn’t follow']},
+  {h:'The mouth, the face', opts:['The smile arrived late and left early','A smile assembled rather than felt','Her jaw loosened — not a smile, permission for one']},
+  {h:'Hands & body', opts:['She turned her mug a quarter-turn, then back','Her shoulders dropped a notch when the kettle clicked','Her thumbnail found the groove in the table and stayed']},
+  {h:'The reader’s read', opts:['He counted it as a win anyway','It was the smile she used on waiters','Whatever it was, it wasn’t for him']}
+];
+const CW_NOTES = 'Mara — guarded, recently bereaved, hates being read. She would never perform warmth for an audience.';
+
+/* ---------- overlay ---------- */
+let CW_OV = null;
+function cwOverlay(){
+  if(!CW_OV){
+    CW_OV = document.createElement('div'); CW_OV.className='cw-ov';
+    CW_OV.addEventListener('click', e=>{ if(e.target===CW_OV) cwClose(); });
+    document.addEventListener('keydown', e=>{ if(e.key==='Escape') cwClose(); });
+    document.body.appendChild(CW_OV);
+  }
+  return CW_OV;
+}
+function cwOpen(inner, narrow){
+  const ov = cwOverlay(); ov.innerHTML='';
+  const m = document.createElement('div'); m.className='cw-modal'+(narrow?' narrow':'');
+  m.setAttribute('role','dialog'); m.setAttribute('aria-modal','true');
+  m.appendChild(inner); ov.appendChild(m); ov.classList.add('open');
+}
+function cwClose(){ if(CW_OV){ CW_OV.classList.remove('open'); CW_OV.innerHTML=''; } }
+function cwXBtn(){
+  const b=document.createElement('button'); b.className='cw-x'; b.title='Close';
+  b.innerHTML=cwIc('x',{size:13,sw:1.8}); b.addEventListener('click',cwClose); return b;
+}
+
+/* ---------- widget browser ---------- */
+function buildWidgetBrowser(onPick, inModal, liveIds){
+  const el=document.createElement('div'); el.className='cw-browser';
+  if(inModal) el.appendChild(cwXBtn());
+  el.insertAdjacentHTML('beforeend',
+    `<div class="cw-eyebrow">Workshop · Composer</div><h3>Widgets</h3>
+     <p class="bsub">Interactive surfaces you <b>play with before anything commits</b>. Tools run once; messages just say things; a widget is played, then committed — a visible event plus an optional shaping payload.</p>`);
+  CW_WIDGETS.forEach(g=>{
+    el.insertAdjacentHTML('beforeend',`<div class="cw-mgh"><span class="t">${g.group}</span><hr></div>`);
+    g.items.forEach(w=>{
+      const b=document.createElement('button');
+      const live = liveIds ? liveIds.includes(w.id) : w.live;
+      b.className='cw-brow'+(live?'':' dis');
+      if(!live) b.title='Not playable in this spread — visible so the registry ships with honest state';
+      b.innerHTML=`<span class="ic">${cwIc(w.icon,{size:16,sw:1.7})}</span>
+        <span class="bt"><span class="nm">${w.name} <span class="cw-rail ${w.rail}">${w.railT}</span> <span class="cw-stag">${w.tag}</span></span>
+        <span class="bl">${w.blurb}</span></span>`;
+      if(live) b.addEventListener('click',()=>onPick(w));
+      el.appendChild(b);
+    });
+  });
+  return el;
+}
+
+/* ---------- gesture playground panel ---------- */
+function buildGesturePanel(o){
+  o = Object.assign({state:'input', banner:null, preselect:[], note:'', prefillNotes:false, live:true, onCommit:null}, o);
+  const root = document.createElement('div'); root.className='cw-panel';
+  if(o.live) root.appendChild(cwXBtn());
+  const notesVal = (o.prefillNotes || o.banner==='clone') ? CW_NOTES : '';
+  root.insertAdjacentHTML('beforeend', `
+    <div class="cw-eyebrow">Widget <span class="cw-rail oneshot">one-shot · thread-artifact</span></div>
+    <h2>${cwIc('hand',{size:17,sw:1.8})} Gesture Playground</h2>
+    <p class="cw-sub">A menu of gesture directions for one phrase. Play freely — <b>nothing touches the conversation until you commit</b>.</p>
+    <div class="cw-bslot"></div>
+    <div class="cw-field"><div class="cw-flabel">Target phrase <span class="src">seeded from selection</span></div><input class="cw-in cw-phrase" value="she smiled"></div>
+    <div class="cw-field"><div class="cw-flabel">Surrounding context <span class="src">from excerpt · kitchen scene</span></div>
+      <div class="cw-ctx">…He set the mug down where her hand could reach it without asking. “You kept the houseplants alive,” he said. <mark>She smiled.</mark> “Somebody had to.”…</div></div>
+    <div class="cw-field"><div class="cw-flabel">Character notes ${o.prefillNotes?'<span class="src">prefilled by Jill</span>':''}</div>
+      <textarea class="cw-in cw-notes" placeholder="Who is she in this beat?">${notesVal}</textarea></div>
+    <button class="cw-gen">${cwIc('sparkle',{size:14,sw:1.8})} Generate directions</button>
+    <div class="cw-seam">deterministic scaffold · one model call, fast tier · commit never re-runs it</div>
+    <div class="cw-menu" hidden></div>
+    <div class="cw-foot">
+      <span class="cw-fnote"><span class="cw-count"></span>Pre-commit play is free — only the commit pays context.</span>
+      ${o.live?'<button class="cw-btn ghost cw-cancel">Cancel</button>':''}
+      <button class="cw-btn primary cw-commit" disabled>${o.banner==='clone'?'Commit as new turn':'Commit to thread'}</button>
+    </div>`);
+  const bslot=root.querySelector('.cw-bslot');
+  if(o.banner==='seed') bslot.innerHTML=`<div class="cw-banner seed">${cwIc('sparkle',{size:13,sw:1.8})}<span><b>Recommended and prefilled by Jill.</b> Everything here is editable — she set the table, you decide what commits.</span></div>`;
+  if(o.banner==='clone') bslot.innerHTML=`<div class="cw-banner clone">${cwIc('refresh',{size:13,sw:1.8})}<span><b>Re-opened from a committed turn.</b> The old chip stays as history — committing again creates a <b>new</b> turn at the head. History is never rewritten.</span></div>`;
+  const menu=root.querySelector('.cw-menu'), gen=root.querySelector('.cw-gen'), commit=root.querySelector('.cw-commit');
+  /* menu content */
+  let mh='';
+  CW_MENU.forEach(g=>{
+    mh+=`<div class="cw-mgh"><span class="t">${g.h}</span><hr></div>`;
+    g.opts.forEach(p=>{ mh+=`<button class="cw-opt" data-p="${cwEsc(p)}"><span class="bx">${cwIc('check',{size:10,sw:3})}</span><span>${cwEsc(p)}</span></button>`; });
+  });
+  mh+=`<div class="cw-field"><div class="cw-flabel">Optional note to the room</div><input class="cw-in cw-note" placeholder="e.g. keep it small" value="${cwEsc(o.note)}"></div>`;
+  menu.innerHTML=mh;
+  const update=()=>{
+    const n=menu.querySelectorAll('.cw-opt.sel').length;
+    root.querySelector('.cw-count').textContent = menu.hidden?'':(n+' selected · ');
+    commit.disabled = !o.live || n===0;
+    if(!o.live) commit.title='Commit is live in the flow demo (§1)';
+  };
+  menu.addEventListener('click',e=>{ const b=e.target.closest('.cw-opt'); if(b){ b.classList.toggle('sel'); update(); } });
+  const reveal=()=>{ menu.hidden=false; gen.className='cw-gen ghost'; gen.innerHTML=`${cwIc('refresh',{size:12,sw:1.8})} Regenerate`; root.querySelector('.cw-seam').remove(); update(); };
+  gen.addEventListener('click',()=>{
+    if(gen.classList.contains('busy')) return;
+    gen.classList.add('busy'); gen.innerHTML='One fast model call…';
+    setTimeout(()=>{ gen.classList.remove('busy'); if(menu.hidden) reveal(); else gen.innerHTML=`${cwIc('refresh',{size:12,sw:1.8})} Regenerate`; }, 900);
+  });
+  if(o.state==='menu'){
+    reveal();
+    [...menu.querySelectorAll('.cw-opt')].forEach(b=>{ if(o.preselect.includes(b.dataset.p)) b.classList.add('sel'); });
+    update();
+  }
+  if(o.live){
+    root.querySelector('.cw-cancel').addEventListener('click',cwClose);
+    commit.addEventListener('click',()=>{
+      const phrases=[...menu.querySelectorAll('.cw-opt.sel')].map(b=>b.dataset.p);
+      o.onCommit && o.onCommit({phrases, note:menu.querySelector('.cw-note').value.trim()});
+    });
+  }
+  update();
+  return root;
+}
+
+/* ---------- live flow stage ---------- */
+function mountWidgetFlow(id){
+  const host=document.getElementById(id);
+  host.innerHTML=`<div class="cw-thread"></div>
+    <div class="cw-composer">
+      <div class="cw-cinput">Continue with Jill…</div>
+      <div class="cw-crow">
+        <button class="cw-sq" title="Attach">+</button>
+        <div class="cw-acts">
+          <button class="cw-abtn" title="Conversation settings"><svg viewBox="0 0 16 16" width="14" height="14" fill="none"><path d="M8 1.5L14.5 8 8 14.5 1.5 8 8 1.5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"></path></svg><b>Balanced</b><span class="sub">FULL</span></button>
+          <button class="cw-abtn">${cwIc('grid',{size:14,sw:1.7})}Tools</button>
+          <button class="cw-abtn cw-wbtn" title="Open a widget">${cwIc('sparkle',{size:14,sw:1.8})}Widgets</button>
+          <button class="cw-send">${cwIc('send',{size:15,sw:1.6})}</button>
+        </div>
+      </div>
+    </div>
+    <div class="cw-hint">Click <b>Widgets</b> — or Jill’s chip below her message</div>`;
+  const thread=host.querySelector('.cw-thread');
+  const add=(who,html)=>{
+    const m=document.createElement('div'); m.className='cw-msg '+who;
+    m.innerHTML=(who==='jill'?`<div class="cw-who"><span class="dot"></span>Jill · persona</div>`:`<div class="cw-who">You</div>`)+`<div class="cw-body">${html}</div>`;
+    thread.appendChild(m); thread.scrollTop=thread.scrollHeight; return m;
+  };
+  const openGesture=(opts)=> cwOpen(buildGesturePanel(Object.assign({live:true,onCommit:commitDraft},opts)));
+  const openBrowser=()=> cwOpen(buildWidgetBrowser(w=>{ if(w.id==='gesture') openGesture({}); }, true), true);
+
+  function commitDraft(d){
+    cwClose();
+    const m=add('you',`For <span class="cw-q">“she smiled”</span> — here are the gesture directions I want${d.note?` — <i>${cwEsc(d.note)}</i>`:''}.`);
+    const wrap=document.createElement('div'); wrap.className='cw-chipwrap';
+    const chip=document.createElement('button'); chip.className='cw-chip';
+    chip.innerHTML=`${cwIc('hand',{size:13,sw:1.8})} Gesture Playground <span class="m">${d.phrases.length} direction${d.phrases.length>1?'s':''} · re-open</span>`;
+    chip.title='Presentation-only — the model never sees this chip';
+    chip.addEventListener('click',()=> openGesture({state:'menu',banner:'clone',preselect:d.phrases,note:d.note}));
+    wrap.appendChild(chip); m.appendChild(wrap); thread.scrollTop=thread.scrollHeight;
+    const t=document.createElement('div'); t.className='cw-msg jill';
+    t.innerHTML=`<div class="cw-who"><span class="dot"></span>Jill · persona</div><div class="cw-typing"><i></i><i></i><i></i></div>`;
+    setTimeout(()=>{ thread.appendChild(t); thread.scrollTop=thread.scrollHeight; },500);
+    setTimeout(()=>{
+      const a=d.phrases[0], b=d.phrases[1];
+      let r='Took the beat again with your directions. ';
+      if(a) r+=`“<i>${cwEsc(a)}</i>” carries the turn now`;
+      if(b) r+=`, and it closes on “<i>${cwEsc(b)}</i>”`;
+      r+='. The stated smile is gone — the reader does the reading. Want the same pass at the other two smiles on this page?';
+      t.querySelector('.cw-typing').outerHTML=`<div class="cw-body">${r}</div>`;
+      thread.scrollTop=thread.scrollHeight;
+    },2100);
+  }
+
+  add('you','Here’s the kitchen scene again. The reunion beat still reads flat — she comes off cheerful, and she shouldn’t.');
+  const j=add('jill','You’re telling the reunion instead of letting it happen — <span class="cw-q">“she smiled”</span> does three different jobs on this page, and the one by the mug is the beat that matters. Want to play with alternatives before I take another pass?');
+  const reco=document.createElement('button'); reco.className='cw-reco';
+  reco.innerHTML=`${cwIc('hand',{size:13,sw:1.8})} Gesture Playground <span class="m">prefilled · “she smiled”</span>`;
+  reco.addEventListener('click',()=> openGesture({banner:'seed',prefillNotes:true}));
+  j.querySelector('.cw-body').appendChild(reco);
+  host.querySelector('.cw-wbtn').addEventListener('click',openBrowser);
+  return {openGesture, openBrowser};
+}
+
+/* ---------- static frame mounts ---------- */
+function mountBrowserFrame(id, openGesture){
+  document.getElementById(id).appendChild(buildWidgetBrowser(w=>{ if(w.id==='gesture') openGesture({}); }, false));
+}
+function mountGestureFrame(id, opts){
+  document.getElementById(id).appendChild(buildGesturePanel(Object.assign({live:false},opts)));
+}

--- a/docs/design/pm-wk-modals.css
+++ b/docs/design/pm-wk-modals.css
@@ -1,0 +1,97 @@
+/* ============================================================
+   Prose Minion — Workshop modals: shared sheet head,
+   conversation settings, host picker, choose-from-project
+   ============================================================ */
+.wk-mhead{padding:24px 26px 2px;flex:none}
+.wk-mkicker{font-family:var(--mono);font-size:10.5px;letter-spacing:.22em;text-transform:uppercase;color:var(--dim);margin-bottom:7px}
+.wk-mhead h2{font-size:21px;font-weight:700;margin:0 0 8px;letter-spacing:-.01em;color:var(--text)}
+.wk-msub{font-size:13px;color:var(--muted);line-height:1.55;margin:0}
+
+/* ---------- conversation settings ---------- */
+.cs-tabs{display:flex;gap:24px;margin:18px 26px 0;border-bottom:1px solid var(--border-soft);flex:none}
+.cs-tab{appearance:none;background:none;border:0;padding:9px 2px;font-size:13.5px;font-weight:600;color:var(--dim);cursor:pointer;position:relative}
+.cs-tab:hover{color:var(--text-2)}
+.cs-tab.on{color:var(--text)}
+.cs-tab.on::after{content:"";position:absolute;left:0;right:0;bottom:-1px;height:2px;background:var(--accent);border-radius:2px}
+.cs-pane{display:none;padding:2px 26px 24px}
+.cs-pane.on{display:block}
+.msec{margin-top:22px}
+.msec-h{display:flex;align-items:center;gap:12px;margin-bottom:12px}
+.msec-h .t{font-family:var(--mono);font-size:10.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--dim);font-weight:600;white-space:nowrap}
+.msec-h hr{flex:1;border:0;border-top:1px solid var(--border-soft);margin:0}
+.segcards{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
+.segcard{background:var(--surface);border:1px solid var(--border);border-radius:11px;padding:13px 14px;cursor:pointer;text-align:left;transition:border-color .12s,background .12s;font-family:var(--sans)}
+.segcard:hover{border-color:var(--border-2)}
+.segcard .sc-top{display:flex;align-items:center;gap:8px;margin-bottom:7px}
+.segcard .sc-top svg{width:16px;height:16px;color:var(--muted);flex:none}
+.segcard .sc-name{font-size:14px;font-weight:700;color:var(--text-2)}
+.segcard .sc-desc{font-size:11.5px;color:var(--dim);line-height:1.5}
+.segcard.sel{background:var(--accent-soft);border-color:rgba(224,103,58,.5)}
+.segcard.sel .sc-name{color:var(--text)}
+.segcard.sel .sc-top svg{color:var(--accent-hi)}
+.segcard.sel .sc-desc{color:var(--muted)}
+.msec-note{font-size:12px;color:var(--dim);line-height:1.55;margin-top:11px}
+.msec-note b{color:var(--muted);font-weight:600}
+.trow{display:flex;align-items:flex-start;gap:12px;padding:12px 13px;background:var(--surface);border:1px solid var(--border);border-radius:11px}
+.trow-txt{flex:1;min-width:0}
+.trow-name{font-size:13.5px;font-weight:600;color:var(--text)}
+.trow-desc{font-size:12px;color:var(--dim);line-height:1.5;margin-top:3px}
+.tog{flex:none;width:38px;height:22px;border-radius:999px;background:var(--surface-3);border:1px solid var(--border-2);position:relative;cursor:pointer;transition:background .15s;margin-top:2px}
+.tog i{position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:var(--muted);transition:left .15s,background .15s}
+.tog.on{background:var(--accent);border-color:var(--accent-lo)}
+.tog.on i{left:18px;background:#fff}
+.field{margin-top:17px}
+.field-label{font-size:13.5px;font-weight:600;color:var(--text);margin-bottom:7px;display:block}
+.tin,.tar{width:100%;box-sizing:border-box;background:var(--inset);border:1px solid var(--border);border-radius:9px;color:var(--text);font-family:var(--sans);font-size:13px;padding:10px 12px}
+.tin::placeholder,.tar::placeholder{color:var(--faint)}
+.tin:focus,.tar:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
+.tar{min-height:110px;line-height:1.55;resize:vertical}
+.counter{font-family:var(--mono);font-size:10.5px;color:var(--faint);text-align:right;margin-top:6px}
+.cs-notice{display:flex;gap:9px;padding:12px 13px;background:var(--inset);border:1px solid var(--border-soft);border-radius:9px;margin-top:18px;font-size:12px;color:var(--muted);line-height:1.55}
+.cs-notice svg{flex:none;color:var(--dim);margin-top:1px}
+.cs-notice b{color:var(--text-2)}
+
+/* ---------- host picker ---------- */
+.hp-body{padding:6px 26px 24px}
+.hp-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px 22px}
+.hp-cell{display:flex;flex-direction:column;gap:9px}
+.hp-card{position:relative;background:var(--surface);border:1px solid var(--border);border-radius:13px;padding:16px;cursor:pointer;text-align:left;transition:border-color .12s,background .12s;font-family:var(--sans)}
+.hp-card:hover{border-color:var(--border-2)}
+.hp-card.sel{border-color:var(--accent);background:var(--accent-soft);box-shadow:0 0 0 1px rgba(224,103,58,.35)}
+.hp-ic{position:relative;width:26px;height:26px;color:var(--accent-hi);margin-bottom:12px}
+.hp-ic .glyph{position:absolute;top:-4px;right:-7px;color:var(--accent-hi)}
+.hp-name{font-size:16px;font-weight:700;color:var(--text);margin-bottom:5px}
+.hp-spec{font-size:12.5px;font-weight:600;color:var(--accent-hi);margin-bottom:9px}
+.hp-desc{font-size:12.5px;color:var(--muted);line-height:1.55}
+.hp-more{display:inline-flex;align-items:center;gap:6px;background:none;border:0;color:var(--dim);font-size:12.5px;font-weight:600;cursor:pointer;padding:0 2px;font-family:var(--sans)}
+.hp-more:hover{color:var(--accent-hi)}
+.hp-more svg{width:13px;height:13px}
+
+/* ---------- choose from project (excerpt) ---------- */
+.cfp-body{padding:8px 26px 8px}
+.cfp-search{display:flex;align-items:center;gap:12px;background:var(--inset);border:1px solid var(--border);border-radius:12px;padding:6px 8px 6px 16px;margin:6px 0 18px}
+.cfp-search .si{color:var(--dim);flex:none}
+.cfp-search input{flex:1;background:none;border:0;outline:none;color:var(--text);font-size:14px;font-family:var(--sans);padding:8px 0}
+.cfp-search input::placeholder{color:var(--faint)}
+.cfp-seg{display:flex;background:var(--surface-2);border:1px solid var(--border);border-radius:9px;padding:3px;flex:none}
+.cfp-seg button{background:none;border:0;border-radius:7px;padding:7px 14px;font-size:12.5px;font-weight:600;color:var(--muted);cursor:pointer;font-family:var(--sans)}
+.cfp-seg button.on{background:linear-gradient(180deg,var(--accent-hi),var(--accent-lo));color:#fff}
+.cfp-cats{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+.cfp-cat{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:18px 18px 16px;cursor:pointer;text-align:left;font-family:var(--sans)}
+.cfp-cat:hover{border-color:var(--accent);background:var(--surface-2)}
+.cfp-cat .cn{font-size:15.5px;font-weight:700;color:var(--text);margin-bottom:8px}
+.cfp-cat .cm{font-family:var(--mono);font-size:12px;color:var(--dim)}
+.cfp-explore{display:flex;align-items:center;gap:10px;width:100%;margin-top:12px;border:1px dashed var(--border-2);background:none;border-radius:11px;padding:14px 16px;color:var(--muted);font-size:13px;cursor:pointer;text-align:left;font-family:var(--sans)}
+.cfp-explore:hover{border-color:var(--accent);color:var(--text)}
+.cfp-explore svg{flex:none;color:var(--dim)}
+.cfp-explore .h{color:var(--faint)}
+.cfp-nav{display:flex;align-items:center;gap:12px;margin-bottom:8px}
+.cfp-back{display:flex;align-items:center;gap:6px;border:1px solid var(--border);background:var(--surface-2);border-radius:8px;padding:6px 12px;font-size:12.5px;color:var(--text-2);cursor:pointer;font-family:var(--sans)}
+.cfp-back:hover{border-color:var(--border-2);color:var(--text)}
+.cfp-crumb{font-family:var(--mono);font-size:13px;color:var(--muted)}
+.cfp-files{display:flex;flex-direction:column}
+.cfp-file{display:flex;align-items:center;gap:14px;width:100%;text-align:left;background:none;border:0;border-bottom:1px solid var(--border-soft);padding:14px 6px;cursor:pointer;font-family:var(--mono);font-size:14px;color:var(--text-2)}
+.cfp-file:hover{color:var(--text);background:rgba(255,255,255,.02)}
+.cfp-file .fp{flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cfp-file .fw{color:var(--faint);white-space:nowrap;font-size:13px}
+.cfp-foot-note{font-size:12.5px;color:var(--dim)}

--- a/docs/design/pm-workshop.css
+++ b/docs/design/pm-workshop.css
@@ -1,0 +1,221 @@
+/* ============================================================
+   Prose Minion — Workshop tab (consolidated) — wk- prefix
+   Tokens from pm-mock.css · modal shell from pm-widgets.css
+   ============================================================ */
+html,body{height:100%}
+body.wk-body{margin:0;background:#0e0c0a;overflow:hidden}
+
+/* ---------- app shell (full viewport) ---------- */
+.wk-app{height:100vh;display:flex;flex-direction:column;background:var(--bg);background-image:linear-gradient(180deg,var(--bg-grad-top) 0%,var(--bg) 240px);overflow:hidden;font-family:var(--sans);color:var(--text);-webkit-font-smoothing:antialiased}
+.wk-topbar{flex:none;display:flex;align-items:center;justify-content:space-between;height:36px;background:#181513;border-bottom:1px solid #000}
+.wk-tabs{display:flex;align-items:stretch;height:100%}
+.wk-tab{display:flex;align-items:center;gap:9px;height:100%;padding:0 15px;font-size:12.5px;color:var(--text);background:#2a2017;border-right:1px solid #000;box-shadow:inset 0 2px 0 var(--accent)}
+.wk-tab .ic{width:15px;height:15px;border-radius:3px;background:#fff;display:grid;place-items:center;overflow:hidden}
+.wk-tab .ic img{width:12px;height:12px;object-fit:contain}
+.wk-tab .x{color:var(--faint);cursor:pointer;display:grid;place-items:center;margin-left:2px}
+.wk-topicons{display:flex;align-items:center;gap:15px;padding:0 15px;color:var(--dim)}
+.wk-topicons span{display:grid;place-items:center;cursor:default}
+.wk-topicons .spark{color:var(--accent-hi)}
+
+/* ---------- header band ---------- */
+.wk-header{position:relative;flex:none;display:flex;align-items:flex-start;justify-content:space-between;gap:20px;padding:20px 26px 22px}
+.wk-header::after{content:"";position:absolute;left:0;right:0;bottom:0;height:2px;background:var(--accent-line)}
+.wk-brand{display:flex;gap:14px;align-items:center;min-width:0}
+.wk-logo{width:52px;height:52px;border-radius:12px;background:#fff;display:grid;place-items:center;flex:none;box-shadow:0 2px 12px rgba(0,0,0,.4);overflow:hidden}
+.wk-logo img{width:44px;height:44px;object-fit:contain}
+.wk-eyebrow{font-family:var(--mono);font-size:10.5px;letter-spacing:.2em;text-transform:uppercase;color:var(--dim);margin:0 0 5px}
+.wk-title{font-size:25px;font-weight:800;letter-spacing:-.02em;line-height:1.05;margin:0}
+.wk-sub{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;color:var(--muted);margin-top:6px}
+.wk-sub svg{color:var(--dim);flex:none}
+.wk-sub .v{color:var(--accent-hi)}
+
+.wk-hcluster{display:flex;align-items:center;gap:10px;flex:none}
+.wk-persona{display:flex;align-items:center;gap:8px;padding:7px 13px 7px 11px;border-radius:999px;border:1px solid var(--border);background:var(--surface-2);color:var(--text);font-size:12.5px;font-weight:600;cursor:pointer}
+.wk-persona:hover{border-color:var(--accent);background:var(--accent-soft)}
+.wk-persona .pav{position:relative;width:18px;height:18px;color:var(--accent-hi);display:grid;place-items:center}
+.wk-persona .pav .glyph{position:absolute;top:-4px;right:-5px;color:var(--accent-hi)}
+.wk-hbtn{display:flex;align-items:center;gap:8px;height:34px;padding:0 13px;border-radius:9px;background:var(--surface-2);border:1px solid var(--border);color:var(--text-2);font-size:12.5px;font-weight:600;cursor:pointer;font-family:var(--sans)}
+.wk-hbtn:hover{border-color:var(--border-2);color:var(--text)}
+.wk-hbtn svg{color:var(--muted);flex:none}
+.wk-hbtn .chev{color:var(--dim)}
+.wk-hbtn>span:not(.chev){max-width:190px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.wk-proc{font-size:12px;color:var(--muted);white-space:nowrap}
+.wk-proc b{color:var(--text-2);font-weight:600;font-variant-numeric:tabular-nums}
+.wk-bal{display:flex;align-items:center;gap:7px;font-size:12.5px;color:var(--text-2);white-space:nowrap}
+.wk-bal .dot{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 7px rgba(111,201,138,.55)}
+.wk-bal b{color:var(--text);font-weight:700;font-variant-numeric:tabular-nums}
+.wk-sep{width:1px;height:22px;background:var(--border-soft)}
+
+/* dropdown menu (sessions) */
+.wk-menuwrap{position:relative}
+.wk-menu{position:absolute;top:calc(100% + 8px);right:0;min-width:300px;background:#1e1712;border:1px solid var(--border-2);border-radius:12px;box-shadow:0 26px 64px rgba(0,0,0,.6);padding:6px;z-index:70;display:none}
+.wk-menu.open{display:block}
+.wk-menu .mh{font-family:var(--mono);font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--dim);padding:9px 11px 5px}
+.wk-mitem{display:flex;align-items:center;gap:11px;width:100%;text-align:left;background:none;border:0;border-radius:8px;padding:9px 11px;color:var(--text-2);font-size:13px;cursor:pointer;font-family:var(--sans)}
+.wk-mitem:hover{background:var(--surface-2);color:var(--text)}
+.wk-mitem svg{color:var(--muted);flex:none}
+.wk-mitem .kbd{margin-left:auto;font-family:var(--mono);font-size:10px;color:var(--faint);letter-spacing:.04em}
+.wk-menu hr{border:0;border-top:1px solid var(--border-soft);margin:6px 6px}
+.wk-mrec{display:flex;flex-direction:column;gap:2px;align-items:flex-start;width:100%;text-align:left;background:none;border:0;border-radius:8px;padding:8px 11px;cursor:pointer;font-family:var(--sans)}
+.wk-mrec:hover{background:var(--surface-2)}
+.wk-mrec .t{font-size:12.5px;color:var(--text);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
+.wk-mrec .m{font-family:var(--mono);font-size:10px;color:var(--dim)}
+
+/* ---------- split ---------- */
+.wk-split{flex:1;min-height:0;display:grid;grid-template-columns:372px 1fr}
+.wk-rail{border-right:1px solid var(--border-soft);background:rgba(0,0,0,.16);overflow-y:auto;padding:22px 22px 20px;display:flex;flex-direction:column;gap:22px}
+.wk-main{min-width:0;display:flex;flex-direction:column;overflow:hidden}
+
+/* rail sections */
+.wk-sec{display:flex;flex-direction:column}
+.wk-sechead{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:11px;min-height:20px}
+.wk-sechead .pm-eyebrow{margin:0;display:flex;align-items:center;gap:7px}
+.wk-sechead .pm-eyebrow svg{color:var(--dim)}
+.wk-secmeta{font-family:var(--mono);font-size:10.5px;color:var(--faint)}
+.wk-sec .cap{font-size:11.5px;color:var(--dim);line-height:1.55;margin-top:10px}
+.stat-chip{font-family:var(--mono);font-size:10px;font-weight:600;letter-spacing:.08em;color:var(--accent-hi);border:1px solid rgba(224,103,58,.4);background:var(--accent-soft);border-radius:5px;padding:3px 8px;white-space:nowrap}
+.stat-chip.lock{color:var(--amber);border-color:rgba(226,178,74,.35);background:rgba(226,178,74,.08)}
+
+/* big empty-state buttons */
+.btnstack{display:flex;flex-direction:column;gap:9px}
+.bigbtn{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:7px;border:1px dashed var(--border-2);background:var(--surface-2);border-radius:10px;color:var(--text-2);font-size:13.5px;font-weight:600;cursor:pointer;padding:20px 14px;text-align:center;font-family:var(--sans)}
+.bigbtn:hover{border-color:var(--accent);color:var(--text);border-style:solid;background:var(--surface-3)}
+.bigbtn svg{width:18px;height:18px;color:var(--muted)}
+.bigbtn:hover svg{color:var(--accent-hi)}
+.bigbtn .sub{font-size:11px;color:var(--faint);font-weight:400;line-height:1.4}
+
+/* small buttons */
+.sbtn{display:inline-flex;align-items:center;gap:7px;font-size:12px;font-weight:500;color:var(--text-2);background:var(--surface-2);border:1px solid var(--border);border-radius:8px;padding:8px 12px;cursor:pointer;font-family:var(--sans)}
+.sbtn:hover{border-color:var(--border-2);color:var(--text)}
+.sbtn svg{width:13px;height:13px;color:var(--muted);flex:none}
+.sbtn.grow{flex:1;justify-content:center}
+.sbtnrow{display:flex;gap:8px;margin-top:11px}
+
+/* excerpt filled */
+.wk-exhead{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;color:var(--muted);margin-bottom:9px}
+.wk-exhead svg{color:var(--dim);flex:none}
+.wk-expreview{background:var(--inset);border:1px solid var(--border);border-radius:10px;padding:14px;font-family:var(--mono);font-size:12.5px;line-height:1.65;color:var(--text-2);white-space:pre-wrap;max-height:230px;overflow:hidden;position:relative;-webkit-mask-image:linear-gradient(180deg,#000 78%,transparent);mask-image:linear-gradient(180deg,#000 78%,transparent)}
+
+/* context pills + meter */
+.wk-pills{display:flex;flex-wrap:wrap;gap:7px;margin-bottom:12px}
+.pill{display:flex;align-items:center;gap:7px;border:1px solid var(--border);background:var(--surface-2);border-radius:999px;padding:5px 7px 5px 10px;font-size:12px;color:var(--text-2);max-width:100%}
+.pill svg{width:12px;height:12px;flex:none;color:var(--blue)}
+.pill.text svg{color:var(--muted)}
+.pill.wizard svg{color:var(--accent-hi)}
+.pill .pl{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0}
+.pill .ps{font-family:var(--mono);font-size:10px;color:var(--faint);white-space:nowrap}
+.pill .px{width:17px;height:17px;border-radius:50%;border:0;background:none;color:var(--dim);cursor:pointer;display:grid;place-items:center;flex:none;padding:0}
+.pill .px:hover{background:rgba(224,90,78,.16);color:#e05a4e}
+.pill .px svg{width:9px;height:9px;color:inherit}
+.meter{margin-top:4px}
+.meter-row{display:flex;align-items:center;gap:10px}
+.meter-track{flex:1;height:5px;border-radius:999px;background:var(--surface-2);overflow:hidden}
+.meter-fill{height:100%;border-radius:999px;background:var(--accent);transition:width .45s cubic-bezier(.3,.8,.3,1)}
+.meter.warn .meter-fill{background:var(--amber)}
+.meter.hot .meter-fill{background:#e05a4e}
+.meter-nums{font-family:var(--mono);font-size:11px;color:var(--muted);white-space:nowrap}
+.meter-nums b{color:var(--text-2);font-weight:500}
+.meter-cap{font-size:10.5px;color:var(--faint);margin-top:5px}
+
+/* tools list */
+.wk-tools{display:flex;flex-direction:column;gap:8px}
+.slt{display:flex;align-items:center;gap:11px;font-size:13px;font-family:var(--sans);color:var(--text-2);background:var(--surface-2);border:1px solid var(--border);border-radius:9px;padding:11px 13px;cursor:pointer;text-align:left}
+.slt:hover{background:var(--surface-3);color:var(--text)}
+.slt svg{color:var(--muted);flex:none}
+.slt.ghost{color:var(--dim);background:transparent;border-style:dashed}
+.slt.ghost:hover{color:var(--text-2);border-color:var(--border-2)}
+
+/* todo (pinned to rail bottom) */
+.wk-todo{margin-top:auto;padding-top:8px}
+.wk-todo-empty{border:1px dashed var(--border);border-radius:10px;padding:14px;font-size:11.5px;color:var(--faint);line-height:1.55;font-family:var(--mono)}
+.wk-todoitem{display:flex;align-items:flex-start;gap:10px;padding:9px 11px;border:1px solid var(--border-soft);background:var(--surface);border-radius:9px}
+.wk-todoitem+.wk-todoitem{margin-top:7px}
+.wk-todoitem .tk{width:15px;height:15px;border-radius:4px;border:1.5px solid var(--border-2);flex:none;margin-top:1px;display:grid;place-items:center;color:transparent;cursor:pointer}
+.wk-todoitem.done .tk{background:var(--green);border-color:var(--green);color:#12100c}
+.wk-todoitem .tt{font-size:12.5px;color:var(--text-2);line-height:1.45}
+.wk-todoitem.done .tt{color:var(--dim);text-decoration:line-through}
+
+/* ---------- center: empty + thread ---------- */
+.wk-center{flex:1;min-height:0;overflow-y:auto}
+.wk-empty{min-height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:9px;color:var(--muted);padding:48px}
+.wk-empty .spk{color:var(--accent-hi)}
+.wk-empty h2{font-size:18px;font-weight:700;color:var(--text);margin:8px 0 0}
+.wk-empty p{font-size:13.5px;max-width:440px;line-height:1.6;margin:0}
+.wk-thread{max-width:860px;margin:0 auto;padding:28px 30px 10px;display:flex;flex-direction:column;gap:20px}
+.wk-restore-note{display:flex;align-items:flex-start;gap:10px;border:1px solid rgba(226,178,74,.32);background:rgba(226,178,74,.07);border-radius:11px;padding:12px 14px;font-size:12.5px;line-height:1.55;color:var(--amber)}
+.wk-restore-note svg{flex:none;margin-top:1px}
+.wk-restore-note b{color:var(--text)}
+.wk-parts{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin:2px 0}
+.wk-parts .lab{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim)}
+.wk-part{display:flex;align-items:center;gap:8px;padding:5px 11px 5px 9px;border-radius:999px;border:1px solid var(--border);background:var(--surface-2);font-size:12.5px;color:var(--text-2)}
+.wk-part .pav{position:relative;width:16px;height:16px;color:var(--accent-hi);display:grid;place-items:center}
+.wk-part .pav .glyph{position:absolute;top:-4px;right:-5px;color:var(--accent-hi)}
+.wk-part .role{font-family:var(--mono);font-size:9px;color:var(--faint);text-transform:uppercase;letter-spacing:.06em}
+.wk-msg{display:flex;gap:13px}
+.wk-msg.you{justify-content:flex-end}
+.wk-who{font-family:var(--mono);font-size:9.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);margin-bottom:6px;display:flex;align-items:center;gap:6px}
+.wk-who .dot{width:6px;height:6px;border-radius:50%;background:var(--accent)}
+.wk-av{width:32px;height:32px;border-radius:8px;background:#fff;display:grid;place-items:center;flex:none;box-shadow:0 2px 8px rgba(0,0,0,.35)}
+.wk-av img{width:21px;height:21px;object-fit:contain}
+.wk-bubble{max-width:74%}
+.wk-msg.bot .wk-bubble{max-width:100%}
+.wk-msg.you .wk-bubble .bd{background:var(--surface-2);border:1px solid var(--border);border-radius:12px 12px 4px 12px;padding:11px 14px;font-size:13.5px;line-height:1.6;color:var(--text)}
+.wk-msg.bot .wk-bubble .bd{font-size:13.5px;line-height:1.65;color:var(--text-2)}
+.wk-msg.bot .wk-bubble .bd em{color:var(--accent-hi);font-style:normal}
+.wk-divider{display:flex;align-items:center;gap:14px;margin:6px 0}
+.wk-divider hr{flex:1;border:0;border-top:1px dashed var(--border-2)}
+.wk-divider span{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);text-align:center;max-width:60%;line-height:1.5}
+
+/* ---------- composer (Conversation Behavior style, wk- prefix) ---------- */
+.wk-composer-wrap{flex:none;padding:12px 30px 18px;background:linear-gradient(180deg,rgba(21,17,13,0),var(--bg) 30px)}
+.wk-ctxline{display:flex;align-items:center;gap:12px;height:38px;padding:0 14px;border:1px solid var(--border-soft);background:var(--inset);border-radius:10px;margin-bottom:11px}
+.wk-ctxline .cdot{width:7px;height:7px;border-radius:50%;background:var(--amber);flex:none}
+.wk-ctxline .cname{font-size:12.5px;font-weight:600;color:var(--text);white-space:nowrap}
+.wk-ctxline .ctrack{flex:1;height:4px;border-radius:999px;background:var(--surface-2);overflow:hidden;position:relative}
+.wk-ctxline .ctrack.empty{background:repeating-linear-gradient(90deg,var(--surface-2),var(--surface-2) 4px,transparent 4px,transparent 9px)}
+.wk-ctxline .cfill{height:100%;border-radius:999px;background:linear-gradient(90deg,var(--accent-lo),var(--accent-hi))}
+.wk-ctxline .cnums{font-family:var(--mono);font-size:11.5px;color:var(--muted)}
+.wk-ctxline .cnums b{color:var(--text-2)}
+.wk-ctxline .cnote{font-size:11.5px;color:var(--faint);font-style:italic}
+.wk-composer{border:1px solid var(--border-2);background:#20180f;border-radius:13px;padding:13px 14px 11px;display:flex;flex-direction:column;gap:13px;box-shadow:0 10px 30px rgba(0,0,0,.3)}
+.wk-cinput{font-size:14px;color:var(--faint);padding:3px 4px;min-height:26px}
+.wk-crow{display:flex;align-items:center;gap:8px}
+.wk-sq{width:36px;height:36px;border-radius:9px;background:var(--surface-2);border:1px solid var(--border);display:grid;place-items:center;color:var(--muted);cursor:pointer}
+.wk-sq:hover{color:var(--accent-hi);border-color:var(--border-2)}
+.wk-acts{margin-left:auto;display:flex;align-items:center;gap:8px}
+.wk-abtn{display:flex;align-items:center;gap:7px;height:36px;padding:0 13px;border-radius:9px;background:var(--surface-2);border:1px solid var(--border);color:var(--text-2);font-size:12.5px;font-weight:500;cursor:pointer;font-family:var(--sans)}
+.wk-abtn:hover{border-color:var(--border-2);color:var(--text)}
+.wk-abtn svg{color:var(--muted);flex:none}
+.wk-modechip{border-color:rgba(224,103,58,.35);background:rgba(224,103,58,.08)}
+.wk-modechip svg{color:var(--accent-hi)}
+.wk-modechip b{color:var(--text);font-weight:600}
+.wk-modechip .sub{font-family:var(--mono);font-size:10px;color:var(--dim);border-left:1px solid var(--border);padding-left:7px;letter-spacing:.04em}
+.wk-modechip .prof{width:6px;height:6px;border-radius:50%;background:var(--green);box-shadow:0 0 0 3px rgba(111,201,138,.14)}
+.wk-modechip:hover{border-color:rgba(224,103,58,.6)}
+.wk-wbtn{border-color:rgba(224,103,58,.4);background:rgba(224,103,58,.07)}
+.wk-wbtn svg{color:var(--accent-hi)}
+.wk-wbtn:hover{border-color:var(--accent)}
+.wk-send{width:36px;height:36px;border-radius:9px;background:linear-gradient(180deg,var(--accent-hi),var(--accent-lo));border:1px solid var(--accent-lo);display:grid;place-items:center;cursor:pointer;color:#fff}
+.wk-enter{text-align:center;font-size:11.5px;color:var(--faint);margin-top:10px}
+.wk-enter b{color:var(--accent-hi);font-weight:600}
+
+/* ---------- toast ---------- */
+#wk-toast{position:fixed;left:50%;bottom:28px;transform:translateX(-50%) translateY(20px);display:flex;align-items:center;gap:9px;background:#241a12;border:1px solid var(--border-2);border-radius:10px;padding:11px 16px;font-size:13px;color:var(--text);box-shadow:0 20px 50px rgba(0,0,0,.5);opacity:0;pointer-events:none;transition:opacity .2s,transform .2s;z-index:200}
+#wk-toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
+#wk-toast svg{color:var(--accent-hi)}
+
+/* ---------- modal width variants + sheet ---------- */
+.cw-modal.wide{width:min(940px,100%)}
+.cw-modal.xwide{width:min(1080px,100%)}
+.cw-modal.sheet{overflow:hidden;display:flex;flex-direction:column;max-height:calc(100vh - 64px)}
+.wk-sheet-body{overflow-y:auto;flex:1;min-height:0}
+.wk-sheet-foot{flex:none;display:flex;align-items:center;gap:11px;padding:15px 26px;border-top:1px solid var(--border-soft);background:#1e1712}
+.wk-sheet-foot .note{flex:1;font-size:11.5px;color:var(--faint);line-height:1.5}
+.mbtn{border:1px solid var(--border-2);background:var(--surface-3);color:var(--text);border-radius:9px;padding:9px 15px;font-size:12.5px;font-weight:600;cursor:pointer;font-family:var(--sans)}
+.mbtn:hover{background:#40301f}
+.mbtn.primary{background:linear-gradient(180deg,var(--accent-hi),var(--accent-lo));border-color:var(--accent-lo);color:#fff}
+.mbtn.primary:hover{filter:brightness(1.06)}
+.mbtn.primary:disabled{filter:saturate(.3) brightness(.7);cursor:not-allowed}
+.mbtn.ghost{background:transparent;color:var(--muted);border-color:transparent}
+.mbtn.danger{border-color:rgba(224,90,78,.5);color:#e8776b;background:transparent}
+.mbtn.danger:hover{background:rgba(224,90,78,.1)}

--- a/docs/design/pm-workshop.js
+++ b/docs/design/pm-workshop.js
@@ -1,0 +1,483 @@
+/* =========================================================================
+   Prose Minion — Workshop tab (consolidated). Needs icons.js + pm-widgets.js.
+   Exposes window.PMW for pm-sessions.js.
+   ========================================================================= */
+const PMW = (() => {
+  const $ = s => document.querySelector(s);
+  const esc = s => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  const fmt = n => n.toLocaleString('en-US');
+
+  /* ---------- data ---------- */
+  const PERSONAS = {
+    jill:  {name:'Jill',        spec:'Creative writing partner', glyph:'sparkle',  desc:'Warm developmental and line-level craft support for the work in front of you.'},
+    agnes: {name:'Sister Agnes',spec:'Theme & symbolism',        glyph:'sparkle',  desc:'Keeps themes embodied, symbols intentional, and insight earned on the page.'},
+    cliff: {name:'Cliff',       spec:'Cliché & repetition',      glyph:'repeat',   desc:'Finds tired phrasing, echo words, and accidental patterns without mistaking motifs for tics.'},
+    dev:   {name:'Dev',         spec:'Dialogue & microbeats',    glyph:'dialogue', desc:'Listens for distinct voices, subtext, purposeful tags, and physical beats that reveal character.'},
+    edna:  {name:'Edna',        spec:'Reader-breaking logic',    glyph:'target',   desc:'Flags only contradictions, impossible scene logic, and trust-breaking information errors.'},
+    felix: {name:'Felix',       spec:'Rhythm & pacing',          glyph:'wave',     desc:'Reads for sentence music, white space, pace, and the moments prose needs a rest.'},
+    harper:{name:'Harper',      spec:'Craft mentorship',         glyph:'sprout',   desc:'Turns visible patterns into durable writing principles and practical habits.'},
+    margot:{name:'Margot',      spec:'Voice & POV',              glyph:'eye',      desc:'Tracks narrative distance, point of view, tense, and whether the narration stays in character.'},
+    penny: {name:'Penny',       spec:'Reader experience',        glyph:'book',     desc:'Responds as an attentive young reader who knows only what the page has earned.'},
+    quinn: {name:'Quinn',       spec:'Continuity & canon',       glyph:'search',   desc:'Checks names, timelines, and facts against the story bible and prior chapters.'},
+    theo:  {name:'Theo',        spec:'Momentum & tension',       glyph:'bolt',     desc:"Tracks stakes, forward pull, and where a scene's energy sags."},
+    wren:  {name:'Wren',        spec:'Line & style',             glyph:'pen',      desc:"Sentence-level polish: diction, cadence, and cutting what the line doesn't need."},
+  };
+  const HOST_ORDER = ['jill','agnes','cliff','dev','edna','felix','harper','margot','penny','quinn','theo','wren'];
+
+  const TOOLS = [
+    {g:'Primary',       n:'Dialogue & Beats', i:'dialogue', d:'Cadence, subtext, and the microbeats between lines.'},
+    {g:'Primary',       n:'Prose',            i:'pen',      d:'Line-level rewrite suggestions for flow and clarity.'},
+    {g:'Primary',       n:'Gestures',         i:'hand',     d:'Body language — variety, repetition, and intent.'},
+    {g:'Craft & Voice', n:'Choreography',     i:'move',     d:'Spatial logic of movement through a scene.'},
+    {g:'Craft & Voice', n:'Cliché',           i:'stamp',    d:'Surface tired phrasings and stock images.'},
+    {g:'Craft & Voice', n:'Repetition',       i:'repeat',   d:'Echoed words, structures, and tics across the passage.'},
+    {g:'Craft & Voice', n:'Show & Tell',      i:'eye',      d:'Where you summarize vs. dramatize on the page.'},
+    {g:'Craft & Voice', n:'Decision Points',  i:'branch',   d:'Moments where a character chooses — and the stakes.'},
+    {g:'Craft & Voice', n:'Stock & Signature',i:'target',   d:'Generic beats vs. your distinctive authorial moves.'},
+    {g:'Technical',     n:'Style',            i:'palette',  d:'Weak verbs, adverbs, filler, and passive voice.'},
+    {g:'Technical',     n:'Editor',           i:'list',     d:'A holistic developmental editor pass.'},
+    {g:'Technical',     n:'Continuity',       i:'link',     d:'Contradictions against characters and prior chapters.'},
+    {g:'Technical',     n:'Placeholders',     i:'search',   d:'Find TODOs, [brackets], and unfinished seams.'},
+    {g:'Technical',     n:'Fresh',            i:'sprout',   d:'Fresh-eyes reactions, as a first-time reader.'},
+  ];
+  const RAIL_TOOLS = ['Dialogue & Beats','Prose','Gestures','Choreography','Cliché','Show & Tell'];
+
+  const EXCERPT_TEXT = `# Pentecost
+
+They moved toward the auditorium as a group, but Nate felt himself floating slightly above the moment—in that hush before the brushstroke. The edge of something breaking.
+
+The auditorium doors loomed ahead, heavy and dark.
+
+"They can't make us do this," Kayla said, but her voice didn't believe it.`;
+
+  const MODES = {analysis:'Analyze', balanced:'Balanced', conversational:'Converse'};
+  const MODELS = ['Arcee Trinity Large Thinking','Claude Opus 4.8','Claude Sonnet 4.6','GPT-5.2','Gemini 3.5 Pro'];
+
+  /* ---------- state ---------- */
+  const state = {
+    excerpt: null,            // {title, source, version, words, text}
+    context: [],              // [{kind,label,words}]
+    host: 'jill',
+    mode: 'balanced', expr: 'amplified', depth: 'reflective',
+    profileShared: false, carryCues: true,
+    todo: [],
+    transcript: null,         // when restored: [{who,text,by}]
+    participants: null,       // [personaId] restored in the room
+    restored: false,
+    session: null,            // {name}
+    model: 'Arcee Trinity Large Thinking',
+    processed: 0,
+  };
+  const BUDGET = 35000;
+  const ctxTotal = () => state.context.reduce((a,x)=>a+x.words,0);
+
+  /* ---------- icon helpers ---------- */
+  const personIc = (o={}) => IC('<circle cx="12" cy="8" r="3.4"/><path d="M5.3 20c0-3.9 3-6.5 6.7-6.5s6.7 2.6 6.7 6.5"/>', Object.assign({sw:1.7}, o));
+  function hostGlyphs(id, size){
+    const p = PERSONAS[id]; const g = size >= 24 ? Math.round(size*0.6) : Math.round(size*0.68);
+    return personIc({size,sw:1.7}) + `<span class="glyph">${(ICONS[p.glyph]||ICONS.sparkle)({size:g,sw:2})}</span>`;
+  }
+  function hostName(id){ return PERSONAS[id].name; }
+
+  /* ---------- header ---------- */
+  function renderTopIcons(){
+    $('#wk-topicons').innerHTML =
+      `<span class="spark" title="Prose Minion">${ICONS.sparkle({size:15,sw:1.8})}</span>`+
+      `<span title="Assistant">${ICONS.bot({size:16,sw:1.6})}</span>`+
+      `<span title="Toggle panel">${ICONS.panelRight({size:15,sw:1.6})}</span>`+
+      `<span title="More">${ICONS.list({size:15,sw:1.6})}</span>`;
+    $('#wk-tabx').innerHTML = ICONS.x({size:12,sw:1.8});
+  }
+  function renderSub(){
+    const e = state.excerpt;
+    $('#wk-sub').innerHTML = e
+      ? `${ICONS.doc({size:12})}<span>${esc(e.source)}</span> · <span class="v">v${e.version}</span> · ${fmt(e.words)} words`
+      : `${ICONS.doc({size:12})}<span>No excerpt pinned yet</span>`;
+  }
+  function renderHeaderCluster(){
+    const modelOpts = MODELS.map(m=>`<button class="wk-mitem" data-act="setmodel" data-v="${esc(m)}">${esc(m)}${m===state.model?' '+ICONS.check({size:13}):''}</button>`).join('');
+    $('#wk-hcluster').innerHTML = `
+      <button class="wk-persona" data-act="host" title="Workshop host — ${esc(hostName(state.host))}">
+        <span class="pav">${hostGlyphs(state.host,18)}</span><span>${esc(hostName(state.host))}</span>
+      </button>
+      <div class="wk-menuwrap">
+        <button class="wk-hbtn" data-act="sessions">${ICONS.cards({size:14,sw:1.7})}<span>${state.session?esc(state.session.name):'Sessions'}</span><span class="chev">${ICONS.chevDown({size:13})}</span></button>
+        <div class="wk-menu" id="wk-sess-menu"></div>
+      </div>
+      <div class="wk-menuwrap">
+        <button class="wk-hbtn" data-act="model">${esc(state.model)}<span class="chev">${ICONS.chevDown({size:13})}</span></button>
+        <div class="wk-menu" id="wk-model-menu">${modelOpts}</div>
+      </div>
+      <div class="wk-sep"></div>
+      <div class="wk-proc">Processed <b>${fmt(state.processed)}</b></div>
+      <div class="wk-bal"><span class="dot"></span>OpenRouter <b>$12.32</b></div>`;
+    if (window.PMSessions) PMSessions.renderMenu($('#wk-sess-menu'));
+  }
+
+  /* ---------- rail ---------- */
+  function excerptSection(){
+    if (!state.excerpt){
+      return `<div class="wk-sec">
+        <div class="wk-sechead"><div class="pm-eyebrow">${ICONS.doc({size:12})} Excerpt</div></div>
+        <div class="btnstack">
+          <button class="bigbtn" data-act="ex-type">${ICONS.pen({size:18})}Paste or type<span class="sub">verified if it matches your editor selection</span></button>
+          <button class="bigbtn" data-act="ex-pick">${ICONS.doc({size:18})}Choose from project…<span class="sub">reads the file, head-slices past 10,000 words</span></button>
+        </div>
+        <div class="cap">The excerpt is the text this room is workshopping.</div>
+      </div>`;
+    }
+    const e = state.excerpt;
+    return `<div class="wk-sec">
+      <div class="wk-sechead"><div class="pm-eyebrow">${ICONS.doc({size:12})} Excerpt</div><span class="stat-chip">EXCERPT · V${e.version}</span></div>
+      <div class="wk-exhead">${ICONS.doc({size:13})} From ${esc(e.source)}</div>
+      <div class="wk-expreview">${esc(e.text||'')}</div>
+      <div class="sbtnrow">
+        <button class="sbtn grow" data-act="ex-type">${ICONS.pen({size:13})} Paste or type</button>
+        <button class="sbtn grow" data-act="ex-pick">${ICONS.doc({size:13})} Choose from project…</button>
+      </div>
+    </div>`;
+  }
+  function contextSection(){
+    const has = state.context.length > 0;
+    const t = ctxTotal(), pct = Math.min(100, Math.round(100*t/BUDGET));
+    const tone = pct>=100?' hot':pct>=70?' warn':'';
+    const meter = `<div class="meter${tone}"><div class="meter-row"><div class="meter-track"><div class="meter-fill" style="width:${Math.max(pct, t?2:0)}%"></div></div><span class="meter-nums"><b>${fmt(t)}</b> / ${fmt(BUDGET)} words</span></div><div class="meter-cap">One budget across all attachments</div></div>`;
+    let body;
+    if (!has){
+      body = `<div class="btnstack">
+        <button class="bigbtn" data-act="ctx-text">${ICONS.list({size:18})}Add text<span class="sub">notes, character sheets, anything typed</span></button>
+        <button class="bigbtn" data-act="ctx-file">${ICONS.doc({size:18})}Add from project…<span class="sub">attach project files to every message</span></button>
+        <button class="bigbtn" data-act="ctx-wizard">${ICONS.sparkle({size:18})}Context wizard<span class="sub">suggests project context — results are yours to keep or remove</span></button>
+      </div>
+      <div class="cap">Context rides along with every message, to every participant.</div>${meter}`;
+    } else {
+      const pills = state.context.map((x,i)=>`<span class="pill ${x.kind}">${ICONS[x.kind==='file'?'doc':x.kind==='wizard'?'sparkle':'list']({size:12})}<span class="pl">${esc(x.label)}</span><span class="ps">${fmt(x.words)} words</span><button class="px" data-act="ctx-rm" data-i="${i}" aria-label="Remove">${ICONS.x({size:9,sw:2.4})}</button></span>`).join('');
+      body = `<div class="wk-pills">${pills}</div>
+      <div class="sbtnrow">
+        <button class="sbtn" data-act="ctx-text">${ICONS.list({size:13})} Add text</button>
+        <button class="sbtn" data-act="ctx-file">${ICONS.doc({size:13})} Add from project…</button>
+        <button class="sbtn" data-act="ctx-wizard">${ICONS.sparkle({size:13})} Context wizard</button>
+      </div>${meter}`;
+    }
+    return `<div class="wk-sec">
+      <div class="wk-sechead"><div class="pm-eyebrow">${ICONS.cards({size:12})} Context</div>${has?`<span class="wk-secmeta">${state.context.length} attachment${state.context.length===1?'':'s'}</span>`:''}</div>
+      ${body}
+    </div>`;
+  }
+  function toolsSection(){
+    const rows = RAIL_TOOLS.map(n=>{ const t=TOOLS.find(x=>x.n===n); return `<button class="slt" data-act="tool" data-n="${esc(n)}">${ICONS[t.i]({size:15})} ${esc(n)}</button>`; }).join('');
+    return `<div class="wk-sec">
+      <div class="wk-sechead"><div class="pm-eyebrow">Tools</div></div>
+      <div class="wk-tools">${rows}<button class="slt ghost" data-act="tools-all">${ICONS.grid({size:15})} All 14 tools…</button></div>
+    </div>`;
+  }
+  function todoSection(){
+    const open = state.todo.filter(t=>!t.done).length, done = state.todo.filter(t=>t.done).length;
+    let body;
+    if (!state.todo.length){
+      body = `<div class="wk-todo-empty">Add a concrete next step from a report or host response. Nothing is added automatically.</div>`;
+    } else {
+      body = state.todo.map((t,i)=>`<div class="wk-todoitem${t.done?' done':''}"><span class="tk" data-act="todo-tog" data-i="${i}">${ICONS.check({size:11,sw:3})}</span><span class="tt">${esc(t.text)}</span></div>`).join('');
+    }
+    return `<div class="wk-sec wk-todo">
+      <div class="wk-sechead"><div class="pm-eyebrow">To-do list</div><span class="wk-secmeta">${open} open · ${done} done</span></div>
+      ${body}
+    </div>`;
+  }
+  function renderRail(){
+    $('#wk-rail').innerHTML = excerptSection() + contextSection() + toolsSection() + todoSection();
+  }
+
+  /* ---------- center ---------- */
+  function avatar(){ return `<div class="wk-av"><img src="assets/prose-minion-book.png" alt=""></div>`; }
+  function renderCenter(){
+    const c = $('#wk-center');
+    if (state.transcript && state.transcript.length){
+      const msgs = state.transcript.map(m => {
+        if (m.who==='you') return `<div class="wk-msg you"><div class="wk-bubble"><div class="wk-who">You</div><div class="bd">${m.text}</div></div></div>`;
+        const by = m.by || state.host;
+        return `<div class="wk-msg bot">${avatar()}<div class="wk-bubble"><div class="wk-who"><span class="dot"></span>${esc(hostName(by))} · ${by===state.host?'host':'guest'}</div><div class="bd">${m.text}</div></div></div>`;
+      }).join('');
+      const parts = state.participants || [state.host];
+      const partRow = `<div class="wk-parts"><span class="lab">In the room</span>${parts.map(id=>`<span class="wk-part"><span class="pav">${hostGlyphs(id,16)}</span>${esc(hostName(id))}<span class="role">${id===state.host?'host':'guest'}</span></span>`).join('')}</div>`;
+      c.innerHTML = `<div class="wk-thread">
+        <div class="wk-restore-note">${ICONS.refresh({size:15,sw:1.8})}<div><b>Session restored.</b> Your excerpt, context, the complete transcript, and every participant are back. Conversational memory isn't carried across — each persona starts the next turn fresh.</div></div>
+        ${partRow}
+        ${msgs}
+        <div class="wk-divider"><hr><span>Previous session restored — transcript preserved · room memory not retained</span><hr></div>
+      </div>`;
+      c.scrollTop = c.scrollHeight;
+    } else if (state.excerpt){
+      c.innerHTML = `<div class="wk-empty"><div class="spk">${ICONS.sparkle({size:26,sw:1.6})}</div><h2>Ready when you are.</h2><p>Ask ${esc(hostName(state.host))} about the excerpt, or run a tool from the left. The excerpt stays pinned while the conversation grows here.</p></div>`;
+    } else {
+      c.innerHTML = `<div class="wk-empty"><div class="spk">${ICONS.sparkle({size:26,sw:1.6})}</div><h2>Pin an excerpt to start the Workshop.</h2><p>Paste text or pin a file on the left. The excerpt stays fixed while the conversation grows here.</p></div>`;
+    }
+  }
+
+  /* ---------- composer ---------- */
+  function renderComposer(){
+    const measured = !state.restored && state.transcript && state.transcript.length;
+    const ctx = measured
+      ? `<div class="ctrack"><div class="cfill" style="width:39%"></div></div><span class="cnums"><b>59K</b> / 150K</span>`
+      : `<div class="ctrack empty"></div><span class="cnote">Not measured yet — updates after the first reply</span>`;
+    $('#wk-composer').innerHTML = `
+      <div class="wk-ctxline"><span class="cdot"></span><span class="cname">${esc(hostName(state.host))} context</span>${ctx}</div>
+      <div class="wk-composer">
+        <div class="wk-cinput">Message ${esc(hostName(state.host))} about this excerpt…</div>
+        <div class="wk-crow">
+          <button class="wk-sq" data-act="ctx-file" title="Attach">${ICONS.plus({size:18})}</button>
+          <div class="wk-acts">
+            <button class="wk-abtn wk-modechip" data-act="convsettings" title="Conversation settings">${ICONS.scale({size:14,sw:1.6})}<b>${MODES[state.mode]}</b><span class="sub">${state.expr.toUpperCase()}</span>${state.profileShared?'<span class="prof" title="Profile shared"></span>':''}</button>
+            <button class="wk-abtn" data-act="tools-all">${ICONS.grid({size:14,sw:1.7})}Tools</button>
+            <button class="wk-abtn wk-wbtn" data-act="widgets" title="Open a widget">${ICONS.sparkle({size:14,sw:1.8})}Widgets</button>
+            <button class="wk-send" data-act="send">${ICONS.send({size:16,sw:1.6})}</button>
+          </div>
+        </div>
+      </div>
+      <div class="wk-enter">Enter to send · <b>Shift+Enter</b> for a new line</div>`;
+  }
+
+  function render(){ renderSub(); renderHeaderCluster(); renderRail(); renderCenter(); renderComposer(); }
+
+  /* ---------- toast ---------- */
+  let toastT;
+  function toast(msg, icon='check'){
+    const el = $('#wk-toast');
+    el.innerHTML = `${(ICONS[icon]||ICONS.check)({size:15})}<span>${esc(msg)}</span>`;
+    el.classList.add('show'); clearTimeout(toastT);
+    toastT = setTimeout(()=>el.classList.remove('show'), 2200);
+  }
+
+  /* ---------- excerpt demo set ---------- */
+  function setExcerptDemo(){
+    state.excerpt = {title:'Pentecost', source:'Drafts/chapter-5.8.md', version:2, words:2015, text:EXCERPT_TEXT};
+    if (!state.context.length){
+      state.context = [
+        {kind:'text',   label:'testing…',                    words:1},
+        {kind:'file',   label:'character-ava.md',            words:2738},
+        {kind:'file',   label:'character-set-piece-moments.md', words:1908},
+        {kind:'file',   label:'character-chen.md',           words:1252},
+      ];
+    }
+    render();
+  }
+
+  /* =======================================================================
+     MODALS
+     ======================================================================= */
+  function wkOpen(inner, cls){ cwOpen(inner); const m = document.querySelector('.cw-ov .cw-modal'); if (m && cls) m.classList.add(...cls.split(' ')); return m; }
+
+  /* ---- host picker ---- */
+  function buildHostPicker(){
+    const root = document.createElement('div'); root.className='cw-sheet-wrap';
+    root.appendChild(cwXBtn());
+    const cards = HOST_ORDER.map(id=>{ const p=PERSONAS[id];
+      return `<div class="hp-cell">
+        <button class="hp-card${id===state.host?' sel':''}" data-host="${id}">
+          <div class="hp-ic">${hostGlyphs(id,26)}</div>
+          <div class="hp-name">${esc(p.name)}</div>
+          <div class="hp-spec">${esc(p.spec)}</div>
+          <div class="hp-desc">${esc(p.desc)}</div>
+        </button>
+        <button class="hp-more" data-more="${id}">More info ${ICONS.chevRight({size:13})}</button>
+      </div>`;
+    }).join('');
+    root.insertAdjacentHTML('beforeend', `
+      <div class="wk-mhead"><div class="wk-mkicker">Workshop host</div><h2>Choose your writing partner</h2><p class="wk-msub">Choose a lens before the conversation begins. Start a new session to change hosts later.</p></div>
+      <div class="wk-sheet-body"><div class="hp-body"><div class="hp-grid">${cards}</div></div></div>`);
+    root.addEventListener('click', e=>{
+      const card = e.target.closest('[data-host]');
+      if (card){ state.host = card.dataset.host; cwClose(); render(); toast('Host set to '+hostName(state.host), 'sparkle'); return; }
+      const more = e.target.closest('[data-more]');
+      if (more){ toast('Persona schematic — '+hostName(more.dataset.more), 'bot'); }
+    });
+    return root;
+  }
+  function openHostPicker(){ wkOpen(buildHostPicker(), 'xwide sheet'); }
+
+  /* ---- conversation settings ---- */
+  const EXPR = {subtle:['Subtle','Quieter delivery — fewer quirks and metaphors, same person and expertise.'], full:['Full','Their natural voice, tastes, trait tensions, and verbal palette without muting.'], amplified:['Amplified','Strongest authored differentiation — calibrated language and communication pressure.']};
+  const DEPTH = {reserved:['Reserved','Responds to feelings and needs you state directly without unsolicited personal interpretation.'], attuned:['Attuned','Uses high emotional intelligence to notice likely immediate cues and adapt with humility.'], reflective:['Reflective','May connect the work with life experience you explicitly shared and invite deeper reflection.']};
+  const MODEDESC = {analysis:['Analyze','Leads with the most important finding, traces evidence, offers next moves.'], balanced:['Balanced','A workshop exchange — one meaningful observation, mixed with real conversation.'], conversational:['Converse','Shorter, responsive turns that follow your thought — no forced reports.']};
+  function segCards(group, map, cur){
+    return Object.keys(map).map(k=>`<button class="segcard${k===cur?' sel':''}" data-${group}="${k}"><span class="sc-top">${ICONS.target({size:15})}<span class="sc-name">${map[k][0]}</span></span><span class="sc-desc">${map[k][1]}</span></button>`).join('');
+  }
+  function buildConvSettings(){
+    const d = {mode:state.mode, expr:state.expr, depth:state.depth, carry:state.carryCues, shared:state.profileShared, addr:'', bio:''};
+    const root = document.createElement('div'); root.className='cw-sheet-wrap';
+    root.appendChild(cwXBtn());
+    root.insertAdjacentHTML('beforeend', `
+      <div class="wk-mhead"><div class="wk-mkicker">Workshop · Room settings</div><h2>Conversation settings</h2><p class="wk-msub">Choose how Workshop personas respond and what you explicitly share with them. Tools are unchanged.</p></div>
+      <div class="cs-tabs"><button class="cs-tab on" data-tab="behavior">Behavior</button><button class="cs-tab" data-tab="profile">About you</button></div>
+      <div class="wk-sheet-body">
+        <div class="cs-pane on" data-pane="behavior">
+          <div class="msec"><div class="msec-h"><span class="t">Response style</span><hr></div><div class="segcards" data-grp="mode">${segCards('mode',MODEDESC,d.mode)}</div><p class="msec-note">What you ask for always wins — “analyze this” gets analysis in any style.</p></div>
+          <div class="msec"><div class="msec-h"><span class="t">Persona expression</span><hr></div><div class="segcards" data-grp="expr">${segCards('expr',EXPR,d.expr)}</div><p class="msec-note">Identity and craft expertise remain present at every level.</p></div>
+          <div class="msec"><div class="msec-h"><span class="t">Relational depth</span><hr></div><div class="segcards" data-grp="depth">${segCards('depth',DEPTH,d.depth)}</div><p class="msec-note">A permission ceiling, not a requirement. Each persona decides when depth helps.</p></div>
+          <div class="msec"><div class="msec-h"><span class="t">Session continuity</span><hr></div><div class="trow"><div class="trow-txt"><div class="trow-name">Carry cues through this session</div><div class="trow-desc">Let demonstrated preferences — like blunt critique or brief answers — shape later turns. Cleared when the session ends.</div></div><span class="tog${d.carry?' on':''}" data-tog="carry"><i></i></span></div></div>
+        </div>
+        <div class="cs-pane" data-pane="profile">
+          <div class="trow" style="margin-top:20px"><div class="trow-txt"><div class="trow-name">Share this profile with Workshop personas</div><div class="trow-desc">When on, the room may use the details below to address you and add relevant context.</div></div><span class="tog${d.shared?' on':''}" data-tog="shared"><i></i></span></div>
+          <div class="field"><label class="field-label">How should the room address you?</label><input class="tin" data-f="addr" maxlength="80" placeholder="e.g. Okey · Dr. Landers · “Okey is fine”"></div>
+          <div class="field"><label class="field-label">What would you like the room to know about you?</label><textarea class="tar" data-f="bio" maxlength="1000" placeholder="A few enduring facts or preferences — not a résumé. The room treats this as background, never as instructions."></textarea></div>
+          <div class="cs-notice">${ICONS.bot({size:15,sw:1.5})}<span>Stored with your global settings — ordinary settings data, <b>not a secret</b>. It's never copied into transcripts, saved sessions, or tools.</span></div>
+        </div>
+      </div>
+      <div class="wk-sheet-foot"><span class="note">Applies the Behavior and About You drafts together to the active room.</span><button class="mbtn" data-close-cs>Cancel</button><button class="mbtn primary" data-apply-cs>Apply to next turn</button></div>`);
+    root.querySelector('.cs-tabs').addEventListener('click', e=>{ const t=e.target.closest('[data-tab]'); if(!t) return;
+      root.querySelectorAll('.cs-tab').forEach(x=>x.classList.toggle('on', x===t));
+      root.querySelectorAll('.cs-pane').forEach(p=>p.classList.toggle('on', p.dataset.pane===t.dataset.tab));
+      root.querySelector('.wk-sheet-body').scrollTop=0;
+    });
+    root.querySelectorAll('.segcards').forEach(sc=> sc.addEventListener('click', e=>{ const b=e.target.closest('[data-'+sc.dataset.grp+']'); if(!b) return; const grp=sc.dataset.grp; d[grp]=b.dataset[grp]; sc.querySelectorAll('.segcard').forEach(x=>x.classList.toggle('sel', x===b)); }));
+    root.querySelectorAll('.tog').forEach(t=> t.addEventListener('click', ()=>{ const k=t.dataset.tog; d[k]=!d[k]; t.classList.toggle('on', d[k]); }));
+    root.querySelector('[data-close-cs]').addEventListener('click', cwClose);
+    root.querySelector('[data-apply-cs]').addEventListener('click', ()=>{ state.mode=d.mode; state.expr=d.expr; state.depth=d.depth; state.carryCues=d.carry; state.profileShared=d.shared && (root.querySelector('[data-f="addr"]').value.trim()||root.querySelector('[data-f="bio"]').value.trim()); cwClose(); render(); toast('Applied to next turn'); });
+    return root;
+  }
+  function openConvSettings(){ wkOpen(buildConvSettings(), 'wide sheet'); }
+
+  /* ---- choose from project (excerpt) ---- */
+  const CFP_CATS = [
+    {n:'Characters',           c:98, kb:'1079.2 KB'},
+    {n:'Locations & Settings', c:26, kb:'143.3 KB'},
+    {n:'Themes',               c:25, kb:'386.5 KB'},
+    {n:'Things / Props',       c:13, kb:'60.9 KB'},
+    {n:'Chapters & Scenes',    c:52, kb:'517.1 KB'},
+    {n:'Manuscript',           c:1,  kb:'1.3 KB'},
+    {n:'Project Brief',        c:3,  kb:'73.6 KB'},
+    {n:'General References',    c:79, kb:'740.7 KB'},
+  ];
+  const CFP_FILES = ['Characters/Ava/ava-appearances.md|34.4 KB','Characters/Ava/ava-voice-guide.md|15.4 KB','Characters/Ava/character-ava.md|18.2 KB','Characters/Bradley/bradley-appearances.md|6.9 KB','Characters/Bradley/bradley-voice-guide.md|11.1 KB','Characters/Bradley/character-bradley.md|14.1 KB','Characters/character-set-piece-moments.md|12.5 KB','Characters/Chen/character-chen.md|9.0 KB','Characters/Chen/chen-appearances.md|5.5 KB','Characters/continuity-issues.md|13.7 KB','Characters/David/character-david.md|1.6 KB','Characters/Demonic-Horde/character-demonic-horde.md|2.3 KB','Characters/Doyle/character-doyle.md|3.4 KB','Characters/Drew/character-drew.md|1.7 KB'];
+  function buildChooseProject(){
+    const root = document.createElement('div'); root.className='cw-sheet-wrap';
+    root.appendChild(cwXBtn());
+    root.insertAdjacentHTML('beforeend', `
+      <div class="wk-mhead"><div class="wk-mkicker">Set excerpt</div><h2>Choose from project</h2><p class="wk-msub">Pick one file to workshop — it becomes the working excerpt, head-sliced past the budget.</p></div>
+      <div class="wk-sheet-body"><div class="cfp-body">
+        <div class="cfp-search"><span class="si">${ICONS.search({size:16})}</span><input placeholder="Search configured resources…"><div class="cfp-seg"><button class="on" data-sm="names">Names</button><button data-sm="content">Names + content</button></div></div>
+        <div class="cfp-view"></div>
+      </div></div>
+      <div class="wk-sheet-foot"><span class="note cfp-foot-note">Click a file to set it as the excerpt</span><button class="mbtn" data-close-cfp>Cancel</button></div>`);
+    const view = root.querySelector('.cfp-view');
+    const renderCats = () => {
+      view.innerHTML = `<div class="cfp-cats">${CFP_CATS.map(c=>`<button class="cfp-cat" data-cat="${esc(c.n)}"><div class="cn">${esc(c.n)}</div><div class="cm">${c.c} file${c.c===1?'':'s'} · ${c.kb}</div></button>`).join('')}</div>
+        <button class="cfp-explore" data-explore>${ICONS.doc({size:16})}<span>Explore project folders… <span class="h">opens the system picker; budget checked on add</span></span></button>`;
+    };
+    const renderFiles = (cat) => {
+      view.innerHTML = `<div class="cfp-nav"><button class="cfp-back" data-back>${ICONS.chevRight({size:12})}<span style="transform:scaleX(-1);display:inline-block">${ICONS.chevRight({size:12})}</span>Back</button><span class="cfp-crumb">${esc(cat)}</span></div>
+        <div class="cfp-files">${CFP_FILES.map(f=>{const[p,w]=f.split('|');return `<button class="cfp-file" data-file="${esc(p)}"><span class="fp">${esc(p)}</span><span class="fw">${w}</span></button>`;}).join('')}</div>`;
+    };
+    renderCats();
+    root.querySelector('.cfp-seg').addEventListener('click', e=>{ const b=e.target.closest('[data-sm]'); if(!b) return; root.querySelectorAll('.cfp-seg button').forEach(x=>x.classList.toggle('on', x===b)); });
+    view.addEventListener('click', e=>{
+      if (e.target.closest('[data-cat]')) return renderFiles(e.target.closest('[data-cat]').dataset.cat);
+      if (e.target.closest('[data-back]')) return renderCats();
+      if (e.target.closest('[data-explore]')) return toast('Opening system file picker…','doc');
+      const f = e.target.closest('[data-file]');
+      if (f){ cwClose(); const base=f.dataset.file.split('/').pop(); state.excerpt={title:base.replace(/\.md$/,''), source:'Drafts/'+base, version:1, words:2015, text:EXCERPT_TEXT}; render(); toast('Excerpt set — '+base,'pin'); }
+    });
+    root.querySelector('[data-close-cfp]').addEventListener('click', cwClose);
+    return root;
+  }
+  function openChooseProject(){ wkOpen(buildChooseProject(), 'wide sheet'); }
+
+  /* ---- tools modal ---- */
+  function openTools(){
+    const el = document.createElement('div'); el.className='cw-browser';
+    el.appendChild(cwXBtn());
+    el.insertAdjacentHTML('beforeend', `<div class="cw-eyebrow">Prose Excerpt Assistant</div><h3>Writing tools</h3><p class="bsub">Pick an analysis — each runs on your excerpt with the context brief attached.</p>`);
+    ['Primary','Craft & Voice','Technical'].forEach(g=>{
+      el.insertAdjacentHTML('beforeend', `<div class="cw-mgh"><span class="t">${g}</span><hr></div>`);
+      TOOLS.filter(t=>t.g===g).forEach(t=>{
+        const b=document.createElement('button'); b.className='cw-brow';
+        b.innerHTML=`<span class="ic">${ICONS[t.i]({size:16})}</span><span class="bt"><span class="nm">${t.n}</span><span class="bl">${t.d}</span></span>`;
+        b.addEventListener('click', ()=>{ cwClose(); toast(t.n+' — running on excerpt','sparkle'); });
+        el.appendChild(b);
+      });
+    });
+    wkOpen(el, 'wide');
+  }
+  function openWidgets(){
+    if (typeof buildWidgetBrowser !== 'function'){ toast('Widgets browser'); return; }
+    cwOpen(buildWidgetBrowser(w=>{ cwClose(); toast('Opening '+w.name+'…','sparkle'); }, true), true);
+  }
+
+  /* =======================================================================
+     WIRING
+     ======================================================================= */
+  function closeMenus(except){ document.querySelectorAll('.wk-menu.open').forEach(m=>{ if(m!==except) m.classList.remove('open'); }); }
+  function wire(){
+    document.addEventListener('click', e=>{
+      const act = e.target.closest('[data-act]');
+      // menu outside-close
+      if (!e.target.closest('.wk-menuwrap')) closeMenus();
+      if (!act) return;
+      const a = act.dataset.act;
+      if (a==='host') return openHostPicker();
+      if (a==='sessions'){ const m=$('#wk-sess-menu'); const wasOpen=m.classList.contains('open'); closeMenus(); if(!wasOpen){ if(window.PMSessions) PMSessions.renderMenu(m); m.classList.add('open'); } return; }
+      if (a==='model'){ const m=$('#wk-model-menu'); const wasOpen=m.classList.contains('open'); closeMenus(); m.classList.toggle('open', !wasOpen); return; }
+      if (a==='setmodel'){ state.model=act.dataset.v; closeMenus(); render(); toast('Model — '+state.model,'bot'); return; }
+      if (a==='ex-type'){ setExcerptDemo(); toast('Excerpt pinned — Pentecost','pin'); return; }
+      if (a==='ex-pick') return openChooseProject();
+      if (a==='ctx-file'){ addCtxDemo('file'); return; }
+      if (a==='ctx-text'){ addCtxDemo('text'); return; }
+      if (a==='ctx-wizard'){ addCtxDemo('wizard'); return; }
+      if (a==='ctx-rm'){ state.context.splice(+act.dataset.i,1); render(); return; }
+      if (a==='tool' || a==='tools-all') return openTools();
+      if (a==='convsettings') return openConvSettings();
+      if (a==='widgets') return openWidgets();
+      if (a==='todo-tog'){ const t=state.todo[+act.dataset.i]; if(t){ t.done=!t.done; render(); } return; }
+      if (a==='send'){ toast('Send is disabled in this mock','send'); return; }
+    });
+  }
+  // context quick-adds (demo)
+  function addCtxDemo(kind){
+    if (kind==='text'){ state.context.push({kind:'text', label:'Note…', words:120}); toast('Context added — text note'); }
+    else if (kind==='file'){ const f={kind:'file',label:'chapter-5.7.md',words:1840}; if(!state.context.some(x=>x.label===f.label)) state.context.push(f); toast('Context added — chapter-5.7.md','doc'); }
+    else { const picks=[{kind:'wizard',label:'kayla-voice-guide.md',words:980},{kind:'wizard',label:'timeline.md',words:2300}].filter(p=>!state.context.some(x=>x.label===p.label)); picks.forEach(p=>state.context.push(p)); toast('Context wizard added '+picks.length+' file'+(picks.length===1?'':'s'),'sparkle'); }
+    render();
+  }
+
+  /* ---------- session hooks (for pm-sessions.js) ---------- */
+  function loadSession(sess){
+    state.excerpt = sess.excerpt ? {...sess.excerpt} : null;
+    state.context = (sess.context||[]).map(x=>({...x}));
+    state.host = sess.host || 'jill';
+    state.mode = sess.mode || 'balanced';
+    state.expr = sess.expr || 'amplified';
+    state.todo = (sess.todo||[]).map(x=>({...x}));
+    state.transcript = (sess.transcript||[]).map(x=>({...x}));
+    state.participants = sess.participants ? [...sess.participants] : [sess.host||'jill'];
+    state.restored = true;
+    state.session = {name: sess.title};
+    render();
+    toast('Opened — '+sess.title,'cards');
+  }
+  function newSession(){
+    state.excerpt=null; state.context=[]; state.host='jill'; state.mode='balanced'; state.expr='amplified'; state.depth='reflective';
+    state.todo=[]; state.transcript=null; state.participants=null; state.restored=false; state.session=null; state.profileShared=false;
+    render(); toast('New session started','refresh');
+  }
+  function currentSnapshot(){
+    return {
+      excerpt: state.excerpt, context: state.context, host: state.host,
+      mode: state.mode, expr: state.expr, todo: state.todo,
+      turns: state.transcript ? state.transcript.length : 0,
+      participants: state.participants || [state.host],
+      hostName: hostName(state.host),
+    };
+  }
+  function setSessionName(n){ state.session = n ? {name:n} : state.session; render(); }
+
+  function init(){
+    renderTopIcons(); render(); wire();
+  }
+  document.addEventListener('DOMContentLoaded', init);
+
+  return { PERSONAS, HOST_ORDER, personIc, hostGlyphs, hostName, fmt, esc, state,
+           render, toast, loadSession, newSession, currentSnapshot, setSessionName,
+           openBrowserFallback: ()=>window.PMSessions&&PMSessions.openBrowser(),
+           MODES };
+})();
+window.PMW = PMW;


### PR DESCRIPTION
## Summary

- import the approved Workshop/session design snapshot and preserve the prior split-pane prototype as Direction B
- amend the persistence ADR and Sprint 10 so T3 conversation continuity is the normal restore path, with T2 only as degraded recovery
- add trusted passage-of-time framing, logical conversation-history remapping, current-prompt reconstruction, and coherent autosave boundaries
- adopt editable session titles plus search/group/rename/duplicate/reveal/delete while keeping stable collision-safe file identities
- align Conversation Widgets: exact configs and standing directives are session-owned; VS Code Settings only seed new instances; turn/artifact/config identities remain distinct

## Verification

- `node --check docs/design/pm-workshop.js`
- `node --check docs/design/pm-sessions.js`
- `node --check docs/design/pm-widgets.js`
- Workshop host asset references resolve locally
- Direction B is byte-identical to the prior Assistant Tab prototype
- `git diff --check`
- stale T2 contract scan across active planning docs

## Notes

The synced prototype still contains the earlier “room memory not retained” copy and slug-only path example. `docs/design/README.md` records that intentional design/product delta; the amended ADR governs implementation semantics until the remote design copy is updated and re-pulled.

The Conversation Widgets ADR link remains a planned pre-Sprint-01 dependency; that ADR has not been authored in this change.