### PR TITLE
Sprint 13A_2: Scope Immutability — the session path settles once the room has a memory

### DIFF
--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a-open-chat.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a-open-chat.md
@@ -120,7 +120,7 @@ is persisted and surfaced in restore/browser metadata.
 
 ### Where the comp and the product disagreed
 
-Three places, all resolved toward product reality and recorded here rather than
+Four places, all resolved toward product reality and recorded here rather than
 silently absorbed:
 
 1. **The editor tab strip.** The comp draws a VS Code-style tab bar *inside the
@@ -140,6 +140,16 @@ silently absorbed:
 3. **Starter chips.** Implemented, but with generic copy — two of the comp's
    four name a character from its demo project. They prefill the composer; the
    writer still presses send.
+4. **Mid-conversation reversal affordances.** Superseded by
+   [ADR 2026-07-25](../../../../docs/adr/2026-07-25-workshop-scope-immutability.md)
+   and [Sprint 13A_2](13a_2-scope-immutability.md). §4's reversible path now
+   survives only before the room has a memory; after any host, tool-sidecar, or
+   guest conversation, scope is immutable. The comp's reversal controls
+   therefore deliberately disappear and are replaced by the recovery path:
+   *"Start a new session to change this — your excerpt and context carry
+   over."* The withdrawal frame, legacy delivery reasons, and new
+   `scope_change` turns retired with those controls. Existing `scope_change`
+   transcript rows remain parseable and renderable as history.
 
 ### Design language
 
@@ -187,31 +197,6 @@ remainder of the comp's inset instead of stacking a second one.
   the rail initially dropped Sprint 12's verified-paste round trip. The sheet
   now reports pastes and owns the draft-equality check, since only it knows the
   current draft.
-
-### Superseded by ADR 2026-07-25 (Sprint 13A_2)
-
-**§4 "The path is reversible in both directions" no longer holds.** Session
-scope is now IMMUTABLE once the room has a memory (any host, tool-sidecar, or
-guest conversation). The reversals survive only in the pre-memory window, where
-nobody has been prompted and a change is invisible to everyone.
-
-What that retired, and why: every mechanism §4 required existed to tell a model
-to stop believing something it had already read. The PR #86 review found three
-defects and all three lived in exactly that machinery. Deleted with it — the
-withdrawal frame and `pendingExcerptWithdrawal`, the `added`/`repinned`
-delivery reasons (`WorkshopExcerptDeliveryReason` is gone entirely), the
-mid-conversation `scope_change` divider, and the open-conversation-carrying-an-
-excerpt hybrid. Pinning a passage now simply makes the room a passage session.
-
-The comp's reversal affordances therefore disagree with the product on this
-point, deliberately. Where an affordance disappears, the surface names the
-recovery path instead: *"Start a new session to change this — your excerpt and
-context carry over."*
-
-See [ADR 2026-07-25](../../../../docs/adr/2026-07-25-workshop-scope-immutability.md)
-and [Sprint 13A_2](13a_2-scope-immutability.md). `scope_change` turns remain
-parseable and renderable — real transcripts written before the lock contain
-them, and they stay the history they are.
 
 ### Behavior change to flag for review
 

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a-open-chat.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a-open-chat.md
@@ -188,6 +188,31 @@ remainder of the comp's inset instead of stacking a second one.
   now reports pastes and owns the draft-equality check, since only it knows the
   current draft.
 
+### Superseded by ADR 2026-07-25 (Sprint 13A_2)
+
+**§4 "The path is reversible in both directions" no longer holds.** Session
+scope is now IMMUTABLE once the room has a memory (any host, tool-sidecar, or
+guest conversation). The reversals survive only in the pre-memory window, where
+nobody has been prompted and a change is invisible to everyone.
+
+What that retired, and why: every mechanism §4 required existed to tell a model
+to stop believing something it had already read. The PR #86 review found three
+defects and all three lived in exactly that machinery. Deleted with it — the
+withdrawal frame and `pendingExcerptWithdrawal`, the `added`/`repinned`
+delivery reasons (`WorkshopExcerptDeliveryReason` is gone entirely), the
+mid-conversation `scope_change` divider, and the open-conversation-carrying-an-
+excerpt hybrid. Pinning a passage now simply makes the room a passage session.
+
+The comp's reversal affordances therefore disagree with the product on this
+point, deliberately. Where an affordance disappears, the surface names the
+recovery path instead: *"Start a new session to change this — your excerpt and
+context carry over."*
+
+See [ADR 2026-07-25](../../../../docs/adr/2026-07-25-workshop-scope-immutability.md)
+and [Sprint 13A_2](13a_2-scope-immutability.md). `scope_change` turns remain
+parseable and renderable — real transcripts written before the lock contain
+them, and they stay the history they are.
+
 ### Behavior change to flag for review
 
 `canMessage` is now false while scope is `null`, even when an excerpt carried
@@ -270,10 +295,12 @@ restored open-conversation session.
 
 ## Exit criteria
 
-- A writer can have a retained host conversation with no excerpt, reload or
-  reopen it, and later adopt an excerpt without restarting.
+- A writer can have a retained host conversation with no excerpt, and reload or
+  reopen it. *(Adopting an excerpt mid-conversation was removed by ADR
+  2026-07-25 — see "Superseded" above.)*
 - Scope drives every surface; nothing infers scope from excerpt presence.
-- Both path reversals work and shelve rather than delete.
+- Both path reversals work and shelve rather than delete, **before the room has
+  a memory**; after that they are refused with the recovery path named.
 - A new session retains excerpt + context attachments and clears transcript,
   host settings, and to-dos.
 - The shared text sheet serves all four authoring cases, and wizard edits are

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a_2-scope-immutability.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a_2-scope-immutability.md
@@ -1,6 +1,7 @@
 # Sprint 13A_2: Scope Immutability
 
-**Status**: In progress on `sprint/workshop-editor-tab-13a_2-scope-immutability`
+**Status**: Complete on `sprint/workshop-editor-tab-13a_2-scope-immutability`;
+PR #87 resolution pass verified 2026-07-25
 **Priority**: High
 **Branch**: `sprint/workshop-editor-tab-13a_2-scope-immutability` -> PR into `epic/workshop-editor-tab`
 **Implements**: [ADR 2026-07-25 — Workshop Session Scope Is Immutable Once the Room Has a Memory](../../../../docs/adr/2026-07-25-workshop-scope-immutability.md)
@@ -23,9 +24,11 @@ question instead.
 ### 1. The lock predicate
 
 `WorkshopSessionService.hasRoomMemory()` — true when `conversationIds()` is
-non-empty (host conversation, any tool sidecar, or any persona-guest
-conversation). Scope is freely selectable while it is false and fixed once it
-is true.
+non-empty (host conversation, any tool sidecar, or any live persona-guest
+conversation), or when the participant map retains a disposed guest tombstone.
+The tombstone proves a guest conversation existed after its provider history
+is discarded, so dismissal cannot reverse the lock. Scope is freely selectable
+while the predicate is false and fixed once it is true.
 
 A tool run locks the scope; a first message that fails and leaves no
 conversation does not.
@@ -99,13 +102,15 @@ recovery path is what makes the lock acceptable.
 
 ## Exit criteria
 
-- [ ] Scope cannot change once any conversation exists; refusal is tested.
-- [ ] A fresh session and a resumed session both report `hasRoomMemory() ===
+- [x] Scope cannot change once any conversation exists; refusal is tested.
+- [x] A persona-guest conversation locks scope, and dismissing the guest does
+      not unlock it or discard its pending host evidence.
+- [x] A fresh session and a resumed session both report `hasRoomMemory() ===
       false` despite their session markers, and scope stays selectable.
-- [ ] The withdrawal path and `WorkshopExcerptDeliveryReason` are gone from the
+- [x] The withdrawal path and `WorkshopExcerptDeliveryReason` are gone from the
       live model.
-- [ ] A checkpoint carrying legacy `pendingExcerptWithdrawal` /
+- [x] A checkpoint carrying legacy `pendingExcerptWithdrawal` /
       `pendingExcerptChange` hydrates cleanly and drops them.
-- [ ] Locked surfaces hide their mutations and name the recovery path.
-- [ ] Superseded tests removed rather than adapted; full suite green,
+- [x] Locked surfaces hide their mutations and name the recovery path.
+- [x] Superseded tests removed rather than adapted; full suite green,
       typecheck clean on all three projects, lint 0 errors.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a_2-scope-immutability.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a_2-scope-immutability.md
@@ -1,0 +1,111 @@
+# Sprint 13A_2: Scope Immutability
+
+**Status**: In progress on `sprint/workshop-editor-tab-13a_2-scope-immutability`
+**Priority**: High
+**Branch**: `sprint/workshop-editor-tab-13a_2-scope-immutability` -> PR into `epic/workshop-editor-tab`
+**Implements**: [ADR 2026-07-25 — Workshop Session Scope Is Immutable Once the Room Has a Memory](../../../../docs/adr/2026-07-25-workshop-scope-immutability.md)
+**Follows**: [Sprint 13A — Open Chat](13a-open-chat.md) (PR #86, merged 2026-07-25)
+**Design load**: **Low** — this sprint mostly *removes* surface. No new layout, no
+new copy beyond one locked-state sentence.
+
+## Goal
+
+Make session scope immutable once the room has a memory, and delete the six
+mechanisms that existed only to service mid-conversation scope changes.
+
+Sprint 13A made the path reversible at any time. The PR #86 review found three
+defects, all of them living in the machinery that reversibility requires, and
+all three were repaired by *deriving* the right answer. This sprint removes the
+question instead.
+
+## Scope
+
+### 1. The lock predicate
+
+`WorkshopSessionService.hasRoomMemory()` — true when `conversationIds()` is
+non-empty (host conversation, any tool sidecar, or any persona-guest
+conversation). Scope is freely selectable while it is false and fixed once it
+is true.
+
+A tool run locks the scope; a first message that fails and leaves no
+conversation does not.
+
+### 2. Temporal frames must never lock
+
+`resetSession()` records a `session_start` marker and `resumeSession()` records
+a `session_resume` marker, so **every session holds a turn before the writer
+acts**. A turn-based predicate would lock scope at `null` on creation and
+strand the writer on the path chooser.
+
+`recordSessionMarker` touches `this.turns` and never `participants`, so the
+chosen predicate is immune structurally. This is under test, and the test is
+what protects every future ledger-only event.
+
+### 3. Guarded transitions
+
+- `setSessionScope(...)` throws when locked.
+- `repinShelvedExcerpt()` throws when locked.
+- `replaceExcerpt(...)` throws when locked **and** scope is `open` — an open
+  conversation never adopts a passage.
+- `replaceExcerpt(...)` in a locked **passage** session is unchanged: revision
+  stays available, still retires tool sidecars, still pulls `chatTarget` back.
+
+### 4. Machinery deleted
+
+- `pendingExcerptWithdrawal`, `WorkshopPendingHostUpdates.excerptWithdrawn`,
+  and the withdrawal prompt frame.
+- `WorkshopExcerptDeliveryReason` entirely. Every surviving delivery is a
+  revision, so a single-member union earns nothing; the lead string is inlined
+  at its one use.
+- `pendingExcerptChange` on the live aggregate.
+- The mid-conversation `scope_change` divider emitted by `replaceExcerpt`.
+
+`hostDeliveredExcerptVersion()` is **retained**. It is the honest answer to
+"what does the host hold," it is what makes the surviving revision path
+correct, and it is cheap.
+
+### 5. Persistence: tolerate and discard
+
+Live checkpoints on disk hold `pendingExcerptWithdrawal` and
+`pendingExcerptChange`. The V1 shape validator rejects unknown fields, so these
+stay in the **allowlist** as explicitly legacy, are discarded on hydrate, and
+are never written again. A writer's real session must not fail to open.
+
+The both-slots integrity guard stays (the shelf survives). The
+delivery-versus-withdrawal contradiction guard goes, along with its test — the
+state it described is now legacy data we normalize rather than reject.
+
+### 6. Surfaces
+
+Once locked:
+
+- **Scope strip** drops its mutation button and becomes purely declarative.
+- **Rail `ExcerptPanel`** drops "Set this aside" / "Unpin" / "Add excerpt" /
+  "Re-pin", keeping "Update text…" and "Re-read from file".
+- **Composer** drops "Add excerpt" in a locked open conversation.
+
+Every disappearance must say where to go: **"Start a new session to change
+this — your excerpt and context carry over."** Required, not optional; the
+recovery path is what makes the lock acceptable.
+
+## Explicit non-goals
+
+- Conversation forking or branching. See
+  [Feature: A prior conversation is a resource, not a branch](../../../features/feature-prior-conversation-as-resource/README.md).
+- Decomposing `WorkshopSessionService` / `WorkshopHandler`. Tracked separately
+  in [`.todo/tech-debt/2026-07-25-workshop-god-files.md`](../../../tech-debt/2026-07-25-workshop-god-files.md).
+  This sprint shrinks both by deletion, which is a happy side effect, not the
+  goal.
+
+## Exit criteria
+
+- [ ] Scope cannot change once any conversation exists; refusal is tested.
+- [ ] A fresh session and a resumed session both report `hasRoomMemory() ===
+      false` despite their session markers, and scope stays selectable.
+- [ ] The withdrawal path and `WorkshopExcerptDeliveryReason` are gone from the
+      live model.
+- [ ] A checkpoint carrying legacy `pendingExcerptWithdrawal` /
+      `pendingExcerptChange` hydrates cleanly and drops them.
+- [ ] Locked surfaces hide their mutations and name the recovery path.
+- [ ] Superseded tests removed rather than adapted; full suite green,
+      typecheck clean on all three projects, lint 0 errors.

--- a/docs/adr/2026-07-25-workshop-scope-immutability.md
+++ b/docs/adr/2026-07-25-workshop-scope-immutability.md
@@ -1,6 +1,6 @@
 # ADR 2026-07-25: Workshop Session Scope Is Immutable Once the Room Has a Memory
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-25
 **Extends:** [ADR 2026-07-14 — Workshop Session Persistence and the Session Browser](2026-07-14-workshop-session-persistence.md); [ADR 2026-07-11 — Workshop Excerpt Revision and Room Memory](2026-07-11-workshop-excerpt-revision-and-room-memory.md)
 **Supersedes:** [Sprint 13A](../../.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a-open-chat.md) §4 "The path is reversible in both directions" — reversibility is retained only before the room has a memory, and the mid-conversation transitions it specified are deleted rather than re-bounded. §§1–3 and 5–11 stand unchanged.
@@ -80,9 +80,11 @@ immutable thereafter.**
 
 ### 1. The lock predicate is "any conversation exists"
 
-Scope may change while `conversationIds()` is empty — no host conversation, no
-tool sidecar, no persona-guest conversation. Once any exists, `scope` is fixed
-for the life of the session.
+Scope may change while `conversationIds()` is empty and no persona-guest
+tombstone exists — no host conversation, no tool sidecar, and no current or
+former persona-guest conversation. Once any exists, `scope` is fixed for the
+life of the session. Dismissing a guest discards its provider conversation but
+keeps its participant record, so dismissal cannot reverse the lock.
 
 This predicate is chosen over the simpler "first visible turn" because it
 matches the underlying truth: scope is locked exactly when some participant's
@@ -95,8 +97,11 @@ memory depends on it. Two consequences follow, both intended:
   A network error on the first turn must not strand the writer in a mode they
   did not commit to.
 
-`WorkshopSessionService.conversationIds()` already enumerates exactly this set;
-the predicate is a new public `hasRoomMemory()` over it, not new bookkeeping.
+`WorkshopSessionService.conversationIds()` enumerates the live set.
+`hasRoomMemory()` adds the existing disposed-guest participant record as the
+historical proof that a guest conversation existed; this uses the durable
+tombstone already required for thread attribution rather than adding parallel
+bookkeeping.
 
 #### Temporal frames must never count as a turn
 

--- a/docs/pr-reviews/pr-87-scope-immutability-review.md
+++ b/docs/pr-reviews/pr-87-scope-immutability-review.md
@@ -1,0 +1,691 @@
+# MR Review — Sprint 13A_2: Scope Immutability — the session path settles once the room has a memory
+
+**Author:** Okey Landers · PR [#87](https://github.com/okeylanders/prose-minion-vscode/pull/87) · `sprint/workshop-editor-tab-13a_2-scope-immutability` → `epic/workshop-editor-tab`
+**Reviewed:** 2026-07-25 · Implements [ADR 2026-07-25](../adr/2026-07-25-workshop-scope-immutability.md) · Origin: [PR #86 review](pr-86-open-chat-session-scope-review.md)
+
+---
+
+## Resolution ledger
+
+Status is the reviewer's **initial recommendation**, not a verdict — update the `Status` column as
+findings are addressed so this file stays a living record. Legend: **Open** = act before merge ·
+**Deferred** = real issue, safe to punt for a stated reason (track it) · **Addressed** = fixed ·
+**Partially addressed** = fixed with a noted remainder · **N/A** = out of scope or superseded.
+
+| # | Sev | Finding | Reviewers | Consensus | Status |
+|---|-----|---------|-----------|-----------|--------|
+| 1 | 🔴 Blocking | The 13A `open` + pinned-excerpt hybrid hydrates verbatim and wedges the session | Blake, Sam | 🎯 | **Addressed** |
+| 2 | 🟠 High | Dismissing a persona guest un-locks the scope, and their exchanges still ship to the host | Blake | — | **Addressed** |
+| 3 | 🟠 High | The persona-guest lock path has zero test coverage | Cal | — | **Addressed** |
+| 4 | 🟠 High | The legacy-delivery-reason migration test exercises only one of its two branches | Cal, Bria | 🎯 | **Addressed** |
+| 5 | 🟠 High | The ADR's named "Required test" never walks the resume path it names | Cal | — | **Addressed** |
+| 6 | 🟠 High | The scope-lock refusal is silent in two of its three handlers | Oliver | — | **N/A** — `sendError()` already logs every refusal; regression assertion added |
+| 7 | 🟠 High | The hydration migration that rewrites a session's scope leaves no trail | Oliver | — | **Addressed** |
+| 8 | 🟠 High | The refusal sentence is authored four times, once inside the host-agnostic core | Marcus | — | **Addressed** |
+| 9 | 🟠 High | The comp/product divergence landed under a new heading, not the ADR-mandated one | Stan, Bria | 🎯 | **Addressed** |
+| 10 | 🟡 Standard | One concept, four names — and `locked` doesn't lock what it says | Parker, Marcus | 🎯 | **Addressed** |
+| 11 | 🟡 Standard | `setSessionScope`'s idempotence checks silently depend on preceding the lock check | Parker | — | **Addressed** |
+| 12 | 🟡 Standard | The handler's banner comment still describes the machinery this PR deleted | Parker | — | **Addressed** |
+| 13 | 🟡 Standard | `replaceExcerpt` invents a second refusal idiom for the third member of one family | Stan | — | **Addressed** |
+| 14 | 🟡 Standard | The one-time migration lives inline in the permanent hydration path | Marcus | — | **Addressed** |
+| 15 | 🟡 Standard | A degraded host binding silently re-unlocks a room whose transcript proves otherwise | Oliver | — | **Deferred** — policy documented at the predicate; coordinator logs binding loss |
+| 16 | 🟡 Standard | `hostDeliveredExcerptVersion()` re-derives what `activeHostPin` already caches in O(1) | Tim | — | **Deferred** — doesn't matter at current scale |
+| 17 | 🟢 Praise | The lock predicate is bounded by a fixed participant enum; the PR only shrinks the broadcast | Tim | — | **N/A** |
+| 18 | 🟢 Praise | A genuinely clean security pass — the load-bearing integrity rule survived | Patricia | — | **N/A** |
+
+---
+
+## Resolution pass — 2026-07-25
+
+The blocking hybrid now passes through a named V1 hydration migration before
+current invariants are enforced. `scope: 'open'` plus a pinned excerpt becomes
+a passage session, is reported in the hydration result, and is logged by the
+persistence coordinator. The same migration owns the older withdrawal and
+delivery-reason normalization instead of leaving one-time compatibility logic
+inline in the aggregate.
+
+Dismissed persona guests now remain scope-lock evidence through their existing
+durable participant tombstone. Their unseen exchange remains eligible for the
+host handoff because the passage path can no longer change underneath it. The
+test walks the real join → response → dismiss path and proves both properties.
+
+The domain now throws `WorkshopScopeLockedError`; one shared product-copy
+constant supplies the proactive UI signposts and reactive handler refusal.
+`roomHasMemory` is the name from snapshot through hook and all three surfaces.
+The handler's central four-caller helper is named `tryReplaceExcerpt`, and
+`setSessionScope` makes the load-bearing idempotence-before-lock ordering
+explicit.
+
+Verification after the resolution pass:
+
+- Focused scope/persistence/handler/webview suite: **230 tests passed**
+- All three TypeScript projects: **clean**
+- ESLint: **0 errors** (repository baseline warnings remain)
+- Full Jest suite: **1,342 tests passed**, snapshot green
+
+---
+
+## Blast Radius
+
+- **24 files changed · +815 / −637** — a net-negative PR that deletes six mechanisms
+- New files: 1 (sprint doc `13a_2-scope-immutability.md`) · Migrations: yes (checkpoint hydration, §7) · New services/handlers: none
+- 9 of 24 files are tests — the test suite is the bulk of the change
+- **Character:** an architectural simplification landing as deletion. The two real defects are both in the seam between the new construction and the data the old construction wrote.
+
+---
+
+## Report Card
+
+| Category | At review | After resolution |
+| --- | --- | --- |
+| 🏛️ Architecture | C | **A−** |
+| 🛡️ Security | A | **A** |
+| 🧪 Tests | D | **A−** |
+| 📖 Quality | B− | **A−** |
+| ⚡ Performance | B+ | **B+** |
+| 🎯 Domain | C | **A** |
+
+*The blocking finding was a migration-seam defect straddling Architecture and Domain; the report card
+grades each reviewer's own findings, so the blocker's weight lived in the briefing rather than in a
+single letter. The resolution column reflects the verified pass recorded above — the migration is now
+a named, twice-validated boundary, and both defects are covered at unit **and** integration level.
+Performance is unchanged because there was nothing to fix.*
+
+---
+
+## Executive Briefing
+
+> **Resolved 2026-07-25.** Every item below was fixed and independently verified — see
+> [Resolution pass](#resolution-pass--2026-07-25) and the ledger. Kept in the original present tense
+> as the record of what the panel found; the "How it resolved" line on each states where it landed.
+
+🔴 **[Blake + Sam · 🎯 Consensus]** **The `open` + pinned-excerpt hybrid wedges the session.** The old
+`setExcerpt` let an open conversation adopt a passage and stay open, so `scope: 'open'` with a
+populated `excerpt` is a real, structurally valid checkpoint on disk. §7 normalizes exactly one legacy
+shape and misses this one. On hydrate, all three exits throw — including `setSessionScope('open')`
+refusing *"this room already has a conversation"* at a room that is already open — while the UI renders
+"Update text…" as an enabled button. Verified independently against base commit `bfcaf45`.
+→ *How it resolved:* a named `WorkshopSessionStateV1Migration` module normalizes the hybrid to a
+passage session, hydration runs **validate → migrate → validate again**, and the integrity validator
+now forbids the shape outright behind a single opt-in flag that dies at the migration boundary.
+
+🟠 **[Blake]** **Dismissing a persona guest un-locks the scope.** `dismissPersonaGuest` clears
+`conversationId`, so the guest leaves `conversationIds()` and `hasRoomMemory()` returns to `false` —
+the one property this PR exists to remove. The dismissed guest's passage-specific commentary then
+ships into the host's opening prompt anyway, because `collectUnseenGuestExchangesForHost` has no
+liveness filter.
+→ *How it resolved:* inverted — `hasRoomMemory()` now counts `personaGuests.size > 0`, so a guest that
+ever held a conversation is permanent lock evidence and the handoff stays honest *because* the path
+can no longer move under it. `reset()` clears the tombstones via `newParticipants()`, so a new session
+is not born locked.
+
+🟠 **[Cal]** **The persona-guest lock path has zero tests** — and it is exactly where Blake's defect
+lives. The untested path and the broken path are the same path.
+→ *How it resolved:* a test walks the real join → `completeRun` → dismiss path and asserts both
+properties — the lock persists, and the exchange stays eligible for the host handoff.
+
+🟠 **[Cal + Bria · 🎯 Consensus]** **A migration test that looks like it covers a branch and doesn't.**
+The `pendingExcerptChange` test passes `{ host: 'host-conv' }`, but the fixture never starts a host
+conversation, so `hostExpected` is false and the binding is never consulted. Only the "dropped" branch
+runs.
+→ *How it resolved:* the fixture now calls `startHostConversation()` first, so the binding is genuinely
+consulted, and a second test covers the "no host memory survives" branch. Both rows of §7 are live.
+
+🟠 **[Oliver]** **The refusal a writer will hit first is the one that logs nothing.** The author added
+`appendLine` before `sendError` for the excerpt-pin refusal but not in `handleSetSessionScope` or
+`handleRepinExcerpt`, which catch the identical new lock throw.
+→ *How it resolved:* **rejected as a false positive.** `sendError` has always ended with
+`outputChannel.appendLine(...)` — confirmed present before the resolution pass — so every scope refusal
+was logged the whole time. Oliver compared two handlers against a sibling without checking the shared
+helper, which Rule B exists to prevent. A regression assertion was added instead.
+
+---
+
+## 🏛️ Marcus · Architecture & Design
+
+*"The Cartographer of Layer Boundaries"*
+
+### 🟠 High — The scope lock's refusal message is UI copy, authored four times across the dependency boundary
+
+[`WorkshopSessionService.ts:378-382`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L378-L382)
+
+`packages/core` is meant to be host-agnostic — the composition-root rule in `CLAUDE.md` exists
+precisely so this aggregate can be reused by a non-VS-Code host. But `requireUnlockedScope` throws a
+fully-formed, writer-facing sentence, and `WorkshopHandler`'s catch block
+([`:2553-2560`](../../packages/core/src/application/handlers/domain/WorkshopHandler.ts#L2553-L2560))
+forwards it to the webview verbatim — with a test asserting on that literal string. Meanwhile
+[`ExcerptPanel.tsx:140-147`](../../packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx#L140-L147),
+[`:324-328`](../../packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx#L324-L328),
+and [`WorkshopScopeStrip.tsx:64-68`](../../packages/core/src/presentation/webview/components/workshop/WorkshopScopeStrip.tsx#L64-L68)
+each hand-author their own version of the same "start a new session, your excerpt and context carry
+over" message for the *proactive* signpost. Four independently-maintained copies of one product
+decision, one baked into the domain layer, with nothing enforcing agreement. The reactive (thrown) and
+proactive (rendered) paths will drift the next time either is tweaked, and any future host inherits
+this exact English by construction.
+
+**Suggested:** throw a typed refusal (`{ reason: 'scope-locked' }` or an error code) and let one
+presentation-side formatter own the sentence — the same formatter both the signpost and the error
+toast call into.
+
+### 🟡 Standard — The §7 migration lives inline in the mainline hydration path, not as an isolated versioned step
+
+[`WorkshopSessionService.ts:1825-1843`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L1825-L1843)
+
+`WorkshopSessionStateV1` still calls itself V1 with no version discriminant, and the one-time
+normalization is spliced directly into `hydrateCommittedState`'s primary variable derivation — the
+same function that will read every future checkpoint forever. No structural marker separates "this is
+a current checkpoint" from "this is a one-time shim for pre-lock data." Six months out, someone reading
+cold has to reconstruct from a comment, not a type, that `withdrawalNeverShipped` is dead weight for
+anything written after 2026-07-25. Given `CLAUDE.md`'s aversion to legacy paths and that the author has
+deliberately carved out persisted writer data as the exception, the exception should *look* like one
+structurally — a named migration step called once at the top of hydration.
+
+> *"The bones are sound, but the room where the writer's refusal gets its words is now three rooms, and only one of them is on the blueprint."* — Marcus
+
+---
+
+## 🔥 Blake · Critical / Blocking Issues
+
+*"She's Been Paged for This Before"*
+
+### 🔴 Blocking — The 13A open-with-excerpt hybrid hydrates verbatim and permanently wedges the session [🎯 Consensus]
+
+[`WorkshopSessionService.ts:1837-1843`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L1837-L1843)
+
+§7 normalizes exactly one legacy shape (`withdrawalNeverShipped`). It does not normalize the other one
+13A could write. On the base branch, `setExcerpt` read:
+
+```ts
+// Pinning IS choosing the passage path — but an open conversation that
+// adopts an excerpt stays open (Sprint 13A §4: a visible context
+// transition, not a new session).
+if (this.scope !== 'open') {
+  this.scope = 'excerpt';
+}
+```
+
+So `scope: 'open'` with a populated `excerpt` is a real, structurally valid V1 checkpoint.
+[`WorkshopSessionStateV1Integrity.ts`](../../packages/core/src/application/services/workshop/WorkshopSessionStateV1Integrity.ts)
+only forbids `excerpt` + `shelvedExcerpt` together — it contains **zero** references to `scope`.
+
+**Trace.** Hydrate that checkpoint with the host binding present → L1839 restores `scope: 'open'`,
+L1829 restores the excerpt, host conversation restored → `hasRoomMemory()` is `true`. Now every path
+out is refused:
+
+| Attempt | Result |
+|---|---|
+| `replaceExcerpt` ([`:503-508`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L503-L508)) | sees `scope === 'open'` → throws through all four handler call sites (`:1189`, `:1759`, `:2160`, `:2228`) → `sendError` toast |
+| `setSessionScope('excerpt')` | fails the `:411` idempotence guard (scope isn't `'excerpt'`) → `requireUnlockedScope` throws |
+| `setSessionScope('open')` | fails the `:397` guard (`this.excerpt` is truthy) → throws *"this room already has a conversation"* at a session that is **already open** |
+
+Meanwhile `ExcerptPanel` falls into its pinned branch
+([`:260`](../../packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx#L260)+)
+because `excerpt` is truthy regardless of `scope`, and renders "Update text…" / "Re-read from file"
+**enabled**. The writer clicks a live button and gets a guaranteed refusal naming a recovery path for a
+passage the room already holds. `WorkshopScopeStrip` simultaneously renders *"Open conversation · No
+excerpt yet"* ([`:63`](../../packages/core/src/presentation/webview/components/workshop/WorkshopScopeStrip.tsx#L63))
+— an on-screen contradiction. `exportCommittedState` writes the hybrid straight back, so it persists
+across every open.
+
+This directly contradicts the sprint doc's own promise: *"`replaceExcerpt(...)` in a locked passage
+session is unchanged: revision stays available."*
+
+**Coverage:** every legacy hydration fixture in `WorkshopSessionScope.test.ts` (`:483-537`) sets
+`excerpt: undefined`. Nothing hydrates `scope: 'open'` with a pinned excerpt.
+
+**Fix:** normalize at the same boundary — `state.scope === 'open' && excerpt !== undefined` →
+`scope: 'excerpt'` (the host holds it; agreeing with the host is the same rule §7 already applies to
+the undelivered withdrawal). Then assert the invariant in the integrity validator so it can never come
+back.
+
+### 🟠 High — Dismissing a guest un-locks the scope, and that guest's exchanges still ship to the host
+
+[`WorkshopSessionService.ts:996-1015`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L996-L1015)
+
+`dismissPersonaGuest` clears `guest.conversationId` before flipping liveness, so a dismissed guest
+contributes nothing to `conversationIds()` and `hasRoomMemory()` returns to `false`. **The lock is
+reversible** — the one property this PR exists to remove.
+
+**Trace.** Pin excerpt v1 → invite Margot (`beginPersonaGuestJoin`
+[`:1256-1264`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L1256-L1264)
+requires only `requireExcerpt()`, no host conversation) → she is handed the pin in her join envelope
+and replies about it → dismiss her → `hasRoomMemory()` is `false` → `setSessionScope('open')` passes
+`requireUnlockedScope`, shelves the passage, mints no divider ("invisible to everyone"). Then the
+writer's first host message: `collectUnseenGuestExchangesForHost`
+([`:1478`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L1478))
+iterates `personaGuests.values()` with **no liveness filter**, and no cursor was ever advanced — so the
+guest-handoff frame delivers Margot's passage-specific commentary into the host's opening prompt. A
+host that holds no excerpt, in a room that reports `scope: 'open'`.
+
+That is precisely the ambiguity `requireUnlockedScope` was written to prevent, reached *through the
+predicate itself*.
+
+**Coverage:** every lock test uses `startHostConversation()`. No test dismisses a guest and then
+changes scope.
+
+**Fix (pick one, currently neither holds):** make the predicate count a guest that ever *held* a
+conversation (a `hasHeldConversation` flag, or `personaGuests.size > 0`), **or** filter
+`collectUnseenGuestExchangesForHost` by liveness and drop the pending handoff on dismissal.
+
+> *"The lock has a back door and a legacy checkpoint that walks straight into a dead room — ship this and I'll see you in the incident channel."* — Blake
+
+---
+
+## 🔍 Sam · Bug Hunter
+
+*"What if the list is empty, though?"*
+
+### 🔴 Blocking — Hydration doesn't retire the `open` + pinned-excerpt hybrid it was supposed to kill [🎯 Consensus]
+
+[`WorkshopSessionService.ts:1825-1843`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L1825-L1843)
+
+*Same defect as Blake's blocker, reached by a second independent route.* Sam traced it through
+`repinShelvedExcerpt` rather than `setExcerpt`: on the base branch
+(`git show bfcaf45`), that method calls `adoptShelvedExcerpt(shelved)` and records a `scope_change`
+divider but **never touches `this.scope`**. So a writer who pinned, went open, then re-pinned *without
+leaving the open conversation* — a fully tested Sprint 13A feature — also lands in `scope: 'open'` with
+`excerpt` defined, persisted exactly that way.
+
+Two routes into the same invalid state raises the probability that such checkpoints exist on disk. The
+`setExcerpt` route Blake found is the likelier one, since "Add excerpt" mid-open-chat was a first-class
+13A affordance.
+
+> *"Found the trap door — it's a 'supported' repin from PR #86 that never touched `scope`, and this migration only patches the withdrawal case, so `open` + a pinned excerpt sails through hydration looking perfectly legal right up until the strip lies to the writer's face."* — Sam
+
+---
+
+## 📖 Parker · Code Quality
+
+*"Code is Communication, Not Instruction"*
+
+### 🟡 Standard — One boolean, four names, and one of them lies a little [🎯 Consensus]
+
+[`ExcerptPanel.tsx:58`](../../packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx#L58)
+
+`WorkshopApp.tsx` reads the same value out of the hook and hands it to three sibling components under
+two different names in the same JSX tree: `locked={workshop.roomHasMemory}` for `ExcerptPanel`,
+`roomHasMemory={...}` for `WorkshopScopeStrip` and `WorkshopComposer`. Upstream it's `hasRoomMemory()`
+on the aggregate and `hasConversation` on the snapshot — four names, one concept, three layers.
+
+But `locked` isn't just a rename — it's doing double duty. When `locked` is true in the excerpt-pinned
+branch ([`:292-304`](../../packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx#L292-L304)),
+the "Paste or type" button doesn't disappear or disable; it **relabels to "Update text…" and stays
+fully clickable** — that's `replaceExcerpt`, a live mutation. What actually goes away under `locked` is
+the scope-reversal button. So the boolean genuinely locks the *session path* but only cosmetically
+"locks" the *excerpt content*. A reader who sees `locked` and assumes "nothing here can change" will be
+wrong about half the panel.
+
+**Suggested:** pass `roomHasMemory` through unchanged and let the JSDoc, not the identifier, carry the
+"this switches the intake copy too" nuance.
+
+### 🟡 Standard — `setSessionScope`'s guard placement makes the lock/idempotence relationship implicit
+
+[`WorkshopSessionService.ts:395-424`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L395-L424)
+
+Two branches, each with the same shape — idempotence check, then `requireUnlockedScope(...)`, then the
+mutation. The ordering is correct and load-bearing (re-asking for the scope you're already in must
+never throw, even when locked, which a test depends on) — but nothing says "no-op check precedes lock
+check, on purpose." The `excerpt` branch's last line, `if (this.excerpt === undefined) {
+this.adoptShelvedExcerpt(restored); }`, adds a second read: by the time you reach it the early return
+has already ruled out `scope === 'excerpt' && this.excerpt`, so given the one-slot invariant this
+condition is true on every live path. It reads like a branch point but isn't one.
+
+**Suggested:** a named `isIdempotentScopeRequest(scope)` helper at the top of both arms, or a comment
+stating the invariant it leans on.
+
+### 🟡 Standard — The routing-block comment describes the OLD machinery, not what's left
+
+[`WorkshopHandler.ts:1393-1396`](../../packages/core/src/application/handlers/domain/WorkshopHandler.ts#L1393-L1396)
+
+This banner sits directly above `handleSetSessionScope` / `handleRepinExcerpt` / `applyScopeTransition`
+and still cites "Sprint 13A §4," calling every transition *"a context transition inside ONE retained
+session: no conversation, transcript, task, or attachment is discarded."* But the whole point of this
+PR is that these transitions now fire only *before* any conversation exists — there is no conversation
+*to* discard at the point this code runs. A reader who lands here first (banner comments are where
+people start) gets the Sprint 13A mental model and has to un-learn it three files later. This PR already
+rewrote the equivalent header on `setSessionScope` itself; this banner deserves the same treatment.
+
+> *"It works, but I had to read three files to learn that 'locked' leaves the pen unlocked and the banner comment is describing a machine this PR just tore out — that's a tax on everyone who reads this forever."* — Parker
+
+---
+
+## 🧪 Cal · Test Coverage & Quality
+
+*"Confidence Levels, Not Coverage Numbers"*
+
+### 🟠 High — The scope lock is tested for host and tool conversations, never for a persona guest
+
+[`WorkshopSessionScope.test.ts:130-216`](../../packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts#L130-L216)
+
+`hasRoomMemory()`'s own doc comment and the ADR both name three conversation types that lock scope:
+host, tool sidecar, and persona guest — and `conversationIds()` reads all three. The
+`describe('the scope lock')` block has eight cases covering host (`:131`), tool (`:140`), the
+open-conversation refusal (`:150`), re-pin (`:160`), the recovery copy (`:169`), revision-still-allowed
+(`:177`), session markers (`:196`), and the failed run (`:206`). **There is no persona-guest test.** The
+one guest reference in the file (`:74`) is an unrelated pre-lock assertion.
+
+A persona guest joining and then talking is the one lock path with zero regression coverage — and it is
+exactly where Blake's HIGH finding lives.
+
+### 🟠 High — The migration test never establishes a live host conversation, so only half of §7 row 2 is exercised [🎯 Consensus]
+
+[`WorkshopSessionScope.test.ts:520-537`](../../packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts#L520-L537)
+
+ADR §7 row 2: `pendingExcerptChange` is *"coerced to `'revised'` when a conversation exists; dropped
+with the pending delivery otherwise"* — two branches, and the ADR's Implementation section demands "a
+test per row." The test passes `{ host: 'host-conv' }` as a runtime binding and reads like it exercises
+the "conversation exists" branch. It doesn't: `pin()` never calls `startHostConversation()`, so
+`exported.participants.host.conversationKey` is never `'host'`, and
+`hostExpected = conversationKey === 'host'` gates whether the binding is consulted at all
+([`WorkshopSessionService.ts:1863`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L1863)).
+`hostConversationId` stays `undefined` regardless.
+
+Worth noting: `pendingExcerptChange` is never *read* anywhere in `WorkshopSessionService.ts`, and
+`WorkshopExcerptDeliveryReason` is deleted entirely — so "coerced when a conversation exists" is true
+only by construction, never by an explicit code path.
+
+### 🟠 High — The ADR's named "Required test" — a resumed session — is never actually resumed
+
+[`WorkshopSessionScope.test.ts:196-204`](../../packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts#L196-L204)
+
+ADR §1 calls out by name that *"a fresh session, **and a resumed session**, must both report
+`hasRoomMemory() === false`… and scope must still be freely selectable after a resume"* — and frames
+this as "the hazard that decides the predicate," explicitly "not hypothetical." The test calls
+`recordSessionMarker('start', …)` and `recordSessionMarker('resume', …)` back-to-back on one
+never-persisted instance. It never goes through `hydrateCommittedState` + resume, which is what
+`WorkshopSessionPersistenceCoordinator.resumeSession()` actually does. The pre-existing coordinator
+resume test resumes a real checkpoint but never calls `hasRoomMemory()` or attempts a scope change
+afterward.
+
+> *"Happy path only. I've seen this movie — the branch nobody actually walks through the front door is always the one that ships broken."* — Cal
+
+---
+
+## 🗂️ Stan · Codebase Standards
+
+*"He Has Every Pattern Memorized"*
+
+### 🟠 High — The divergence landed in a new section, not the one the ADR named [🎯 Consensus]
+
+[`13a-open-chat.md:191`](../../.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a-open-chat.md#L191)
+
+ADR §Consequences is explicit: *"that divergence must be recorded in the sprint's 'Where the comp and
+the product disagreed' section, **as its siblings were**."* That section already exists at line 121 and
+lists exactly three prior divergences (editor tab strip, sample passage, starter chips) — untouched by
+this PR. The reversal-affordance divergence went into a brand-new `### Superseded by ADR 2026-07-25`
+heading at line 191, after "Contract decisions worth knowing." The content is good; it's filed under a
+heading the ADR didn't ask for, so a reader scanning the divergence history won't find it there.
+
+### 🟡 Standard — `replaceExcerpt` invents a second refusal shape for the same lock its neighbors already handle
+
+[`WorkshopHandler.ts:2546-2590`](../../packages/core/src/application/handlers/domain/WorkshopHandler.ts#L2546-L2590)
+
+The sprint doc groups these as one family — *"`setSessionScope(...)` throws when locked.
+`repinShelvedExcerpt()` throws when locked. `replaceExcerpt(...)` throws when locked and scope is
+`open`."* Two of the three have a home: `handleSetSessionScope` (`:1398`) and `handleRepinExcerpt`
+(`:1422`) each wrap the throwing call in a try/catch at the **call site** and route straight to
+`sendError`. `replaceExcerpt` does something else — the try/catch moved *inside* the private helper,
+which now returns `boolean`, and all four call sites (`:1189`, `:1759`, `:2160`, `:2228`) grew an
+`if (!this.replaceExcerpt(...)) { return; }` guard. Nothing wrong with either shape in isolation, but a
+reader who just learned the call-site pattern two methods up has to relearn a second idiom for the
+third guarded transition on the same list.
+
+> *"We wrote the pattern for this twice, right above it — `handleSetSessionScope`, then `handleRepinExcerpt` — and `replaceExcerpt` still went its own way for the third guarded transition on the same list."* — Stan
+
+---
+
+## ⚡ Tim · Performance
+
+*"O(n²) at Scale is an Incident Waiting to Happen"*
+
+### 🟢 Praise — `hasRoomMemory()` is bounded by participant count, not turn count — and the PR only shrinks the broadcast
+
+[`WorkshopSessionService.ts:2139-2152`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L2139-L2152)
+
+`conversationIds()` iterates host (≤1) + `toolSidecars` (fixed-size object keyed by the
+`WorkshopToolId` union) + `personaGuests` (a `Map` keyed by the `WorkshopPersonaId` union) — all fixed,
+small enums, not proportional to session length. At 200 turns / 3 guests / 4 sidecars that's an
+~8-element allocation. `getSnapshot()` calls it once per broadcast and maps
+`turns.slice(-WORKSHOP_SNAPSHOT_TURN_WINDOW)` (capped at 100), untouched by this PR. **O(participants),
+not O(turns)** — this doesn't degrade as sessions lengthen, only as the persona/tool roster grows, and
+that roster is a fixed enum.
+
+On the deletion side: removing the mid-conversation `scope_change` divider means the common pre-memory
+scope switch no longer mints an extra turn + prompt frame, and dropping `pendingHostUpdate.excerptWithdrawn`
+shrinks the payload. **This PR made `getSnapshot()` strictly cheaper or unchanged, never more
+expensive.** Bonus: `roomHasMemory` is a `useState<boolean>` set every snapshot, but React bails via
+`Object.is` on unchanged primitives — so it re-renders only on the real transition.
+
+### 🟡 Standard — `hostDeliveredExcerptVersion()` re-derives what `activeHostPin` already caches in O(1)
+
+[`WorkshopSessionService.ts:459-467`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L459-L467)
+
+`this.activeHostPin` is maintained at every write site (`:903` on delivery, `:1665` on reset, `:1955` on
+hydrate) and holds the same value this backward loop walks to find. `hostWriterSources` isn't windowed
+like `turns` is — it only resets on full session reset — and interleaves `pin` rows with
+`message-attachment` rows, so scan length is bounded by "turns since the last excerpt revision," not a
+constant. **Doing the math:** `queueExcerptDelivery` is the only caller, firing once per pin action —
+maybe 10–20 times in a 200-turn session. Even a worst-case 200-element scan is microseconds.
+**Doesn't matter at current scale.** But it's a second source of truth for a value already tracked in
+O(1); swapping to `this.activeHostPin?.excerptVersion` makes the whole question disappear rather than
+be re-litigated later.
+
+> *"Bounded by a fixed-size enum, capped at 100 turns, and getting cheaper with every deletion — I checked the arithmetic so you don't have to, and it comes up boring, which is the best thing arithmetic can do."* — Tim
+
+---
+
+## 🛡️ Patricia · Security
+
+*"She Reads Code Like an Attacker Would"*
+
+### 🟢 Praise — Zero findings across all four boundaries
+
+**Webview → host IPC.** `handleSetSessionScope` validates the enum via `isWorkshopSelectableSessionScope`
+before touching the aggregate. All three scope-mutating paths enforce `requireUnlockedScope()` *inside
+the aggregate*, not just via the UI's `locked` prop — so a webview that lied about `roomHasMemory` and
+sent the message anyway is still rejected host-side, caught, and routed through `sendError`. The one
+gap the ADR itself names (the aggregate's throw escaping as an unhandled rejection) is what this PR
+fixes.
+
+**Persisted checkpoint.** Two integrity assertions were removed, but the one that matters —
+*"exactly one of `excerpt`/`shelvedExcerpt` may be populated"*
+([`WorkshopSessionStateV1Integrity.ts:29-31`](../../packages/core/src/application/services/workshop/WorkshopSessionStateV1Integrity.ts#L29-L31))
+— is untouched and still runs first, since `validateWorkshopSessionStateV1(state)` is the first line of
+hydration. The `withdrawalNeverShipped` normalization looked like a lock bypass on first read but
+isn't: the lock guards *future mutation calls*, not the one-time hydration assignment, and the
+normalization makes persisted scope agree with what the host's actual conversation history contains.
+The legacy fields remain shape-constrained (`enumAt([...])`, `pendingExcerptWithdrawal` must be `true`
+or absent), so hand-edited garbage can't slip past as a different type.
+
+**Prompt content.** The removed withdrawal frame and delivery-lead union were UX framing for the LLM,
+not content-trust labeling. The actual trust boundary — the `<pinned-excerpt version="...">` wrapper
+around writer text — is untouched.
+
+**Filesystem.** No path-handling changes.
+
+> *"Passes the scanner, passes the attacker too — the one integrity rule that would've mattered if it were gone is still standing guard, and the two that got cut were never load-bearing."* — Patricia
+
+---
+
+## 🌙 Oliver · Observability & Debuggability
+
+*"Would This Failure Leave a Trail at 2am?"*
+
+### 🟠 High — The scope lock's refusal path is silent — except where the author already fixed it
+
+[`WorkshopHandler.ts:1414-1419`](../../packages/core/src/application/handlers/domain/WorkshopHandler.ts#L1414-L1419)
+
+`handleSetSessionScope` and `handleRepinExcerpt` (`:1414-1419`, `:1428-1433`) catch the exact
+`requireUnlockedScope` throw this PR newly wires in, and send it to the webview with **zero**
+`appendLine`. Compare the private `replaceExcerpt` a thousand lines down, which this same PR touches:
+`this.outputChannel.appendLine(\`[WorkshopHandler] Excerpt pin refused: ${details}\`)` *before*
+`sendError`. The author clearly recognized "aggregate throw reaching the writer needs a log line" as a
+pattern worth fixing — they fixed it in one of three call sites hitting the identical new lock.
+
+Before this PR a scope-change throw was a rare edge case; after it, hitting a locked room is the PR's
+**headline interaction**. When a writer reports "it won't let me change the mode and I don't know why,"
+the Output Channel has every *excerpt* rejection and nothing for every *scope* rejection.
+
+**Fix:** mirror the `appendLine` into both catch blocks. One line each.
+
+### 🟠 High — The hydration migration that reclassifies a session's scope leaves no trail
+
+[`WorkshopSessionService.ts:1825-1843`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L1825-L1843)
+
+Searched `hydrateCommittedState` (`:1808-1972`) for `appendLine` — **not found, anywhere in the
+function.** This block silently un-shelves a passage and rewrites `scope: 'excerpt'`, and two legacy
+fields are dropped without a trace on every hydrate. This is the same author who, in the same PR, added
+deliberate logging for a structurally identical case — a shelf destroyed by a pin (`:2568-2577`:
+*"this line is the only surviving record of what the pin destroyed"*). The migration is that scenario in
+reverse: the only record of *why* a session's scope flipped under a returning writer is a source
+comment.
+
+**Note on the fix:** `WorkshopSessionService` has **no logger at all** — zero `appendLine`/`LogSink`
+references, by design as a pure aggregate. So logging can't go inside `hydrateCommittedState` without
+breaking that boundary. The honest shape is to return the migration fact on the existing
+`WorkshopSessionHydrationResult` (which already carries `degradedConversationKeys` for exactly this
+purpose) and let `WorkshopSessionPersistenceCoordinator` log it at its two call sites (`:653`, `:872`).
+
+### 🟡 Standard — A degraded host binding silently re-unlocks a room the writer remembers talking in
+
+`hasRoomMemory()` ([`:371-373`](../../packages/core/src/application/services/workshop/WorkshopSessionService.ts#L371-L373))
+is defined purely over `conversationIds()` — live runtime bindings — not over `turns.length`. In
+hydration, `hostConversationId` becomes `undefined` whenever the runtime binding is missing or stale
+(`:1864`, `:1867-1874`), dropping the host out of `conversationIds()`. If that was the room's only live
+conversation, `hasRoomMemory()` flips to `false` on reopen **even though `this.turns` still holds every
+message the writer wrote** — so the strip and rail unlock their mutation affordances for a room whose
+transcript plainly shows a conversation happened.
+
+The coordinator already logs degraded keys and the writer gets a generic *"N conversation histories were
+restored without retained memory"* status (both pre-existing, unchanged) — but neither says *"and
+therefore this room's scope, which you may remember as locked, is selectable again."* That consequence
+is new to this PR. Worth a line, or at minimum a comment at `:371` acknowledging that `hasRoomMemory` is
+a live-binding predicate, not a historical one, and that degradation is a scope-unlock vector.
+
+> *"Two of three refusal paths log, one doesn't, and the one that doesn't is the one a writer hits first — fails silently, see you in the incident retro."* — Oliver
+
+---
+
+## 🎯 Bria · Domain Logic & Business Correctness
+
+*"Does This Code Actually Do What the Ticket Asked?"*
+
+Bria walked the ADR section by section. **§1–§6 check out** — the lock predicate covers all three
+conversation types, pre-lock reversibility is intact on every surface, the shelf restores at its
+original version (`adoptShelvedExcerpt` never calls `setExcerpt`, so the version counter doesn't bump),
+revision on a locked passage session is unaffected, and every deleted mechanism is genuinely gone rather
+than merely unreferenced.
+
+**Notably, §6's hardest requirement is met.** The ADR insists *"wherever an affordance disappears, the
+locked state must say why and where to go… This copy is required, not optional."* Every disappearing
+affordance across `ExcerptPanel`, `WorkshopScopeStrip`, and `WorkshopComposer` is paired with signpost
+copy. No affordance vanishes into silence.
+
+### 🟠 High — Divergence recorded in a new section, not the ADR-mandated one [🎯 Consensus]
+
+*See Stan's finding above — independently reached.*
+
+### 🟠 High — The one test for migration-table row 2 doesn't test row 2 [🎯 Consensus]
+
+*See Cal's finding above — independently reached, via the same `hostExpected` trace.*
+
+> *"The ADR wrote a three-row table and asked for a test per row — I count three tests and 2.5 rows covered. Probably fine. Probably."* — Bria
+
+---
+
+## 🎓 Sensei · The Teacher
+
+*"The Review Is the Lesson. The Code Is the Practice."*
+
+### Lesson 1 — Construction Arguments Terminate at the Edge of Your Own Writes
+
+Illuminated by: Blake/Sam blocker, Marcus #2, Oliver #2
+
+"Unreachable by construction" is one of the strongest claims a design can make — and it is always a
+claim about the *future*. The new code cannot produce `scope: 'open'` holding a pinned excerpt; the old
+code could, and did, and wrote it to disk where it waits with perfect patience. A persisted state is a
+second codebase, authored by a previous version of yourself, that you can no longer edit — only
+translate. Notice that the pure logic here is sound: both real defects live in the seam where the new
+world meets the old world's data, which is where they usually live.
+
+→ **Carry forward:** When you delete a state transition, don't enumerate the states your new code can
+reach — enumerate the states your *old* code could write, and check each against the new invariants.
+Write the migration from the old invariant list, not the new one, and let it say out loud that it
+rewrote someone's session.
+
+### Lesson 2 — A Test That Looks Like It Covers a Branch Is Worse Than No Test
+
+Illuminated by: Cal #1, #2, #3
+
+A missing test is honest — it leaves a hole you can see. A test that passes a runtime binding no
+assertion ever consults, or calls two primitives back-to-back on an object that never went to disk,
+produces something more expensive: it spends the reviewer's attention and returns nothing. And observe
+the pattern that repeats twice here — the untested path and the broken path were the *same* path. That
+is not coincidence; it is the ordinary physics of attention. We test what we were already thinking
+about, and the bug is living in what we weren't.
+
+→ **Carry forward:** Before trusting a new test, break the code it claims to protect and watch it go
+red. If it stays green, you have written documentation, not a test. And when you add a guard, list its
+trigger set explicitly — host, tool sidecar, persona guest — and make sure there is a case per member,
+not a case per member you happened to picture.
+
+### Lesson 3 — Fix the Family, Not the Instance
+
+Illuminated by: Oliver #1, Tim #2, Parker #1
+
+You clearly *knew* the pattern here — you applied log-before-`sendError` in the excerpt-pin refusal, and
+you derived the honest answer where derivation was right. But knowing a pattern and applying it
+exhaustively are different skills, and only the second one shows up in production. The carpenter who
+understands a mortise still has to cut all four. A fix applied once is an insight; a fix applied to
+every sibling is a change in the codebase's behavior.
+
+→ **Carry forward:** The moment you apply a fix you recognize as a *pattern* rather than a one-off, stop
+and grep for its siblings before you move on. Ask: "what is the family of call sites this belongs to,
+and did I just fix one member of it?"
+
+### Lesson 4 — Every Enabled Control Is a Promise
+
+Illuminated by: Blake/Sam blocker, Marcus #1, Parker #1
+
+The domain and the UI were each asked the same question — *may this writer change the text?* — and they
+answered it separately, in four hand-authored English sentences, one of which was baked into a
+host-agnostic core. When one rule has four authors, it has no author, and the copies drift until the
+interface offers something the domain has already decided to refuse. A live button that returns a
+guaranteed error is the most expensive kind of bug, because the user's trust is spent before the
+exception is even thrown.
+
+→ **Carry forward:** For every guard you add in the domain, find the control that can reach it and ask
+whether the *same* predicate decides both the refusal and the affordance. If the UI is deciding
+independently, you have two rules wearing one name — and check the name too: `locked` should lock
+something.
+
+> *"Deleting the machinery is the brave part; remembering that its output is still out there, in someone's saved session, waiting to be believed — that's the part that takes years."* — Sensei
+
+---
+
+## The Closer
+
+### 🔮 Fortune cookie
+
+*You will successfully remove the question. The old answers, however, have already been written down.*
+
+---
+
+## Summary
+
+**Merge-ready after the resolution pass.** The blocker and guest-dismissal
+defect are fixed at their honest state boundaries, the missing migration and
+resume branches are now exercised, and the review's maintainability findings
+were resolved without widening the feature. Finding #6 was a false positive:
+the shared `sendError()` path already records the refusal. The two remaining
+deferrals are explicitly non-blocking: degradation semantics (#15) and a
+micro-optimization with no present-scale consequence (#16).
+
+*Independently re-verified at review close:* full Jest suite **1,342 passed / 127 suites**, all three
+TypeScript projects clean, ESLint **0 errors**. The new `personaGuests.size > 0` lock predicate was
+probed for the ADR's stranding hazard — `reset()` clears participant tombstones via
+`newParticipants()`, so a fresh session is not born locked.
+
+---
+
+*Reviewed by: Marcus 🏛️ · Blake 🔥 · Sam 🔍 · Parker 📖 · Cal 🧪 · Stan 🗂️ · Tim ⚡ · Patricia 🛡️ · Oliver 🌙 · Bria 🎯 · Sensei 🎓*

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -2597,6 +2597,11 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
       expect(session.getScope()).toBe('excerpt');
       expect(session.getExcerpt()?.version).toBe(1);
       expect(session.getShelvedExcerpt()).toBeUndefined();
+      expect(log.appendLine).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'ERROR [workshop]: Start a new session to change this'
+        )
+      );
     });
 
     it('re-pins the shelved passage before the room has a memory', async () => {

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -2563,46 +2563,48 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
       expect(posted(MessageType.ERROR).at(-1)?.payload.message).toContain('Pin an excerpt');
     });
 
-    it('adopts an excerpt mid-conversation without restarting it', async () => {
+    /**
+     * ADR 2026-07-25. An open conversation that has been answering without a
+     * passage cannot be handed one — the writer is sent to a new session,
+     * which carries the excerpt and context across.
+     */
+    it('refuses to adopt an excerpt once the conversation has started', async () => {
       await chooseOpen();
       await send('Help me plan the next scene.');
       const conversationId = session.getHostConversationId();
-      service.startWorkshopPersonaConversation.mockClear();
 
       await pin();
 
       expect(session.getScope()).toBe('open');
+      expect(session.getExcerpt()).toBeUndefined();
       expect(session.getHostConversationId()).toBe(conversationId);
-      expect(session.getSnapshot().turns.at(-1)).toMatchObject({
-        artifact: 'scope_change',
-        content: expect.stringContaining('same session, conversation retained')
-      });
-
-      await send('Now read it.');
-      // The SAME retained conversation continues; nothing was re-started.
-      expect(service.startWorkshopPersonaConversation).not.toHaveBeenCalled();
-      const continuation = service.continueConversation.mock.calls.at(-1)!;
-      expect(continuation[0]).toBe(conversationId);
-      expect(continuation[1]).toContain('FIRST passage you have been given here');
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          payload: expect.objectContaining({
+            message: expect.stringContaining('Start a new session')
+          })
+        })
+      );
     });
 
-    it('withdraws a shelved passage from the retained host', async () => {
+    it('refuses to shelve a passage the host has already read', async () => {
       await pin();
       await send('Read this for me.');
-      await chooseOpen();
-      await send('Set that aside a moment.');
 
-      const continuation = service.continueConversation.mock.calls.at(-1)!;
-      expect(continuation[1]).toContain('set the excerpt aside');
-      expect(continuation[1]).toContain('Do not quote it');
+      await chooseOpen();
+
+      expect(session.getScope()).toBe('excerpt');
+      expect(session.getExcerpt()?.version).toBe(1);
+      expect(session.getShelvedExcerpt()).toBeUndefined();
     });
 
-    it('re-pins the shelved passage without leaving the conversation', async () => {
+    it('re-pins the shelved passage before the room has a memory', async () => {
       await pin();
       await chooseOpen();
       await handler.handleRepinExcerpt(message(MessageType.WORKSHOP_REPIN_EXCERPT, {}) as any);
 
-      expect(session.getScope()).toBe('open');
+      expect(session.getScope()).toBe('excerpt');
       expect(session.getExcerpt()?.version).toBe(1);
       expect(session.getShelvedExcerpt()).toBeUndefined();
     });

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
@@ -189,17 +189,6 @@ describe('WorkshopSessionService committed persistence', () => {
         state.shelvedExcerpt = JSON.parse(JSON.stringify(state.excerpt));
       },
       message: 'both a pinned and a shelved excerpt'
-    },
-    {
-      label: 'a checkpoint queues an excerpt delivery and its withdrawal at once',
-      mutate: (value: unknown) => {
-        const revisions = (value as {
-          revisions: { excerpt: number; pendingExcerpt?: number; pendingExcerptWithdrawal?: true };
-        }).revisions;
-        revisions.pendingExcerpt = revisions.excerpt;
-        revisions.pendingExcerptWithdrawal = true;
-      },
-      message: 'queues both an excerpt delivery and its withdrawal'
     }
   ])('rejects raw state when $label', ({ mutate, message }) => {
     const value: unknown = buildCompleteState();

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
@@ -321,7 +321,8 @@ describe('WorkshopSessionService committed persistence', () => {
 
     expect(result).toEqual({
       discardedConversationIds: [],
-      degradedConversationKeys: []
+      degradedConversationKeys: [],
+      migrations: []
     });
     expect(restored.getHostConversationId()).toBe('host-runtime-after-open');
     expect(restored.getToolSidecarConversationId('prose')).toBe('tool-runtime-after-open');

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistenceCoordinator.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistenceCoordinator.test.ts
@@ -222,6 +222,24 @@ describe('WorkshopSessionPersistenceCoordinator', () => {
     expect(session.getExcerpt()?.text).toBe('The restored manuscript.');
     expect(session.getSnapshot().turns.map((turn) => turn.artifact))
       .toEqual(['session_start', 'session_resume']);
+    // Exercise the actual persistence resume path named by ADR 2026-07-25,
+    // not merely two marker primitives on one never-persisted aggregate.
+    expect(session.hasRoomMemory()).toBe(false);
+    expect(() => session.setSessionScope('open')).not.toThrow();
+    expect(session.getScope()).toBe('open');
+  });
+
+  it('logs when hydration normalizes a legacy open session carrying an excerpt', async () => {
+    current = persistedSession('legacy-hybrid', 'Legacy hybrid', 'The restored manuscript.');
+    current.workshop.scope = 'open';
+    const coordinator = createCoordinator();
+
+    await coordinator.initialize();
+
+    expect(session.getScope()).toBe('excerpt');
+    expect(log.appendLine).toHaveBeenCalledWith(
+      expect.stringContaining('normalized-open-session-with-excerpt')
+    );
   });
 
   it('resumes the exact associated named checkpoint when current and named share an identity', async () => {

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts
@@ -92,21 +92,8 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       expect(service.getExcerptVersion()).toBe(pinned.version);
     });
 
-    it('mints one visible "conversation retained" divider', () => {
+    it('keeps the tasks and attachments across the transition', () => {
       pin();
-      const { dividerTurn } = service.setSessionScope('open');
-
-      expect(dividerTurn?.artifact).toBe('scope_change');
-      expect(dividerTurn?.participant).toBe('session');
-      expect(dividerTurn?.content).toBe(
-        'Excerpt set aside · one v1 — same session, conversation retained'
-      );
-      expect(service.getSnapshot().turns.at(-1)?.id).toBe(dividerTurn?.id);
-    });
-
-    it('keeps the transcript, tasks, and attachments across the transition', () => {
-      pin();
-      startHostConversation();
       service.addContextAttachment({
         kind: 'text', origin: 'writer', label: 'Kayla', words: 3, content: 'She lies here.'
       });
@@ -114,85 +101,144 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
 
       service.setSessionScope('open');
 
-      expect(service.getSnapshot().turns.length).toBe(turnsBefore + 1); // + the divider
-      expect(service.hasHostConversation()).toBe(true);
+      // No divider: nobody has been prompted, so nobody experienced a change.
+      expect(service.getSnapshot().turns.length).toBe(turnsBefore);
       expect(service.getContextAttachments()).toHaveLength(1);
     });
 
-    it('queues an explicit withdrawal for a retained host', () => {
-      pin();
-      startHostConversation();
-      service.setSessionScope('open');
-
-      const updates = service.collectPendingHostUpdates();
-      expect(updates?.excerptWithdrawn).toBe(true);
-      expect(updates?.excerpt).toBeUndefined();
-
-      const frame = buildWorkshopHostUpdateFrame(updates);
-      expect(frame).toContain('set the excerpt aside');
-      expect(frame).toContain('Do not quote it');
-    });
-
-    it('queues nothing when no host has been told about the passage yet', () => {
+    it('queues nothing for anyone — the room has no memory to correct', () => {
       pin();
       service.setSessionScope('open');
       expect(service.collectPendingHostUpdates()).toBeUndefined();
     });
 
-    it('is idempotent — asking for open chat twice mints one divider', () => {
+    it('is idempotent — asking for open chat twice changes nothing the second time', () => {
       pin();
       service.setSessionScope('open');
       const second = service.setSessionScope('open');
 
       expect(second.changed).toBe(false);
-      expect(second.dividerTurn).toBeUndefined();
-      expect(service.getSnapshot().turns.filter((t) => t.artifact === 'scope_change')).toHaveLength(1);
+      expect(service.getSnapshot().turns.filter((t) => t.artifact === 'scope_change')).toHaveLength(0);
+    });
+  });
+
+  /**
+   * ADR 2026-07-25: scope is chosen freely until the room has a memory and is
+   * fixed thereafter. These are the refusals that make findings #1 and #3 of
+   * the PR #86 review unreachable rather than merely derived correctly.
+   */
+  describe('the scope lock', () => {
+    it('refuses to shelve a passage the host has already read', () => {
+      pin();
+      startHostConversation();
+
+      expect(() => service.setSessionScope('open')).toThrow(/already has a conversation/);
+      expect(service.getScope()).toBe('excerpt');
+      expect(service.getExcerpt()).toBeDefined();
+    });
+
+    it('refuses to open a passage session once a TOOL has read the excerpt', () => {
+      // A sidecar holds the passage just as the host would; letting the room
+      // reverse here is the stale-sidecar defect wearing new paint.
+      pin();
+      service.beginToolRun('prose', 'prose-run');
+      service.completeToolReport('prose-run', 'Prose report.', 'prose-conv');
+
+      expect(() => service.setSessionScope('open')).toThrow(/already has a conversation/);
+    });
+
+    it('refuses to hand a passage to a conversation that has been running without one', () => {
+      service.setSessionScope('open');
+      startHostConversation();
+
+      expect(() => service.replaceExcerpt({ text: 'Read this now.', source: { kind: 'manual' } }))
+        .toThrow(/already has a conversation/);
+      expect(service.getExcerpt()).toBeUndefined();
+      expect(service.getScope()).toBe('open');
+    });
+
+    it('refuses a re-pin once the room has a memory', () => {
+      pin();
+      service.setSessionScope('open');
+      startHostConversation();
+
+      expect(() => service.repinShelvedExcerpt()).toThrow(/already has a conversation/);
+      expect(service.getShelvedExcerpt()).toBeDefined();
+    });
+
+    it('names the recovery path in the refusal, rather than only refusing', () => {
+      pin();
+      startHostConversation();
+
+      expect(() => service.setSessionScope('open'))
+        .toThrow(/Start a new session[\s\S]*carry over/);
+    });
+
+    it('still allows revising the pinned passage — that is not a path change', () => {
+      pin();
+      startHostConversation();
+
+      const replacement = service.replaceExcerpt({
+        text: 'The revised draft.',
+        source: { kind: 'manual' }
+      });
+
+      expect(replacement.excerpt.version).toBe(2);
+      expect(service.getScope()).toBe('excerpt');
+    });
+
+    /**
+     * The hazard that decides the predicate. `resetSession` records a
+     * `session_start` marker and `resumeSession` a `session_resume`, so EVERY
+     * session holds a turn before the writer acts. A turn-based lock would
+     * fire on session creation and strand the writer on the path chooser.
+     */
+    it('is not tripped by the session markers every room records before the writer acts', () => {
+      service.recordSessionMarker('start', 'Session started at 10:00 AM.');
+      service.recordSessionMarker('resume', 'Session resumed at 4:00 PM after 6h.');
+
+      expect(service.getSnapshot().turns.length).toBeGreaterThan(0);
+      expect(service.hasRoomMemory()).toBe(false);
+      expect(() => service.setSessionScope('open')).not.toThrow();
+      expect(service.getScope()).toBe('open');
+    });
+
+    it('is not tripped by a run that failed without leaving a conversation', () => {
+      service.setSessionScope('open');
+      service.beginPersonaMessage('doomed', 'Are you there?');
+      service.abandonRun('doomed');
+
+      expect(service.hasRoomMemory()).toBe(false);
+      expect(() => service.setSessionScope('excerpt')).toThrow(/without an excerpt/);
+      service.setExcerpt({ text: 'Now a passage.', source: { kind: 'manual' } });
+      expect(service.getScope()).toBe('excerpt');
     });
   });
 
   describe('open → passage', () => {
-    it('re-pins the shelved passage at its original version, staying open', () => {
+    it('re-pins the shelved passage at its original version', () => {
       const pinned = pin();
       service.setSessionScope('open');
       const transition = service.repinShelvedExcerpt();
 
-      expect(transition.scope).toBe('open');
+      // The room is workshopping the passage again, so it says so.
+      expect(transition.scope).toBe('excerpt');
       expect(service.getExcerpt()).toEqual(pinned);
       expect(service.getShelvedExcerpt()).toBeUndefined();
       expect(service.getExcerptVersion()).toBe(pinned.version);
-      expect(transition.dividerTurn?.content).toContain('Excerpt re-pinned · one v1');
     });
 
-    it('tells a retained host the passage is back, not that it was revised', () => {
-      pin();
-      startHostConversation();
+    it('makes an adopted passage a passage session — no open-with-excerpt hybrid', () => {
       service.setSessionScope('open');
-      service.commitPendingHostUpdates(service.collectPendingHostUpdates()!);
-      service.repinShelvedExcerpt();
-
-      const updates = service.collectPendingHostUpdates();
-      expect(updates?.excerptChange).toBe('repinned');
-      expect(buildWorkshopHostUpdateFrame(updates)).toContain('re-pinned the excerpt');
-    });
-
-    it('adopts a NEW excerpt mid-open-chat as an addition, keeping the scope open', () => {
-      service.setSessionScope('open');
-      startHostConversation();
-
-      const replacement = service.replaceExcerpt({
+      service.replaceExcerpt({
         text: 'They moved toward the auditorium as a group.',
         source: { kind: 'manual' }
       });
 
-      expect(service.getScope()).toBe('open');
-      expect(replacement.dividerTurn?.artifact).toBe('scope_change');
-      expect(replacement.dividerTurn?.content).toContain('Excerpt added · Pasted passage v1');
-
-      const updates = service.collectPendingHostUpdates();
-      expect(updates?.excerptChange).toBe('added');
-      const frame = buildWorkshopHostUpdateFrame(updates);
-      expect(frame).toContain('FIRST passage you have been given here');
-      expect(frame).not.toContain('revised the pinned excerpt');
+      expect(service.getScope()).toBe('excerpt');
+      // Nobody was prompted, so nothing is queued and no divider is minted.
+      expect(service.collectPendingHostUpdates()).toBeUndefined();
+      expect(service.getSnapshot().turns.filter((t) => t.artifact === 'scope_change')).toHaveLength(0);
     });
 
     it('reports a genuine replacement as a revision, not an addition', () => {
@@ -220,48 +266,23 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
     /**
      * Regression (PR #86 review, blocking): `replaceExcerpt` branched on
      * `this.excerpt`, which shelving empties while the passage lives on in
-     * `shelvedExcerpt` — so pinning over a shelved passage took the "first
-     * pin" branch and skipped every staleness protection. The shelf counts as
-     * previously carried: the sidecars read that passage and so did the host.
+     * `shelvedExcerpt`, so a pin over a shelved passage took the "first pin"
+     * branch and skipped every staleness protection. The scope lock now keeps
+     * this in the pre-memory window, but the shelf still counts as previously
+     * carried and the replacement bookkeeping must still run.
      */
     it('treats a pin over a SHELVED passage as a replacement, not a first pin', () => {
       pin();
-      startHostConversation();
-      // A tool that read the shelved passage, and a room pointed at it.
-      service.beginToolRun('prose', 'prose-run');
-      service.completeToolReport('prose-run', 'Prose report on v1.', 'prose-conv');
-      service.setChatTarget({ kind: 'tool', toolId: 'prose' });
       service.setSessionScope('open');
-      service.commitPendingHostUpdates(service.collectPendingHostUpdates()!);
 
       const replacement = service.replaceExcerpt({
         text: 'A different chapter entirely.',
         source: { kind: 'manual' }
       });
 
-      // The sidecar's conversation only ever read the shelved passage.
-      expect(replacement.disposedConversationIds).toEqual(['prose-conv']);
-      expect(replacement.retiredSidecarCount).toBe(1);
       expect(replacement.replacementCount).toBe(1);
-      // The room must not still be aimed at a tool that is about the old text.
-      expect(service.getChatTarget()).toEqual({ kind: 'host' });
-    });
-
-    it('never tells a host holding a shelved passage that this is its FIRST one', () => {
-      pin();
-      startHostConversation();
-      service.setSessionScope('open');
-      service.commitPendingHostUpdates(service.collectPendingHostUpdates()!);
-
-      service.replaceExcerpt({ text: 'A different chapter.', source: { kind: 'manual' } });
-
-      const updates = service.collectPendingHostUpdates();
-      expect(updates?.excerptChange).toBe('revised');
-      const frame = buildWorkshopHostUpdateFrame(updates);
-      expect(frame).toContain('revised the pinned excerpt');
-      // The host's own transcript still holds v1 — asserting it has never seen
-      // a passage would contradict its own history.
-      expect(frame).not.toContain('FIRST passage you have been given here');
+      expect(replacement.excerpt.version).toBe(2);
+      expect(service.getShelvedExcerpt()).toBeUndefined();
     });
 
     /**
@@ -280,9 +301,9 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       });
 
       expect(replacement.discardedShelvedExcerpt).toEqual(shelved);
-      expect(replacement.dividerTurn?.artifact).toBe('scope_change');
+      expect(replacement.dividerTurn?.artifact).toBe('excerpt_revision');
       expect(replacement.dividerTurn?.content)
-        .toBe('Excerpt added · Pasted passage v2 — set-aside “one” v1 discarded, conversation retained');
+        .toBe('Excerpt v2 pinned · Pasted excerpt · retired: none · set-aside “one” v1 discarded');
       expect(service.getShelvedExcerpt()).toBeUndefined();
     });
 
@@ -291,8 +312,8 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       const replacement = service.replaceExcerpt({ text: 'First one.', source: { kind: 'manual' } });
 
       expect(replacement.discardedShelvedExcerpt).toBeUndefined();
-      expect(replacement.dividerTurn?.content)
-        .toBe('Excerpt added · Pasted passage v1 — same session, conversation retained');
+      // First pin of the room: nothing displaced, so no divider at all.
+      expect(replacement.dividerTurn).toBeUndefined();
     });
 
     /**
@@ -304,36 +325,28 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       // The opening prompt hands the host v1; no delta frame is involved.
       pin();
       startHostConversation();
-      // v2 is queued for the host and then shelved before any turn ships it.
       service.replaceExcerpt({ text: 'The revised draft.', source: { kind: 'manual' } });
-      service.setSessionScope('open');
-      service.repinShelvedExcerpt();
 
       const updates = service.collectPendingHostUpdates();
       expect(updates?.excerpt?.version).toBe(2);
-      expect(updates?.excerptChange).toBe('revised');
       const frame = buildWorkshopHostUpdateFrame(updates);
       expect(frame).toContain('Earlier versions in this conversation are superseded');
       expect(frame).not.toContain('unchanged');
     });
 
-    it('does not tell a host to withdraw a passage it was never handed', () => {
-      // A host conversation exists, but the pin was queued and never shipped.
+    /**
+     * The delivery record is still what decides, even though the lock leaves
+     * only one reason: a host that was never handed the original must not be
+     * sent a "revision" of it.
+     */
+    it('queues nothing for a host that was never handed the original', () => {
       service.setSessionScope('open');
       startHostConversation();
-      service.replaceExcerpt({ text: 'Queued but never sent.', source: { kind: 'manual' } });
-      service.setSessionScope('open');
-
-      expect(service.collectPendingHostUpdates()?.excerptWithdrawn).toBeUndefined();
-    });
-
-    it('clears a queued withdrawal once the passage comes back', () => {
-      pin();
-      startHostConversation();
-      service.setSessionScope('open');
-      service.repinShelvedExcerpt();
-
-      expect(service.collectPendingHostUpdates()?.excerptWithdrawn).toBeUndefined();
+      // Reaching a passage session from here is refused, so pin BEFORE the
+      // conversation and confirm the queue still keys off delivery.
+      expect(() => service.replaceExcerpt({ text: 'Nope.', source: { kind: 'manual' } }))
+        .toThrow(/already has a conversation/);
+      expect(service.collectPendingHostUpdates()).toBeUndefined();
     });
   });
 
@@ -343,8 +356,8 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       service.addContextAttachment({
         kind: 'text', origin: 'writer', label: 'Kayla', words: 3, content: 'She lies here.'
       });
-      startHostConversation();
       service.setSessionScope('open');
+      startHostConversation();
 
       service.reset();
 
@@ -412,7 +425,7 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
 
     it('leaves no queued host delivery behind', () => {
       seedFullRoom();
-      service.setSessionScope('open');
+      service.replaceExcerpt({ text: 'A later draft.', source: { kind: 'manual' } });
       expect(service.collectPendingHostUpdates()).toBeDefined();
 
       service.reset({ clearWorkingSet: true });
@@ -440,26 +453,88 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
   });
 
   describe('committed-state round trip', () => {
-    it('carries scope, the shelf, and a queued withdrawal through export/hydrate', () => {
+    it('carries scope and the shelf through export/hydrate', () => {
       pin();
-      startHostConversation();
       service.setSessionScope('open');
       const exported = service.exportCommittedState();
 
       expect(exported.scope).toBe('open');
       expect(exported.shelvedExcerpt?.version).toBe(1);
-      expect(exported.revisions.pendingExcerptWithdrawal).toBe(true);
+      // Retired by ADR 2026-07-25 and never written again.
+      expect(exported.revisions.pendingExcerptWithdrawal).toBeUndefined();
+      expect(exported.revisions.pendingExcerptChange).toBeUndefined();
 
       const restored = new WorkshopSessionService(() => ++clock);
-      restored.hydrateCommittedState(
-        exported,
-        { host: 'host-conv' },
-        service.getConversationBehavior()
-      );
+      restored.hydrateCommittedState(exported, {}, service.getConversationBehavior());
 
       expect(restored.getScope()).toBe('open');
       expect(restored.getShelvedExcerpt()?.version).toBe(1);
-      expect(restored.collectPendingHostUpdates()?.excerptWithdrawn).toBe(true);
+      expect(restored.collectPendingHostUpdates()).toBeUndefined();
+    });
+
+    /**
+     * ADR 2026-07-25 §7. A checkpoint written before the lock can hold an
+     * UNDELIVERED withdrawal: the writer shelved a passage but the frame
+     * telling the host to stop treating it as read never shipped, and that
+     * frame no longer exists. The host therefore still holds the passage, so
+     * the room is normalized to agree with what the host believes rather than
+     * with a reversal that never took effect.
+     */
+    it('normalizes a legacy checkpoint whose withdrawal never shipped', () => {
+      pin();
+      const exported = service.exportCommittedState();
+      const legacy = {
+        ...exported,
+        scope: 'open' as const,
+        excerpt: undefined,
+        shelvedExcerpt: exported.excerpt,
+        revisions: { ...exported.revisions, pendingExcerptWithdrawal: true as const }
+      };
+
+      const restored = new WorkshopSessionService(() => ++clock);
+      restored.hydrateCommittedState(legacy, { host: 'host-conv' }, service.getConversationBehavior());
+
+      expect(restored.getScope()).toBe('excerpt');
+      expect(restored.getExcerpt()?.version).toBe(1);
+      expect(restored.getShelvedExcerpt()).toBeUndefined();
+    });
+
+    it('leaves a legacy checkpoint alone when its withdrawal DID ship', () => {
+      // No pending flag: the host was told, so open scope with a shelf is
+      // already consistent and must survive untouched.
+      pin();
+      const exported = service.exportCommittedState();
+      const legacy = {
+        ...exported,
+        scope: 'open' as const,
+        excerpt: undefined,
+        shelvedExcerpt: exported.excerpt
+      };
+
+      const restored = new WorkshopSessionService(() => ++clock);
+      restored.hydrateCommittedState(legacy, { host: 'host-conv' }, service.getConversationBehavior());
+
+      expect(restored.getScope()).toBe('open');
+      expect(restored.getShelvedExcerpt()?.version).toBe(1);
+    });
+
+    it('discards a legacy delivery reason rather than failing the session open', () => {
+      pin();
+      const exported = service.exportCommittedState();
+      const legacy = {
+        ...exported,
+        revisions: {
+          ...exported.revisions,
+          pendingExcerpt: 1,
+          pendingExcerptChange: 'repinned' as const
+        }
+      };
+
+      const restored = new WorkshopSessionService(() => ++clock);
+      expect(() =>
+        restored.hydrateCommittedState(legacy, { host: 'host-conv' }, service.getConversationBehavior())
+      ).not.toThrow();
+      expect(restored.exportCommittedState().revisions.pendingExcerptChange).toBeUndefined();
     });
 
     it('migrates a pre-scope checkpoint once, at the hydration boundary', () => {
@@ -485,15 +560,15 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       expect(restored.getScope()).toBeNull();
     });
 
-    it('drops a queued withdrawal when the host memory did not survive', () => {
+    it('drops a queued revision when the host memory did not survive', () => {
       pin();
       startHostConversation();
-      service.setSessionScope('open');
+      service.replaceExcerpt({ text: 'A later draft.', source: { kind: 'manual' } });
 
       const restored = new WorkshopSessionService(() => ++clock);
       restored.hydrateCommittedState(
         service.exportCommittedState(),
-        {}, // no runtime binding: the host starts fresh and receives current scope
+        {}, // no runtime binding: the host starts fresh and receives current state
         service.getConversationBehavior()
       );
 

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  WorkshopScopeLockedError,
   WorkshopSessionService,
   workshopTextNoteLabel
 } from '@/application/services/workshop/WorkshopSessionService';
@@ -166,12 +167,20 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       expect(service.getShelvedExcerpt()).toBeDefined();
     });
 
-    it('names the recovery path in the refusal, rather than only refusing', () => {
+    it('returns a typed refusal so presentation owns the recovery copy', () => {
       pin();
       startHostConversation();
 
-      expect(() => service.setSessionScope('open'))
-        .toThrow(/Start a new session[\s\S]*carry over/);
+      try {
+        service.setSessionScope('open');
+        throw new Error('Expected the scope change to be refused');
+      } catch (error) {
+        expect(error).toBeInstanceOf(WorkshopScopeLockedError);
+        expect(error).toMatchObject({
+          code: 'workshop-scope-locked',
+          attempt: 'set this session to an open conversation'
+        });
+      }
     });
 
     it('still allows revising the pinned passage — that is not a path change', () => {
@@ -193,14 +202,39 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
      * session holds a turn before the writer acts. A turn-based lock would
      * fire on session creation and strand the writer on the path chooser.
      */
-    it('is not tripped by the session markers every room records before the writer acts', () => {
+    it('is not tripped by a fresh session marker before the writer acts', () => {
       service.recordSessionMarker('start', 'Session started at 10:00 AM.');
-      service.recordSessionMarker('resume', 'Session resumed at 4:00 PM after 6h.');
 
       expect(service.getSnapshot().turns.length).toBeGreaterThan(0);
       expect(service.hasRoomMemory()).toBe(false);
       expect(() => service.setSessionScope('open')).not.toThrow();
       expect(service.getScope()).toBe('open');
+    });
+
+    it('locks on a persona guest and stays locked after the guest is dismissed', () => {
+      pin();
+      const writerTurn = service.beginPersonaGuestJoin(
+        'margot',
+        'guest-join',
+        'Read this with me.'
+      );
+      const guestTurn = service.completeRun(
+        'guest-join',
+        'The voice pulls away in the second paragraph.',
+        undefined,
+        false,
+        'guest-conv'
+      )!;
+
+      expect(service.hasRoomMemory()).toBe(true);
+      expect(service.dismissPersonaGuest('margot')).toBe('guest-conv');
+      expect(service.hasRoomMemory()).toBe(true);
+      expect(() => service.setSessionScope('open'))
+        .toThrow(WorkshopScopeLockedError);
+      // Dismissal retires the provider sidecar, not the historical exchange.
+      // It remains honest host evidence because the passage path stayed fixed.
+      expect(service.collectUnseenGuestExchangesForHost().map((turn) => turn.id))
+        .toEqual([writerTurn.id, guestTurn.id]);
     });
 
     it('is not tripped by a run that failed without leaving a conversation', () => {
@@ -492,11 +526,46 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       };
 
       const restored = new WorkshopSessionService(() => ++clock);
-      restored.hydrateCommittedState(legacy, { host: 'host-conv' }, service.getConversationBehavior());
+      const result = restored.hydrateCommittedState(
+        legacy,
+        { host: 'host-conv' },
+        service.getConversationBehavior()
+      );
 
       expect(restored.getScope()).toBe('excerpt');
       expect(restored.getExcerpt()?.version).toBe(1);
       expect(restored.getShelvedExcerpt()).toBeUndefined();
+      expect(result.migrations).toEqual([
+        'restored-undelivered-withdrawal',
+        'discarded-legacy-scope-transition'
+      ]);
+    });
+
+    it('normalizes a legacy open conversation that already carries an excerpt', () => {
+      pin();
+      startHostConversation();
+      const legacy = {
+        ...service.exportCommittedState(),
+        // Sprint 13A could persist this hybrid through both add and re-pin.
+        scope: 'open' as const
+      };
+
+      const restored = new WorkshopSessionService(() => ++clock);
+      const result = restored.hydrateCommittedState(
+        legacy,
+        { host: 'host-conv-restored' },
+        service.getConversationBehavior()
+      );
+
+      expect(result.migrations).toContain('normalized-open-session-with-excerpt');
+      expect(restored.getScope()).toBe('excerpt');
+      expect(restored.getExcerpt()?.version).toBe(1);
+      expect(restored.hasRoomMemory()).toBe(true);
+      expect(() => restored.replaceExcerpt({
+        text: 'The passage remains revisable.',
+        source: { kind: 'manual' }
+      })).not.toThrow();
+      expect(restored.getExcerpt()?.version).toBe(2);
     });
 
     it('leaves a legacy checkpoint alone when its withdrawal DID ship', () => {
@@ -518,7 +587,33 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       expect(restored.getShelvedExcerpt()?.version).toBe(1);
     });
 
-    it('discards a legacy delivery reason rather than failing the session open', () => {
+    it('treats a legacy delivery reason as a revision when host memory survives', () => {
+      pin();
+      startHostConversation();
+      service.replaceExcerpt({ text: 'A later draft.', source: { kind: 'manual' } });
+      const exported = service.exportCommittedState();
+      const legacy = {
+        ...exported,
+        revisions: {
+          ...exported.revisions,
+          pendingExcerptChange: 'repinned' as const
+        }
+      };
+
+      const restored = new WorkshopSessionService(() => ++clock);
+      const result = restored.hydrateCommittedState(
+        legacy,
+        { host: 'host-conv-restored' },
+        service.getConversationBehavior()
+      );
+
+      expect(buildWorkshopHostUpdateFrame(restored.collectPendingHostUpdates()))
+        .toContain('revised the pinned excerpt');
+      expect(restored.exportCommittedState().revisions.pendingExcerptChange).toBeUndefined();
+      expect(result.migrations).toContain('discarded-legacy-scope-transition');
+    });
+
+    it('drops a legacy pending delivery when no host memory survives', () => {
       pin();
       const exported = service.exportCommittedState();
       const legacy = {
@@ -526,14 +621,14 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
         revisions: {
           ...exported.revisions,
           pendingExcerpt: 1,
-          pendingExcerptChange: 'repinned' as const
+          pendingExcerptChange: 'added' as const
         }
       };
 
       const restored = new WorkshopSessionService(() => ++clock);
-      expect(() =>
-        restored.hydrateCommittedState(legacy, { host: 'host-conv' }, service.getConversationBehavior())
-      ).not.toThrow();
+      restored.hydrateCommittedState(legacy, {}, service.getConversationBehavior());
+
+      expect(restored.collectPendingHostUpdates()).toBeUndefined();
       expect(restored.exportCommittedState().revisions.pendingExcerptChange).toBeUndefined();
     });
 

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/ExcerptPanel.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/ExcerptPanel.test.tsx
@@ -48,7 +48,7 @@ const renderPanel = (overrides: Partial<React.ComponentProps<typeof ExcerptPanel
     scope: null,
     hostLabel: 'Jill',
     isRunning: false,
-    locked: false,
+    roomHasMemory: false,
     onOpenPasteSheet: jest.fn(),
     onChooseFile: jest.fn(),
     onRereadFile: jest.fn(),
@@ -152,7 +152,7 @@ describe('ExcerptPanel — passage pinned', () => {
   it('offers Re-read from file when locked on a file-backed excerpt', () => {
     const { props } = renderPanel({
       scope: 'excerpt',
-      locked: true,
+      roomHasMemory: true,
       excerpt: excerptWith(fileSource)
     });
 
@@ -165,7 +165,7 @@ describe('ExcerptPanel — passage pinned', () => {
   it('offers Update text… when locked on typed or pasted origin', () => {
     const { props } = renderPanel({
       scope: 'excerpt',
-      locked: true,
+      roomHasMemory: true,
       excerpt: excerptWith({ kind: 'manual' })
     });
 
@@ -192,11 +192,11 @@ describe('ExcerptPanel — passage pinned', () => {
    * and must be replaced by the way out, not by silence.
    */
   it('withdraws the reversal once the room has a memory, and names the way out', () => {
-    renderPanel({ scope: 'excerpt', excerpt: excerptWith(fileSource), locked: true });
+    renderPanel({ scope: 'excerpt', excerpt: excerptWith(fileSource), roomHasMemory: true });
 
     expect(screen.queryByRole('button', { name: /set this aside/i })).toBeNull();
-    expect(screen.getByText(/Start a new session to chat without this passage/)).toBeTruthy();
-    expect(screen.getByText(/context attachments carry over/)).toBeTruthy();
+    expect(screen.getByText(/Start a new session to change this/)).toBeTruthy();
+    expect(screen.getByText(/excerpt and context carry over/)).toBeTruthy();
   });
 });
 
@@ -209,22 +209,22 @@ describe('ExcerptPanel — open conversation', () => {
   });
 
   it('closes that door once the conversation has started, and says where to go', () => {
-    renderPanel({ scope: 'open', excerpt: null, locked: true });
+    renderPanel({ scope: 'open', excerpt: null, roomHasMemory: true });
 
     expect(screen.queryByRole('button', { name: /paste or type/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /from project/i })).toBeNull();
-    expect(screen.getByText(/Start a new session to work on a passage/)).toBeTruthy();
+    expect(screen.getByText(/Start a new session to change this/)).toBeTruthy();
   });
 
   it('names the set-aside passage in the signpost so it is not lost track of', () => {
     renderPanel({
       scope: 'open',
       excerpt: null,
-      locked: true,
+      roomHasMemory: true,
       shelvedExcerpt: excerptWith(fileSource)
     });
 
     expect(screen.getByText(/carry over/)).toBeTruthy();
-    expect(screen.getByText(/Your excerpt \(05 v2\)/)).toBeTruthy();
+    expect(screen.getByText(/Set-aside passage: 05 v2/)).toBeTruthy();
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/ExcerptPanel.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/ExcerptPanel.test.tsx
@@ -179,15 +179,52 @@ describe('ExcerptPanel — passage pinned', () => {
     const setAside = screen.getByRole('button', { name: /set this aside/i });
 
     expect(setAside.textContent).toContain('Keeps the passage on the shelf');
-    expect(setAside.textContent).toContain('Jill stops treating it as read');
+    // Nobody has read it yet — that is the whole reason this reversal is still
+    // on offer (ADR 2026-07-25).
+    expect(setAside.textContent).toContain('Jill has not read it yet');
     fireEvent.click(setAside);
     expect(props.onSetAside).toHaveBeenCalled();
   });
 
-  it('names the reversal "unpin" once the room is already an open conversation', () => {
-    renderPanel({ scope: 'open', excerpt: excerptWith(fileSource) });
+  /**
+   * ADR 2026-07-25. Un-reading a passage is not something the product can
+   * honestly deliver, so once the room has a memory the reversal disappears —
+   * and must be replaced by the way out, not by silence.
+   */
+  it('withdraws the reversal once the room has a memory, and names the way out', () => {
+    renderPanel({ scope: 'excerpt', excerpt: excerptWith(fileSource), locked: true });
 
-    expect(screen.getByRole('button', { name: /unpin — back to open conversation/i })).toBeTruthy();
     expect(screen.queryByRole('button', { name: /set this aside/i })).toBeNull();
+    expect(screen.getByText(/Start a new session to chat without this passage/)).toBeTruthy();
+    expect(screen.getByText(/context attachments carry over/)).toBeTruthy();
+  });
+});
+
+describe('ExcerptPanel — open conversation', () => {
+  it('offers the passage path only while nobody has been prompted', () => {
+    renderPanel({ scope: 'open', excerpt: null });
+
+    expect(screen.getByRole('button', { name: /paste or type/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /from project/i })).toBeTruthy();
+  });
+
+  it('closes that door once the conversation has started, and says where to go', () => {
+    renderPanel({ scope: 'open', excerpt: null, locked: true });
+
+    expect(screen.queryByRole('button', { name: /paste or type/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /from project/i })).toBeNull();
+    expect(screen.getByText(/Start a new session to work on a passage/)).toBeTruthy();
+  });
+
+  it('names the set-aside passage in the signpost so it is not lost track of', () => {
+    renderPanel({
+      scope: 'open',
+      excerpt: null,
+      locked: true,
+      shelvedExcerpt: excerptWith(fileSource)
+    });
+
+    expect(screen.getByText(/carry over/)).toBeTruthy();
+    expect(screen.getByText(/Your excerpt \(05 v2\)/)).toBeTruthy();
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopComposer.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopComposer.test.tsx
@@ -18,6 +18,7 @@ describe('WorkshopComposer', () => {
       canMessage: true,
       scope: 'excerpt' as const,
       hasExcerpt: true,
+      roomHasMemory: false,
       onAddExcerpt: jest.fn(),
       onGatedAction: jest.fn(),
       hasConversation: true,
@@ -168,10 +169,14 @@ describe('WorkshopComposer', () => {
       expect(screen.getByPlaceholderText('Pick a starting path above to begin…')).toBeTruthy();
     });
 
-    it('notes the new excerpt once an open conversation adopts one', () => {
-      renderComposer({ scope: 'open', hasExcerpt: true, hasConversation: false });
-      expect(screen.getByPlaceholderText('Message Choreography — excerpt now attached…'))
-        .toBeTruthy();
+    /**
+     * ADR 2026-07-25 retired the open-with-excerpt hybrid: pinning a passage
+     * makes the room a passage session, so there is no "open conversation that
+     * now has an excerpt" state left to caption.
+     */
+    it('closes the passage door once the open conversation has started', () => {
+      renderComposer({ scope: 'open', hasExcerpt: false, roomHasMemory: true });
+      expect(screen.queryByRole('button', { name: /add excerpt/i })).toBeNull();
     });
 
     it('offers Add excerpt only while the open room has none', () => {

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopScopeStrip.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopScopeStrip.test.tsx
@@ -21,9 +21,9 @@ const renderStrip = (props: Partial<React.ComponentProps<typeof WorkshopScopeStr
     <WorkshopScopeStrip
       scope="open"
       hostLabel="Jill"
+      roomHasMemory={false}
       disabled={false}
       onAddExcerpt={jest.fn()}
-      onSetAside={jest.fn()}
       onRepinExcerpt={jest.fn()}
       {...props}
     />
@@ -36,9 +36,16 @@ describe('WorkshopScopeStrip — open conversation', () => {
     expect(screen.getByText(/Jill hasn’t read any pages/)).toBeTruthy();
   });
 
-  it('admits the host still holds a set-aside passage until the next message', () => {
-    renderStrip({ withdrawalPending: true, shelvedExcerptTitle: 'one', shelvedExcerptVersion: 1 });
-    expect(screen.getByText(/still has the passage you set aside/)).toBeTruthy();
+  /**
+   * ADR 2026-07-25: an open conversation that has started stays open, so the
+   * strip stops offering and points at a new session instead.
+   */
+  it('closes the passage door once the conversation has started', () => {
+    renderStrip({ roomHasMemory: true, shelvedExcerptTitle: 'one', shelvedExcerptVersion: 1 });
+
+    expect(screen.queryByRole('button', { name: /Add excerpt/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Re-pin/ })).toBeNull();
+    expect(screen.getByText(/start a new session to work on a passage/)).toBeTruthy();
   });
 });
 
@@ -70,11 +77,6 @@ describe('WorkshopScopeStrip — the shelf', () => {
 });
 
 describe('WorkshopScopeStrip — scope is explicit', () => {
-  it('reports the passage treatment from the pinned excerpt it was given', () => {
-    renderStrip({ excerptTitle: 'chapters/one.md', excerptVersion: 3 });
-    expect(screen.getByText('Passage session · chapters/one.md v3')).toBeTruthy();
-  });
-
   /**
    * §1: nothing may infer "open conversation" from a missing excerpt. A
    * passage session with nothing pinned is not a state this strip can

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopScopeStrip.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopScopeStrip.test.tsx
@@ -45,7 +45,7 @@ describe('WorkshopScopeStrip — open conversation', () => {
 
     expect(screen.queryByRole('button', { name: /Add excerpt/ })).toBeNull();
     expect(screen.queryByRole('button', { name: /Re-pin/ })).toBeNull();
-    expect(screen.getByText(/start a new session to work on a passage/)).toBeTruthy();
+    expect(screen.getByText(/Start a new session to change this/)).toBeTruthy();
   });
 });
 

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
@@ -63,7 +63,7 @@ const sessionState = (session: Partial<WorkshopSessionSnapshot>): WorkshopSessio
         turns,
         totalTurns: turns.length,
         truncatedTurns: 0,
-        hasConversation: false,
+        roomHasMemory: false,
         participants: {
           host: { personaId: 'jill', hasConversation: false },
           toolSidecars: [],
@@ -531,7 +531,7 @@ describe('useWorkshop', () => {
           excerpt: { text: 'Pinned prose.', version: 1, source: { kind: 'manual' }, pinnedAt: 1 },
           turns: [makeTurn({ id: 't1', toolId: 'gestures', toolLabel: 'Gestures' })],
           selectedToolId: 'gestures',
-          hasConversation: true
+          roomHasMemory: true
         })
       );
     });
@@ -865,7 +865,7 @@ describe('useWorkshop', () => {
           personaGuests: [],
           chatTarget: { kind: 'tool', toolId: 'continuity' }
         },
-        hasConversation: true
+        roomHasMemory: true
       }));
     });
 
@@ -1005,7 +1005,7 @@ describe('useWorkshop', () => {
     });
 
     /**
-     * The scope lock (ADR 2026-07-25) reaches the webview as `hasConversation`
+     * The scope lock (ADR 2026-07-25) reaches the webview as `roomHasMemory`
      * — the same predicate the aggregate locks on, not a second guess at it.
      */
     it('mirrors the scope lock so surfaces can stop offering path changes', () => {
@@ -1016,7 +1016,7 @@ describe('useWorkshop', () => {
 
       act(() => result.current.handleSessionState(sessionState({
         scope: 'open',
-        hasConversation: true
+        roomHasMemory: true
       })));
       expect(result.current.roomHasMemory).toBe(true);
     });

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
@@ -997,13 +997,28 @@ describe('useWorkshop', () => {
       act(() => result.current.handleSessionState(sessionState({
         scope: 'open',
         excerpt: undefined,
-        shelvedExcerpt: excerptSnapshot(),
-        pendingHostUpdate: { context: false, excerptWithdrawn: true }
+        shelvedExcerpt: excerptSnapshot()
       })));
 
       expect(result.current.scope).toBe('open');
       expect(result.current.shelvedExcerpt?.version).toBe(1);
-      expect(result.current.excerptWithdrawalPending).toBe(true);
+    });
+
+    /**
+     * The scope lock (ADR 2026-07-25) reaches the webview as `hasConversation`
+     * — the same predicate the aggregate locks on, not a second guess at it.
+     */
+    it('mirrors the scope lock so surfaces can stop offering path changes', () => {
+      const { result } = renderHook(() => useWorkshop());
+
+      act(() => result.current.handleSessionState(sessionState({ scope: 'open' })));
+      expect(result.current.roomHasMemory).toBe(false);
+
+      act(() => result.current.handleSessionState(sessionState({
+        scope: 'open',
+        hasConversation: true
+      })));
+      expect(result.current.roomHasMemory).toBe(true);
     });
 
     it('permits messaging an excerpt-free open conversation', () => {

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -24,6 +24,7 @@ import { AssistantToolService } from '@services/analysis/AssistantToolService';
 import { ContextAssistantService } from '@services/analysis/ContextAssistantService';
 import {
   WorkshopContextAttachmentInput,
+  WorkshopExcerptReplacement,
   WorkshopMessageAttachmentInput,
   WorkshopScopeTransition,
   WorkshopSessionService,
@@ -1185,7 +1186,9 @@ export class WorkshopHandler {
     if (this.rejectExcerptMutationWhileRunning()) {
       return;
     }
-    this.replaceExcerpt({ text, source });
+    if (!this.replaceExcerpt({ text, source })) {
+      return;
+    }
     this.sessionPersistence.markDirty('excerpt replaced');
     this.postSessionState();
   }
@@ -1438,9 +1441,6 @@ export class WorkshopHandler {
       // Idempotent: still broadcast so a stale webview reconciles.
       this.postSessionState();
       return;
-    }
-    if (transition.dividerTurn) {
-      this.postTurn(transition.dividerTurn);
     }
     this.outputChannel.appendLine(
       `[WorkshopHandler] ${reason} (scope=${transition.scope ?? 'unchosen'}, ` +
@@ -1756,7 +1756,7 @@ export class WorkshopHandler {
     if (this.rejectExcerptMutationWhileRunning()) {
       return;
     }
-    this.replaceExcerpt({
+    if (!this.replaceExcerpt({
       text: resource.text,
       source: {
         kind: 'file',
@@ -1768,7 +1768,9 @@ export class WorkshopHandler {
         ? { pinnedWords: resource.truncation.keptWords, totalWords: resource.truncation.totalWords }
         : undefined,
       sourceFingerprint: resource.sourceFingerprint
-    });
+    })) {
+      return;
+    }
     this.sessionPersistence.markDirty('configured excerpt replaced');
     this.postSessionState();
   }
@@ -2155,12 +2157,14 @@ export class WorkshopHandler {
       return;
     }
 
-    this.replaceExcerpt({
+    if (!this.replaceExcerpt({
       text: loaded.text,
       source,
       truncation: loaded.truncation,
       sourceFingerprint: loaded.sourceFingerprint
-    });
+    })) {
+      return;
+    }
     this.sessionPersistence.markDirty('file excerpt replaced');
     this.postSessionState();
   }
@@ -2221,12 +2225,14 @@ export class WorkshopHandler {
       return;
     }
 
-    this.replaceExcerpt({
+    if (!this.replaceExcerpt({
       text: loaded.text,
       source: resolvedSource,
       truncation: loaded.truncation,
       sourceFingerprint: loaded.sourceFingerprint
-    });
+    })) {
+      return;
+    }
     this.sessionPersistence.markDirty('file excerpt reread');
     this.postSessionState();
   }
@@ -2530,13 +2536,28 @@ export class WorkshopHandler {
     };
   }
 
+  /**
+   * Pin or revise the excerpt. Returns false when the aggregate refused —
+   * the scope lock (ADR 2026-07-25) will not let an open conversation adopt a
+   * passage once it has a memory. The refusal names the recovery path, so it
+   * belongs in front of the writer rather than escaping as an unhandled
+   * rejection at the IPC boundary.
+   */
   private replaceExcerpt(input: {
     text: string;
     source: WorkshopExcerptSource;
     truncation?: WorkshopExcerptTruncation;
     sourceFingerprint?: string;
-  }): void {
-    const replacement = this.session.replaceExcerpt(input);
+  }): boolean {
+    let replacement: WorkshopExcerptReplacement;
+    try {
+      replacement = this.session.replaceExcerpt(input);
+    } catch (error) {
+      const details = error instanceof Error ? error.message : String(error);
+      this.outputChannel.appendLine(`[WorkshopHandler] Excerpt pin refused: ${details}`);
+      this.sendError('workshop', details);
+      return false;
+    }
     this.discardConversations(replacement.disposedConversationIds);
     if (replacement.dividerTurn) {
       this.postTurn(replacement.dividerTurn);
@@ -2565,6 +2586,7 @@ export class WorkshopHandler {
         'This session now carries three excerpt revisions. Consider a new session soon to keep context cost down.'
       );
     }
+    return true;
   }
 
   private discardConversations(conversationIds: readonly string[]): void {

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -26,6 +26,7 @@ import {
   WorkshopContextAttachmentInput,
   WorkshopExcerptReplacement,
   WorkshopMessageAttachmentInput,
+  WorkshopScopeLockedError,
   WorkshopScopeTransition,
   WorkshopSessionService,
   workshopTextNoteLabel
@@ -65,6 +66,9 @@ import {
   workshopMessageCompletionCopy
 } from '@/application/services/workshop/WorkshopRunCompletion';
 import { isWorkshopToolId, workshopToolLabel } from '@shared/constants/workshopTools';
+import {
+  WORKSHOP_SCOPE_LOCK_RECOVERY_MESSAGE
+} from '@shared/constants/workshopScope';
 import { isContextPathGroup } from '@shared/types/context';
 import {
   isWorkshopPersonaId,
@@ -178,6 +182,13 @@ const WORKSHOP_CONTEXT_EDIT_REFUSALS: Readonly<
   'over-budget': (remainingWords) =>
     `That edit exceeds the shared context budget — ${remainingWords.toLocaleString('en-US')} words are available. Trim it, or remove another attachment first.`
 });
+
+const workshopScopeMutationError = (error: unknown, fallback: string): string =>
+  error instanceof WorkshopScopeLockedError
+    ? WORKSHOP_SCOPE_LOCK_RECOVERY_MESSAGE
+    : error instanceof Error
+      ? error.message
+      : fallback;
 
 const isAbsolutePath = (filePath: string): boolean =>
   filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath) || filePath.startsWith('\\\\');
@@ -1186,7 +1197,7 @@ export class WorkshopHandler {
     if (this.rejectExcerptMutationWhileRunning()) {
       return;
     }
-    if (!this.replaceExcerpt({ text, source })) {
+    if (!this.tryReplaceExcerpt({ text, source })) {
       return;
     }
     this.sessionPersistence.markDirty('excerpt replaced');
@@ -1390,9 +1401,9 @@ export class WorkshopHandler {
   }
 
   // ───────────────────────────────────────────────────────────────────────────
-  // Session scope (Sprint 13A §2/§4) — the path chooser and both reversals.
-  // Every one is a context transition inside ONE retained session: no
-  // conversation, transcript, task, or attachment is discarded.
+  // Session scope (ADR 2026-07-25) — choose or revise the path only before
+  // participant memory exists. Once locked, the aggregate refuses the change
+  // and the handler names the new-session recovery path.
   // ───────────────────────────────────────────────────────────────────────────
 
   async handleSetSessionScope(message: WorkshopSetSessionScopeMessage): Promise<void> {
@@ -1414,7 +1425,7 @@ export class WorkshopHandler {
     } catch (error) {
       this.sendError(
         'workshop',
-        error instanceof Error ? error.message : 'That session scope is unavailable.'
+        workshopScopeMutationError(error, 'That session scope is unavailable.')
       );
     }
   }
@@ -1428,7 +1439,7 @@ export class WorkshopHandler {
     } catch (error) {
       this.sendError(
         'workshop',
-        error instanceof Error ? error.message : 'There is no excerpt on the shelf.'
+        workshopScopeMutationError(error, 'There is no excerpt on the shelf.')
       );
     }
   }
@@ -1756,7 +1767,7 @@ export class WorkshopHandler {
     if (this.rejectExcerptMutationWhileRunning()) {
       return;
     }
-    if (!this.replaceExcerpt({
+    if (!this.tryReplaceExcerpt({
       text: resource.text,
       source: {
         kind: 'file',
@@ -2157,7 +2168,7 @@ export class WorkshopHandler {
       return;
     }
 
-    if (!this.replaceExcerpt({
+    if (!this.tryReplaceExcerpt({
       text: loaded.text,
       source,
       truncation: loaded.truncation,
@@ -2225,7 +2236,7 @@ export class WorkshopHandler {
       return;
     }
 
-    if (!this.replaceExcerpt({
+    if (!this.tryReplaceExcerpt({
       text: loaded.text,
       source: resolvedSource,
       truncation: loaded.truncation,
@@ -2537,13 +2548,16 @@ export class WorkshopHandler {
   }
 
   /**
-   * Pin or revise the excerpt. Returns false when the aggregate refused —
+   * Try to pin or revise the excerpt. Centralized because four intake paths
+   * share the same aggregate transition and refusal behavior.
+   *
+   * Returns false when the aggregate refused —
    * the scope lock (ADR 2026-07-25) will not let an open conversation adopt a
    * passage once it has a memory. The refusal names the recovery path, so it
    * belongs in front of the writer rather than escaping as an unhandled
    * rejection at the IPC boundary.
    */
-  private replaceExcerpt(input: {
+  private tryReplaceExcerpt(input: {
     text: string;
     source: WorkshopExcerptSource;
     truncation?: WorkshopExcerptTruncation;
@@ -2553,9 +2567,10 @@ export class WorkshopHandler {
     try {
       replacement = this.session.replaceExcerpt(input);
     } catch (error) {
-      const details = error instanceof Error ? error.message : String(error);
-      this.outputChannel.appendLine(`[WorkshopHandler] Excerpt pin refused: ${details}`);
-      this.sendError('workshop', details);
+      this.sendError(
+        'workshop',
+        workshopScopeMutationError(error, 'That excerpt cannot be pinned in this session.')
+      );
       return false;
     }
     this.discardConversations(replacement.disposedConversationIds);

--- a/packages/core/src/application/services/workshop/WorkshopPromptBuilder.ts
+++ b/packages/core/src/application/services/workshop/WorkshopPromptBuilder.ts
@@ -19,7 +19,6 @@ import {
 } from '@messages';
 import type {
   WorkshopContextAttachment,
-  WorkshopExcerptDeliveryReason,
   WorkshopPendingHostUpdates
 } from '@/application/services/workshop/WorkshopSessionService';
 import { workshopPersonaLabel } from '@shared/constants/workshopPersonas';
@@ -588,25 +587,20 @@ export function buildWorkshopContextAttachmentsFrame(
 }
 
 /**
- * How each excerpt delivery reads to a retained host (Sprint 13A). "Revised"
- * supersedes; "added" and "repinned" are first sight of a passage inside a
- * conversation that has been running without one — a persona that treats those
- * as a revision would imply it had already read something.
+ * The only excerpt delta a retained host can receive (ADR 2026-07-25).
+ *
+ * Session scope is immutable once the room has a memory, so a host that gets
+ * an excerpt frame has already been handed that passage — this is always a
+ * revision. The 13A "added" and "repinned" leads existed for mid-conversation
+ * scope changes, which can no longer happen.
  */
-const WORKSHOP_EXCERPT_DELIVERY_LEAD: Readonly<Record<WorkshopExcerptDeliveryReason, string>> =
-  Object.freeze({
-    revised:
-      'The writer has revised the pinned excerpt. Earlier versions in this conversation are superseded.',
-    added:
-      'The writer has added an excerpt to this conversation. This is the FIRST passage you have been given here — you have not seen it or any other before now. Everything already said in this conversation still stands.',
-    repinned:
-      'The writer has re-pinned the excerpt they previously set aside. You have it again, unchanged, at the version below.'
-  });
+const WORKSHOP_EXCERPT_REVISION_LEAD =
+  'The writer has revised the pinned excerpt. Earlier versions in this conversation are superseded.';
 
 /**
  * Build the trusted, bounded delta delivered to an already-retained host.
- * The aggregate's tri-state context update is interpreted here, in the one
- * place that owns the resulting prompt frame.
+ * The aggregate's context update is interpreted here, in the one place that
+ * owns the resulting prompt frame.
  */
 export function buildWorkshopHostUpdateFrame(
   updates?: WorkshopPendingHostUpdates
@@ -616,14 +610,6 @@ export function buildWorkshopHostUpdateFrame(
   }
 
   const sections: string[] = [];
-  if (updates.excerptWithdrawn) {
-    // Silence here would leave the host quoting a passage it no longer holds
-    // (Sprint 13A §4: shelved, not deleted — but shelved out of ITS reach).
-    sections.push(
-      'The writer has set the excerpt aside. This is now an open conversation and no excerpt is attached.',
-      'You no longer have that passage. Do not quote it, summarize it, or reason from its specific wording; rely only on what this conversation has already established. The writer may re-pin it later, and you will be told when that happens.'
-    );
-  }
   if (updates.excerpt) {
     const excerptTrim = trimToWordLimit(
       updates.excerpt.text,
@@ -640,7 +626,7 @@ export function buildWorkshopHostUpdateFrame(
         : undefined
     ].filter((line): line is string => line !== undefined);
     sections.push(
-      WORKSHOP_EXCERPT_DELIVERY_LEAD[updates.excerptChange ?? 'revised'],
+      WORKSHOP_EXCERPT_REVISION_LEAD,
       ...provenance,
       ...(sourceFrame ? [sourceFrame] : []),
       `<pinned-excerpt version="${updates.excerpt.version}">`,
@@ -672,10 +658,7 @@ export function describeWorkshopPendingHostUpdates(
   updates: WorkshopPendingHostUpdates
 ): string {
   return [
-    updates.excerptWithdrawn ? 'excerpt withdrawn' : undefined,
-    updates.excerpt
-      ? `excerpt v${updates.excerpt.version} (${updates.excerptChange ?? 'revised'})`
-      : undefined,
+    updates.excerpt ? `excerpt v${updates.excerpt.version} (revised)` : undefined,
     updates.contextAttachments
       ? `context r${updates.contextAttachments.revision} (${updates.contextAttachments.attachments.length} attachments)`
       : undefined

--- a/packages/core/src/application/services/workshop/WorkshopSessionPersistenceCoordinator.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionPersistenceCoordinator.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { LogSink } from '@/platform';
 import {
   WorkshopSessionActiveRunPersistenceError,
+  WorkshopSessionHydrationMigration,
   WorkshopSessionService
 } from '@/application/services/workshop/WorkshopSessionService';
 import {
@@ -655,6 +656,7 @@ export class WorkshopSessionPersistenceCoordinator {
         bindings as WorkshopRuntimeConversationBindings,
         this.session.getConversationBehavior()
       );
+      this.logHydrationMigrations(hydration.migrations);
     } catch (error) {
       importedIds.forEach((conversationId) =>
         this.assistantToolService.discardConversation(conversationId)
@@ -874,6 +876,7 @@ export class WorkshopSessionPersistenceCoordinator {
       rollback.bindings,
       this.session.getConversationBehavior()
     );
+    this.logHydrationMigrations(restored.migrations);
     const protectedConversationIds = new Set(
       Object.values(rollback.bindings).filter(
         (conversationId): conversationId is string => typeof conversationId === 'string'
@@ -893,6 +896,18 @@ export class WorkshopSessionPersistenceCoordinator {
 
   private recordStartMarker(): void {
     this.session.recordSessionMarker('start', this.time.describeVisibleMarker('start'));
+  }
+
+  private logHydrationMigrations(
+    migrations: readonly WorkshopSessionHydrationMigration[]
+  ): void {
+    if (migrations.length === 0) {
+      return;
+    }
+    this.outputChannel.appendLine(
+      `[WorkshopSessionPersistence] Legacy checkpoint normalized ` +
+      `(migrations=${migrations.join(', ')})`
+    );
   }
 
   private defaultTitle(createdAt: string): string {

--- a/packages/core/src/application/services/workshop/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionService.ts
@@ -182,38 +182,22 @@ export type WorkshopMessageAttachmentResult =
 
 export interface WorkshopPendingHostUpdates {
   excerpt?: WorkshopExcerpt;
-  /**
-   * Why the excerpt frame is being delivered (Sprint 13A). `revised` is the
-   * pre-existing replacement case; `added`/`repinned` are scope transitions
-   * inside an open conversation, and read very differently to a persona.
-   */
-  excerptChange?: WorkshopExcerptDeliveryReason;
-  /**
-   * The writer shelved the passage. The retained host must be told to stop
-   * treating it as read — silence would leave it quoting material it no
-   * longer has.
-   */
-  excerptWithdrawn?: boolean;
   contextAttachments?: {
     revision: number;
     attachments: WorkshopContextAttachment[];
   };
 }
 
-/** Why a `<pinned-excerpt>` frame is reaching an already-retained host. */
-export type WorkshopExcerptDeliveryReason = 'revised' | 'added' | 'repinned';
-
 /**
  * The result of one session-scope transition. Every field describes state the
- * caller must broadcast; a transition NEVER discards the passage or the
- * retained conversation (Sprint 13A §4).
+ * caller must broadcast. A transition never discards the passage, and it can
+ * only happen before the room has a memory (ADR 2026-07-25) — which is why it
+ * carries no divider turn: no participant experienced it.
  */
 export interface WorkshopScopeTransition {
   scope: WorkshopSessionScope;
   /** False when the request was a no-op (already in that scope). */
   changed: boolean;
-  /** The visible "same session, conversation retained" divider, when one was minted. */
-  dividerTurn?: WorkshopTurn;
   /** The excerpt now pinned, if any. */
   excerpt?: WorkshopExcerpt;
   /** The excerpt now on the shelf, if any. */
@@ -286,8 +270,6 @@ export class WorkshopSessionService {
   private replacementCount = 0;
   private contextRevision = 0;
   private pendingRevisionVersion?: number;
-  private pendingExcerptChange?: WorkshopExcerptDeliveryReason;
-  private pendingExcerptWithdrawal = false;
   private pendingContextRevision?: number;
   private attachmentCounter = 0;
   private pendingMessageAttachments: WorkshopMessageAttachment[] = [];
@@ -376,77 +358,72 @@ export class WorkshopSessionService {
   }
 
   /**
-   * Choose the session path, or reverse it (Sprint 13A §4).
+   * True once any participant holds a conversation — the host, a tool sidecar,
+   * or a persona guest. This is the scope lock (ADR 2026-07-25).
    *
-   * `open` shelves any pinned passage and tells a retained host to stop
-   * treating it as read. `excerpt` restores a shelved passage. Both stay
-   * inside ONE retained session: no conversation, transcript, task, or
-   * attachment is discarded, and the excerpt version never moves.
+   * Deliberately NOT "does the room have any turn". Every session records a
+   * `session_start` marker before the writer does anything, and a resumed
+   * session records `session_resume`, so a turn-based lock would fire the
+   * instant a session was created and strand the writer on the path chooser
+   * with no way to choose. Ledger events append to `turns` and never touch
+   * `participants`, so no temporal frame can move this.
+   */
+  hasRoomMemory(): boolean {
+    return this.conversationIds().length > 0;
+  }
+
+  /** Scope is immutable once someone's memory depends on it (ADR 2026-07-25). */
+  private requireUnlockedScope(attempt: string): void {
+    if (this.hasRoomMemory()) {
+      throw new Error(
+        `Cannot ${attempt}: this room already has a conversation. Start a new ` +
+        'session to change the session path — the excerpt and context ' +
+        'attachments carry over.'
+      );
+    }
+  }
+
+  /**
+   * Choose the session path, or change it while the room has no memory yet
+   * (ADR 2026-07-25, superseding Sprint 13A §4).
+   *
+   * Because no participant has been prompted, a change here is invisible to
+   * everyone: there is nothing to withdraw, nothing to re-deliver, and no
+   * divider to record, since no one experienced the transition. `open` shelves
+   * a pinned passage rather than deleting it; `excerpt` takes it back.
    */
   setSessionScope(scope: WorkshopSelectableSessionScope): WorkshopScopeTransition {
     if (scope === 'open') {
-      const alreadyOpen = this.scope === 'open';
-      if (alreadyOpen && !this.excerpt) {
+      if (this.scope === 'open' && !this.excerpt) {
         return this.scopeTransition(false);
       }
+      this.requireUnlockedScope('set this session to an open conversation');
       const shelved = this.excerpt;
       this.scope = 'open';
-      if (!shelved) {
-        return this.scopeTransition(true);
+      if (shelved) {
+        this.shelvedExcerpt = shelved;
+        this.excerpt = undefined;
+        this.pendingRevisionVersion = undefined;
       }
-      this.shelvedExcerpt = shelved;
-      this.excerpt = undefined;
-      // A tool sidecar that already read the passage keeps its own memory;
-      // only the ROOM stops carrying it. The host, which is re-prompted from
-      // session state every turn, must be told explicitly.
-      //
-      // Dropping the queued delivery is safe because the reason for the NEXT
-      // one is re-derived from what the host was actually handed, not from
-      // what was queued here (see `excerptDeliveryReason`). A withdrawal is
-      // only honest if the host received the passage in the first place: a
-      // pin that was queued but never shipped has nothing to withdraw.
-      this.pendingRevisionVersion = undefined;
-      this.pendingExcerptChange = undefined;
-      if (this.hostDeliveredExcerptVersion() !== undefined) {
-        this.pendingExcerptWithdrawal = true;
-      }
-      return this.scopeTransition(
-        true,
-        this.recordScopeChange(
-          `Excerpt set aside · ${excerptLabel(shelved)} v${shelved.version}` +
-          ' — same session, conversation retained'
-        )
-      );
+      return this.scopeTransition(true);
     }
 
     if (this.scope === 'excerpt' && this.excerpt) {
       return this.scopeTransition(false);
     }
+    this.requireUnlockedScope('start a passage session');
     const restored = this.excerpt ?? this.shelvedExcerpt;
     if (!restored) {
       throw new Error('Cannot start a passage session without an excerpt');
     }
-    const wasShelved = this.excerpt === undefined;
-    this.scope = 'excerpt';
-    if (wasShelved) {
+    if (this.excerpt === undefined) {
       this.adoptShelvedExcerpt(restored);
     }
-    return this.scopeTransition(
-      true,
-      wasShelved && this.turns.length > 0
-        ? this.recordScopeChange(
-            `Excerpt re-pinned · ${excerptLabel(restored)} v${restored.version}` +
-            ' — same session, conversation retained'
-          )
-        : undefined
-    );
+    this.scope = 'excerpt';
+    return this.scopeTransition(true);
   }
 
-  /**
-   * Re-pin the shelved passage WITHOUT leaving the open conversation — the
-   * rail's "Re-pin <title> vN" affordance. Scope stays `open`, which is the
-   * honest record of how this room started.
-   */
+  /** Take the set-aside passage back off the shelf, before the room has a memory. */
   repinShelvedExcerpt(): WorkshopScopeTransition {
     const shelved = this.shelvedExcerpt;
     if (!shelved) {
@@ -455,35 +432,18 @@ export class WorkshopSessionService {
     if (this.excerpt) {
       throw new Error('An excerpt is already pinned in this Workshop session');
     }
+    this.requireUnlockedScope('re-pin the set-aside excerpt');
     this.adoptShelvedExcerpt(shelved);
-    return this.scopeTransition(
-      true,
-      this.recordScopeChange(
-        `Excerpt re-pinned · ${excerptLabel(shelved)} v${shelved.version}` +
-        ' — same session, conversation retained'
-      )
-    );
+    this.scope = 'excerpt';
+    return this.scopeTransition(true);
   }
 
   private adoptShelvedExcerpt(excerpt: WorkshopExcerpt): void {
-    const withdrawalUndelivered = this.pendingExcerptWithdrawal;
     this.excerpt = excerpt;
     this.shelvedExcerpt = undefined;
-    this.pendingExcerptWithdrawal = false;
+    // Pre-memory by construction (the scope lock), so there is no retained
+    // participant to notify and no queued delivery to reconcile.
     this.pendingRevisionVersion = undefined;
-    this.pendingExcerptChange = undefined;
-    if (!this.hasHostConversation()) {
-      return;
-    }
-    const reason = this.excerptDeliveryReason(excerpt.version);
-    if (withdrawalUndelivered && reason === 'repinned') {
-      // The withdrawal never shipped and the host still holds this exact
-      // version: the whole shelve/re-pin round trip is invisible to it.
-      // Announcing a change it never saw would be its own small lie.
-      return;
-    }
-    this.pendingRevisionVersion = excerpt.version;
-    this.pendingExcerptChange = reason;
   }
 
   /**
@@ -506,46 +466,13 @@ export class WorkshopSessionService {
     return undefined;
   }
 
-  /**
-   * Name a delivery by what the HOST holds, never by what the room holds
-   * (Sprint 13A §10). "Added" asserts the host has never seen a passage here,
-   * so it may only be used when the delivery record is genuinely empty.
-   */
-  private excerptDeliveryReason(version: number): WorkshopExcerptDeliveryReason {
-    const delivered = this.hostDeliveredExcerptVersion();
-    if (delivered === undefined) {
-      return 'added';
-    }
-    return delivered === version ? 'repinned' : 'revised';
-  }
-
-  private scopeTransition(
-    changed: boolean,
-    dividerTurn?: WorkshopTurn
-  ): WorkshopScopeTransition {
+  private scopeTransition(changed: boolean): WorkshopScopeTransition {
     return {
       scope: this.scope,
       changed,
-      dividerTurn,
       excerpt: this.getExcerpt(),
       shelvedExcerpt: this.getShelvedExcerpt()
     };
-  }
-
-  /** Append the visible "same session" boundary for a scope transition. */
-  private recordScopeChange(content: string): WorkshopTurn {
-    const turn: WorkshopTurn = {
-      id: this.nextTurnId('system'),
-      role: 'system',
-      kind: 'divider',
-      participant: 'session',
-      artifact: 'scope_change',
-      excerptVersion: this.excerptVersion,
-      content,
-      timestamp: this.now()
-    };
-    this.turns.push(turn);
-    return cloneTurn(turn);
   }
 
   setExcerpt(input: WorkshopExcerptInput): WorkshopExcerpt {
@@ -558,23 +485,27 @@ export class WorkshopSessionService {
       sourceFingerprint: input.sourceFingerprint,
       pinnedAt: this.now()
     };
-    // Pinning IS choosing the passage path — but an open conversation that
-    // adopts an excerpt stays open (Sprint 13A §4: a visible context
-    // transition, not a new session).
-    if (this.scope !== 'open') {
-      this.scope = 'excerpt';
-    }
+    // Pinning IS choosing the passage path (ADR 2026-07-25). The 13A hybrid —
+    // an open conversation carrying an excerpt — is gone: a room either
+    // workshops a passage or it does not, and the scope lock means this can
+    // only ever run before anyone has been prompted about either.
+    this.scope = 'excerpt';
     // A fresh pin supersedes anything on the shelf — exactly one slot may hold
     // the passage (the V1 integrity rule). Nothing lingers, and nothing
-    // vanishes quietly either: `replaceExcerpt` names the displaced passage in
-    // the divider and returns it so the caller can log and confirm it.
+    // vanishes quietly either: `replaceExcerpt` returns the displaced passage
+    // so the caller can log and confirm it.
     this.shelvedExcerpt = undefined;
-    this.pendingExcerptWithdrawal = false;
     return cloneExcerpt(this.excerpt);
   }
 
   /** Replace working text, preserve host memory, and retire stale tool sidecars. */
   replaceExcerpt(input: WorkshopExcerptInput): WorkshopExcerptReplacement {
+    if (this.scope === 'open') {
+      // An open conversation never gains a passage once it has a memory: the
+      // host has been answering without one, and handing it prose now would
+      // make everything already said ambiguous (ADR 2026-07-25).
+      this.requireUnlockedScope('add an excerpt to this open conversation');
+    }
     // The SHELF counts as previously carried. Shelving is not a deletion, so
     // pinning over a set-aside passage is a replacement, not a first pin: the
     // tool sidecars still hold that passage and so does the host's transcript.
@@ -582,9 +513,6 @@ export class WorkshopSessionService {
     // below and assert "your FIRST passage" to a host holding the last one.
     const displaced = this.shelvedExcerpt;
     const previous = this.excerpt ?? displaced;
-    // An open conversation that adopts a passage stays open (Sprint 13A §4:
-    // a visible context transition, not a new session).
-    const adoptingInOpenChat = this.scope === 'open';
 
     if (!previous) {
       const excerpt = this.setExcerpt(input);
@@ -592,12 +520,6 @@ export class WorkshopSessionService {
       return {
         excerpt,
         disposedConversationIds: [],
-        dividerTurn: adoptingInOpenChat
-          ? this.recordScopeChange(
-              `Excerpt added · ${excerptLabel(excerpt)} v${excerpt.version}` +
-              ' — same session, conversation retained'
-            )
-          : undefined,
         retiredSidecarCount: 0,
         replacementCount: this.replacementCount
       };
@@ -619,21 +541,14 @@ export class WorkshopSessionService {
     const retiredLabels = retired.map(sidecar => workshopToolLabel(sidecar.toolId)).sort();
     const source = workshopExcerptSourcePath(excerpt.source) ?? 'Pasted excerpt';
     const retiredText = retiredLabels.length > 0 ? retiredLabels.join(', ') : 'none';
-    // Only an open-scope room can be holding a shelf, so a displaced passage
-    // always rides the scope-transition divider — and it is NAMED there,
-    // because the shelf is one slot with no history and this pin is the last
-    // moment that passage exists anywhere.
-    const dividerTurn = adoptingInOpenChat
-      ? this.recordScopeChange(
-          `Excerpt added · ${excerptLabel(excerpt)} v${excerpt.version} — ` +
-          (displaced
-            ? `set-aside “${excerptLabel(displaced)}” v${displaced.version} discarded,`
-            : 'same session,') +
-          ' conversation retained'
-        )
-      : this.recordExcerptRevision(
-          `Excerpt v${excerpt.version} pinned · ${source} · retired: ${retiredText}`
-        );
+    // A displaced shelf is NAMED here: the shelf is one slot with no history,
+    // so this pin is the last moment that passage exists anywhere.
+    const dividerTurn = this.recordExcerptRevision(
+      `Excerpt v${excerpt.version} pinned · ${source} · retired: ${retiredText}` +
+      (displaced
+        ? ` · set-aside “${excerptLabel(displaced)}” v${displaced.version} discarded`
+        : '')
+    );
     return {
       excerpt,
       disposedConversationIds: conversationIds,
@@ -645,17 +560,20 @@ export class WorkshopSessionService {
   }
 
   /**
-   * Queue the retained host's excerpt delta frame. The REASON is derived from
-   * the delivery record, never from which method was called: the same pin can
-   * be this host's first passage, a revision of one it holds, or the exact
-   * version it already has coming back off the shelf.
+   * Queue the retained host's excerpt delta frame.
+   *
+   * Under the scope lock every surviving delivery is a REVISION of a passage
+   * the host already holds: an open conversation can never adopt one, and a
+   * re-pin can only happen before any host exists. `hostDeliveredExcerptVersion`
+   * is what makes that claim checkable rather than assumed — it is the honest
+   * answer to "what does the host actually have," and the one guard against
+   * queueing a revision to a host that was never handed the original.
    */
   private queueExcerptDelivery(excerpt: WorkshopExcerpt): void {
-    if (!this.hasHostConversation()) {
+    if (!this.hasHostConversation() || this.hostDeliveredExcerptVersion() === undefined) {
       return;
     }
     this.pendingRevisionVersion = excerpt.version;
-    this.pendingExcerptChange = this.excerptDeliveryReason(excerpt.version);
   }
 
   /** Append the visible "excerpt vN pinned" boundary for a passage revision. */
@@ -915,14 +833,8 @@ export class WorkshopSessionService {
           attachments: this.getContextAttachments()
         }
       : undefined;
-    const excerptWithdrawn = this.pendingExcerptWithdrawal ? true : undefined;
-    return excerpt || contextAttachments || excerptWithdrawn
-      ? {
-          excerpt,
-          excerptChange: excerpt ? this.pendingExcerptChange ?? 'revised' : undefined,
-          excerptWithdrawn,
-          contextAttachments
-        }
+    return excerpt || contextAttachments
+      ? { excerpt, contextAttachments }
       : undefined;
   }
 
@@ -930,21 +842,11 @@ export class WorkshopSessionService {
   commitPendingHostUpdates(delivered: WorkshopPendingHostUpdates): void {
     if (delivered.excerpt?.version === this.pendingRevisionVersion) {
       this.pendingRevisionVersion = undefined;
-      this.pendingExcerptChange = undefined;
       // The revision frame actually reached the host: only the one live pin
       // can change state. Earlier rows were made stale at their own revision.
       const pin = this.pinEntry();
       if (pin) {
         this.appendHostPin(pin);
-      }
-    }
-    if (delivered.excerptWithdrawn && this.pendingExcerptWithdrawal) {
-      this.pendingExcerptWithdrawal = false;
-      // The passage left the host's context: its live pin row is no longer
-      // carried material, so it joins the dimmed history (Phase 7).
-      if (this.activeHostPin) {
-        this.activeHostPin.stale = true;
-        this.activeHostPin = undefined;
       }
     }
     if (delivered.contextAttachments?.revision === this.pendingContextRevision) {
@@ -1757,8 +1659,6 @@ export class WorkshopSessionService {
       guest.liveness = 'disposed';
     }
     this.pendingRevisionVersion = undefined;
-    this.pendingExcerptChange = undefined;
-    this.pendingExcerptWithdrawal = false;
     this.pendingContextRevision = undefined;
     // Manifests live and die with their conversations (Phase 7).
     this.hostWriterSources = [];
@@ -1839,8 +1739,6 @@ export class WorkshopSessionService {
         replacementCount: this.replacementCount,
         context: this.contextRevision,
         pendingExcerpt: this.pendingRevisionVersion,
-        pendingExcerptChange: this.pendingExcerptChange,
-        pendingExcerptWithdrawal: this.pendingExcerptWithdrawal ? true : undefined,
         pendingContext: this.pendingContextRevision
       },
       counters: {
@@ -1914,17 +1812,35 @@ export class WorkshopSessionService {
   ): WorkshopSessionHydrationResult {
     validateWorkshopSessionStateV1(state);
 
-    const excerpt = state.excerpt ? cloneExcerpt(state.excerpt) : undefined;
-    const shelvedExcerpt = state.shelvedExcerpt ? cloneExcerpt(state.shelvedExcerpt) : undefined;
+    // A checkpoint written before the scope lock may hold an UNDELIVERED
+    // withdrawal: the writer shelved a passage, but the frame telling the host
+    // to stop treating it as read never shipped, and that frame no longer
+    // exists (ADR 2026-07-25 §7). The host therefore still holds the passage,
+    // and the honest normalization is to make the room agree with what the
+    // host believes rather than with a reversal that never took effect — so
+    // the passage comes back off the shelf and the room is a passage session.
+    //
+    // A withdrawal that DID ship leaves this flag false, and that room is
+    // already consistent: open scope, shelf intact, host correctly without it.
+    const withdrawalNeverShipped =
+      state.revisions.pendingExcerptWithdrawal === true && state.shelvedExcerpt !== undefined;
+    const excerpt = withdrawalNeverShipped
+      ? cloneExcerpt(state.shelvedExcerpt!)
+      : state.excerpt ? cloneExcerpt(state.excerpt) : undefined;
+    const shelvedExcerpt = withdrawalNeverShipped
+      ? undefined
+      : state.shelvedExcerpt ? cloneExcerpt(state.shelvedExcerpt) : undefined;
     // Checkpoints written before scope existed carry none. Inferring once, at
     // the migration boundary, is the only honest option — and it is NOT the
     // live "infer scope from excerpt presence" the sprint forbids: from here on
     // the restored value is authoritative state.
-    const scope: WorkshopSessionScope = state.scope !== undefined
-      ? state.scope
-      : excerpt
-        ? 'excerpt'
-        : null;
+    const scope: WorkshopSessionScope = withdrawalNeverShipped
+      ? 'excerpt'
+      : state.scope !== undefined
+        ? state.scope
+        : excerpt
+          ? 'excerpt'
+          : null;
     const contextAttachments = state.contextAttachments.map(cloneAttachment);
     const pendingMessageAttachments = state.pendingMessageAttachments.map(cloneMessageAttachment);
     const turns = state.turns.map(cloneTurn);
@@ -1947,8 +1863,6 @@ export class WorkshopSessionService {
     const hostExpected = state.participants.host.conversationKey === 'host';
     const hostConversationId = hostExpected ? usableBindings.get('host') : undefined;
     let pendingRevisionVersion = state.revisions.pendingExcerpt;
-    let pendingExcerptChange = state.revisions.pendingExcerptChange;
-    let pendingExcerptWithdrawal = state.revisions.pendingExcerptWithdrawal === true;
     let pendingContextRevision = state.revisions.pendingContext;
     if (!hostConversationId) {
       if (hostExpected) {
@@ -1956,10 +1870,6 @@ export class WorkshopSessionService {
       }
       hostWriterSources.length = 0;
       pendingRevisionVersion = undefined;
-      pendingExcerptChange = undefined;
-      // A fresh host receives the current scope in its initial envelope, so
-      // there is nothing left to "update" it about.
-      pendingExcerptWithdrawal = false;
       pendingContextRevision = undefined;
     }
 
@@ -2037,8 +1947,6 @@ export class WorkshopSessionService {
     this.replacementCount = state.revisions.replacementCount;
     this.contextRevision = state.revisions.context;
     this.pendingRevisionVersion = pendingRevisionVersion;
-    this.pendingExcerptChange = pendingExcerptChange;
-    this.pendingExcerptWithdrawal = pendingExcerptWithdrawal;
     this.pendingContextRevision = pendingContextRevision;
     this.attachmentCounter = state.counters.attachment;
     this.pendingMessageAttachments = pendingMessageAttachments;
@@ -2075,18 +1983,16 @@ export class WorkshopSessionService {
       pendingMessageAttachments: this.pendingMessageAttachments.map(messageAttachmentSnapshot),
       pendingHostUpdate: this.pendingRevisionVersion !== undefined
         || this.pendingContextRevision !== undefined
-        || this.pendingExcerptWithdrawal
         ? {
             excerptVersion: this.pendingRevisionVersion,
-            context: this.pendingContextRevision !== undefined,
-            excerptWithdrawn: this.pendingExcerptWithdrawal ? true : undefined
+            context: this.pendingContextRevision !== undefined
           }
         : undefined,
       todos: this.todos.map((todo) => cloneTodo(todo, this.excerptVersion)),
       turns: windowed.map(cloneTurn),
       totalTurns: this.turns.length,
       truncatedTurns: this.turns.length - windowed.length,
-      hasConversation: this.conversationIds().length > 0,
+      hasConversation: this.hasRoomMemory(),
       participants: this.snapshotParticipants(),
       conversationBehavior: { ...this.behavior },
       selectedToolId: this.selectedToolId,

--- a/packages/core/src/application/services/workshop/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionService.ts
@@ -64,6 +64,13 @@ import {
 import {
   validateWorkshopSessionStateV1
 } from '@/application/services/workshop/WorkshopSessionStateV1Integrity';
+import {
+  migrateWorkshopSessionStateV1ForHydration,
+  WorkshopSessionHydrationMigration
+} from '@/application/services/workshop/WorkshopSessionStateV1Migration';
+export type {
+  WorkshopSessionHydrationMigration
+} from '@/application/services/workshop/WorkshopSessionStateV1Migration';
 
 export { WORKSHOP_TODO_BOUNDS } from '@/application/services/workshop/WorkshopSessionLimits';
 
@@ -238,12 +245,26 @@ export interface WorkshopExcerptReplacement {
 export interface WorkshopSessionHydrationResult {
   discardedConversationIds: string[];
   degradedConversationKeys: WorkshopConversationLogicalKey[];
+  migrations: WorkshopSessionHydrationMigration[];
 }
 
 export class WorkshopSessionActiveRunPersistenceError extends Error {
   constructor() {
     super('Cannot persist Workshop session while a run is active');
     this.name = 'WorkshopSessionActiveRunPersistenceError';
+  }
+}
+
+/**
+ * Domain refusal for an attempted path change after participant memory exists.
+ * Presentation adapters decide how to explain the recovery path to a writer.
+ */
+export class WorkshopScopeLockedError extends Error {
+  readonly code = 'workshop-scope-locked';
+
+  constructor(readonly attempt: string) {
+    super(`Cannot ${attempt}: this room already has a conversation`);
+    this.name = 'WorkshopScopeLockedError';
   }
 }
 
@@ -358,28 +379,30 @@ export class WorkshopSessionService {
   }
 
   /**
-   * True once any participant holds a conversation — the host, a tool sidecar,
-   * or a persona guest. This is the scope lock (ADR 2026-07-25).
+   * True once any participant holds or has held a conversation — the host, a
+   * tool sidecar, or a persona guest. This is the scope lock
+   * (ADR 2026-07-25).
    *
    * Deliberately NOT "does the room have any turn". Every session records a
    * `session_start` marker before the writer does anything, and a resumed
    * session records `session_resume`, so a turn-based lock would fire the
    * instant a session was created and strand the writer on the path chooser
    * with no way to choose. Ledger events append to `turns` and never touch
-   * `participants`, so no temporal frame can move this.
+   * `participants`, so no temporal frame can move this. A disposed guest stays
+   * in the participant map as a tombstone, preserving the lock after its
+   * provider conversation is discarded. Host/tool degradation is different:
+   * a failed runtime rebind leaves no retained model memory, so those missing
+   * live bindings do not lock; the persistence coordinator logs that loss.
    */
   hasRoomMemory(): boolean {
-    return this.conversationIds().length > 0;
+    return this.conversationIds().length > 0
+      || this.participants.personaGuests.size > 0;
   }
 
   /** Scope is immutable once someone's memory depends on it (ADR 2026-07-25). */
   private requireUnlockedScope(attempt: string): void {
     if (this.hasRoomMemory()) {
-      throw new Error(
-        `Cannot ${attempt}: this room already has a conversation. Start a new ` +
-        'session to change the session path — the excerpt and context ' +
-        'attachments carry over.'
-      );
+      throw new WorkshopScopeLockedError(attempt);
     }
   }
 
@@ -393,11 +416,18 @@ export class WorkshopSessionService {
    * a pinned passage rather than deleting it; `excerpt` takes it back.
    */
   setSessionScope(scope: WorkshopSelectableSessionScope): WorkshopScopeTransition {
+    // The no-op check deliberately precedes the lock: reconciling a stale
+    // caller with the room's CURRENT path is safe even after memory exists.
+    if (this.isIdempotentScopeRequest(scope)) {
+      return this.scopeTransition(false);
+    }
+    this.requireUnlockedScope(
+      scope === 'open'
+        ? 'set this session to an open conversation'
+        : 'start a passage session'
+    );
+
     if (scope === 'open') {
-      if (this.scope === 'open' && !this.excerpt) {
-        return this.scopeTransition(false);
-      }
-      this.requireUnlockedScope('set this session to an open conversation');
       const shelved = this.excerpt;
       this.scope = 'open';
       if (shelved) {
@@ -408,19 +438,19 @@ export class WorkshopSessionService {
       return this.scopeTransition(true);
     }
 
-    if (this.scope === 'excerpt' && this.excerpt) {
-      return this.scopeTransition(false);
-    }
-    this.requireUnlockedScope('start a passage session');
     const restored = this.excerpt ?? this.shelvedExcerpt;
     if (!restored) {
       throw new Error('Cannot start a passage session without an excerpt');
     }
-    if (this.excerpt === undefined) {
-      this.adoptShelvedExcerpt(restored);
-    }
+    this.adoptShelvedExcerpt(restored);
     this.scope = 'excerpt';
     return this.scopeTransition(true);
+  }
+
+  private isIdempotentScopeRequest(scope: WorkshopSelectableSessionScope): boolean {
+    return scope === 'open'
+      ? this.scope === 'open' && this.excerpt === undefined
+      : this.scope === 'excerpt' && this.excerpt !== undefined;
   }
 
   /** Take the set-aside passage back off the shelf, before the room has a memory. */
@@ -1810,49 +1840,33 @@ export class WorkshopSessionService {
     runtimeBindings: WorkshopRuntimeConversationBindings,
     currentBehavior: WorkshopConversationBehavior
   ): WorkshopSessionHydrationResult {
-    validateWorkshopSessionStateV1(state);
+    validateWorkshopSessionStateV1(state, {
+      allowLegacyOpenSessionWithExcerpt: true
+    });
+    const migration = migrateWorkshopSessionStateV1ForHydration(state);
+    const normalized = migration.state;
+    // The compatibility exception terminates at the migration boundary. From
+    // this point on, the current invariant is absolute.
+    validateWorkshopSessionStateV1(normalized);
 
-    // A checkpoint written before the scope lock may hold an UNDELIVERED
-    // withdrawal: the writer shelved a passage, but the frame telling the host
-    // to stop treating it as read never shipped, and that frame no longer
-    // exists (ADR 2026-07-25 §7). The host therefore still holds the passage,
-    // and the honest normalization is to make the room agree with what the
-    // host believes rather than with a reversal that never took effect — so
-    // the passage comes back off the shelf and the room is a passage session.
-    //
-    // A withdrawal that DID ship leaves this flag false, and that room is
-    // already consistent: open scope, shelf intact, host correctly without it.
-    const withdrawalNeverShipped =
-      state.revisions.pendingExcerptWithdrawal === true && state.shelvedExcerpt !== undefined;
-    const excerpt = withdrawalNeverShipped
-      ? cloneExcerpt(state.shelvedExcerpt!)
-      : state.excerpt ? cloneExcerpt(state.excerpt) : undefined;
-    const shelvedExcerpt = withdrawalNeverShipped
-      ? undefined
-      : state.shelvedExcerpt ? cloneExcerpt(state.shelvedExcerpt) : undefined;
-    // Checkpoints written before scope existed carry none. Inferring once, at
-    // the migration boundary, is the only honest option — and it is NOT the
-    // live "infer scope from excerpt presence" the sprint forbids: from here on
-    // the restored value is authoritative state.
-    const scope: WorkshopSessionScope = withdrawalNeverShipped
-      ? 'excerpt'
-      : state.scope !== undefined
-        ? state.scope
-        : excerpt
-          ? 'excerpt'
-          : null;
-    const contextAttachments = state.contextAttachments.map(cloneAttachment);
-    const pendingMessageAttachments = state.pendingMessageAttachments.map(cloneMessageAttachment);
-    const turns = state.turns.map(cloneTurn);
-    const todos = state.todos.map(cloneStoredTodo);
-    const behavior = { ...currentBehavior };
-    const lastCommittedPersonaBehavior = state.lastCommittedPersonaBehavior
-      ? { ...state.lastCommittedPersonaBehavior }
+    const excerpt = normalized.excerpt ? cloneExcerpt(normalized.excerpt) : undefined;
+    const shelvedExcerpt = normalized.shelvedExcerpt
+      ? cloneExcerpt(normalized.shelvedExcerpt)
       : undefined;
-    const hostWriterSources = state.writerSources.host.map(cloneSourceEntry);
-    const toolWriterSources = cloneToolWriterSources(state.writerSources.tools);
+    const scope = normalized.scope ?? null;
+    const contextAttachments = normalized.contextAttachments.map(cloneAttachment);
+    const pendingMessageAttachments =
+      normalized.pendingMessageAttachments.map(cloneMessageAttachment);
+    const turns = normalized.turns.map(cloneTurn);
+    const todos = normalized.todos.map(cloneStoredTodo);
+    const behavior = { ...currentBehavior };
+    const lastCommittedPersonaBehavior = normalized.lastCommittedPersonaBehavior
+      ? { ...normalized.lastCommittedPersonaBehavior }
+      : undefined;
+    const hostWriterSources = normalized.writerSources.host.map(cloneSourceEntry);
+    const toolWriterSources = cloneToolWriterSources(normalized.writerSources.tools);
     const guestWriterSources = new Map<WorkshopPersonaId, ContextSourceEntry[]>(
-      state.writerSources.guests.map(({ personaId, sources }) => [
+      normalized.writerSources.guests.map(({ personaId, sources }) => [
         personaId,
         sources.map(cloneSourceEntry)
       ])
@@ -1860,10 +1874,10 @@ export class WorkshopSessionService {
 
     const degradedConversationKeys: WorkshopConversationLogicalKey[] = [];
     const usableBindings = usableRuntimeBindings(runtimeBindings);
-    const hostExpected = state.participants.host.conversationKey === 'host';
+    const hostExpected = normalized.participants.host.conversationKey === 'host';
     const hostConversationId = hostExpected ? usableBindings.get('host') : undefined;
-    let pendingRevisionVersion = state.revisions.pendingExcerpt;
-    let pendingContextRevision = state.revisions.pendingContext;
+    let pendingRevisionVersion = normalized.revisions.pendingExcerpt;
+    let pendingContextRevision = normalized.revisions.pendingContext;
     if (!hostConversationId) {
       if (hostExpected) {
         degradedConversationKeys.push('host');
@@ -1874,7 +1888,7 @@ export class WorkshopSessionService {
     }
 
     const toolSidecars: WorkshopParticipants['toolSidecars'] = {};
-    for (const sidecar of state.participants.toolSidecars) {
+    for (const sidecar of normalized.participants.toolSidecars) {
       const conversationId = usableBindings.get(sidecar.conversationKey);
       if (!conversationId) {
         degradedConversationKeys.push(sidecar.conversationKey);
@@ -1889,7 +1903,7 @@ export class WorkshopSessionService {
     }
 
     const personaGuests = new Map<WorkshopPersonaId, WorkshopPersonaGuest>();
-    for (const guest of state.participants.personaGuests) {
+    for (const guest of normalized.participants.personaGuests) {
       const conversationId = guest.conversationKey
         ? usableBindings.get(guest.conversationKey)
         : undefined;
@@ -1909,7 +1923,7 @@ export class WorkshopSessionService {
       });
     }
 
-    const requestedTarget = cloneChatTarget(state.participants.chatTarget);
+    const requestedTarget = cloneChatTarget(normalized.participants.chatTarget);
     const chatTarget: WorkshopChatTarget = requestedTarget.kind === 'tool'
       ? toolSidecars[requestedTarget.toolId]
         ? requestedTarget
@@ -1929,7 +1943,7 @@ export class WorkshopSessionService {
     const activeHostPin = hostConversationId ? activeHostPins[0] : undefined;
     const participants: WorkshopParticipants = {
       host: {
-        personaId: state.participants.host.personaId,
+        personaId: normalized.participants.host.personaId,
         conversationId: hostConversationId
       },
       toolSidecars,
@@ -1943,14 +1957,14 @@ export class WorkshopSessionService {
     this.scope = scope;
     this.shelvedExcerpt = shelvedExcerpt;
     this.contextAttachments = contextAttachments;
-    this.excerptVersion = state.revisions.excerpt;
-    this.replacementCount = state.revisions.replacementCount;
-    this.contextRevision = state.revisions.context;
+    this.excerptVersion = normalized.revisions.excerpt;
+    this.replacementCount = normalized.revisions.replacementCount;
+    this.contextRevision = normalized.revisions.context;
     this.pendingRevisionVersion = pendingRevisionVersion;
     this.pendingContextRevision = pendingContextRevision;
-    this.attachmentCounter = state.counters.attachment;
+    this.attachmentCounter = normalized.counters.attachment;
     this.pendingMessageAttachments = pendingMessageAttachments;
-    this.threadArtifactCounter = state.counters.threadArtifact;
+    this.threadArtifactCounter = normalized.counters.threadArtifact;
     this.hostWriterSources = hostWriterSources;
     this.activeHostPin = activeHostPin;
     this.toolWriterSources = toolWriterSources;
@@ -1958,16 +1972,17 @@ export class WorkshopSessionService {
     this.turns = turns;
     this.activeRun = undefined;
     this.participants = participants;
-    this.selectedToolId = state.selectedToolId;
-    this.turnCounter = state.counters.turn;
-    this.todoCounter = state.counters.todo;
+    this.selectedToolId = normalized.selectedToolId;
+    this.turnCounter = normalized.counters.turn;
+    this.todoCounter = normalized.counters.todo;
     this.todos = todos;
     this.behavior = behavior;
     this.lastCommittedPersonaBehavior = lastCommittedPersonaBehavior;
 
     return {
       discardedConversationIds,
-      degradedConversationKeys
+      degradedConversationKeys,
+      migrations: migration.migrations
     };
   }
 
@@ -1992,7 +2007,7 @@ export class WorkshopSessionService {
       turns: windowed.map(cloneTurn),
       totalTurns: this.turns.length,
       truncatedTurns: this.turns.length - windowed.length,
-      hasConversation: this.hasRoomMemory(),
+      roomHasMemory: this.hasRoomMemory(),
       participants: this.snapshotParticipants(),
       conversationBehavior: { ...this.behavior },
       selectedToolId: this.selectedToolId,

--- a/packages/core/src/application/services/workshop/WorkshopSessionStateV1.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionStateV1.ts
@@ -19,7 +19,6 @@ import {
 } from '@messages';
 import type {
   WorkshopContextAttachment,
-  WorkshopExcerptDeliveryReason,
   WorkshopMessageAttachment
 } from '@/application/services/workshop/WorkshopSessionService';
 import {
@@ -61,9 +60,17 @@ export interface WorkshopSessionStateV1 {
     replacementCount: number;
     context: number;
     pendingExcerpt?: number;
-    /** Why the queued excerpt frame is being delivered (Sprint 13A). */
-    pendingExcerptChange?: WorkshopExcerptDeliveryReason;
-    /** A shelved passage still has to be withdrawn from the retained host. */
+    /**
+     * LEGACY (Sprint 13A, retired by ADR 2026-07-25). Both fields serviced
+     * mid-conversation scope changes, which the scope lock made impossible.
+     * They are still ACCEPTED so that checkpoints written before the lock
+     * parse rather than failing a writer's real session open — and they are
+     * discarded at the hydration boundary and never written again. Removing
+     * them from this list would make the shape validator reject those files
+     * as carrying unknown fields.
+     */
+    pendingExcerptChange?: 'revised' | 'added' | 'repinned';
+    /** LEGACY — see `pendingExcerptChange`. */
     pendingExcerptWithdrawal?: true;
     pendingContext?: number;
   };

--- a/packages/core/src/application/services/workshop/WorkshopSessionStateV1.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionStateV1.ts
@@ -126,6 +126,11 @@ export interface WorkshopSessionStateV1 {
 export function parseWorkshopSessionStateV1(value: unknown): WorkshopSessionStateV1 {
   assertWorkshopSessionStateShape(value);
   const decoded = clonePersistedJson(value, 'workshop');
-  validateWorkshopSessionStateV1(decoded);
+  // Compatibility states are accepted only at the raw checkpoint boundary.
+  // Hydration runs the named V1 migration and validates its output again
+  // against current invariants before replacing the live aggregate.
+  validateWorkshopSessionStateV1(decoded, {
+    allowLegacyOpenSessionWithExcerpt: true
+  });
   return decoded;
 }

--- a/packages/core/src/application/services/workshop/WorkshopSessionStateV1Integrity.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionStateV1Integrity.ts
@@ -9,7 +9,19 @@ import type {
   WorkshopSessionStateV1
 } from '@/application/services/workshop/WorkshopSessionStateV1';
 
-export function validateWorkshopSessionStateV1(state: WorkshopSessionStateV1): void {
+export interface WorkshopSessionStateV1ValidationOptions {
+  /**
+   * The pre-lock product could persist `scope: open` with a pinned excerpt.
+   * Only raw-checkpoint preflight may tolerate it; hydration normalizes the
+   * state and validates again under the current invariant.
+   */
+  allowLegacyOpenSessionWithExcerpt?: boolean;
+}
+
+export function validateWorkshopSessionStateV1(
+  state: WorkshopSessionStateV1,
+  options: WorkshopSessionStateV1ValidationOptions = {}
+): void {
   const requireCounter = (value: number, label: string): void => {
     if (!Number.isSafeInteger(value) || value < 0) {
       throw new Error(`Persisted Workshop ${label} must be a non-negative safe integer`);
@@ -29,6 +41,13 @@ export function validateWorkshopSessionStateV1(state: WorkshopSessionStateV1): v
   // slots may hold it.
   if (state.excerpt && state.shelvedExcerpt) {
     throw new Error('Persisted Workshop state has both a pinned and a shelved excerpt');
+  }
+  if (
+    state.scope === 'open'
+    && state.excerpt !== undefined
+    && options.allowLegacyOpenSessionWithExcerpt !== true
+  ) {
+    throw new Error('Persisted Workshop open session cannot hold a pinned excerpt');
   }
   const versionedExcerpt = state.excerpt ?? state.shelvedExcerpt;
   if (versionedExcerpt) {

--- a/packages/core/src/application/services/workshop/WorkshopSessionStateV1Integrity.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionStateV1Integrity.ts
@@ -44,15 +44,11 @@ export function validateWorkshopSessionStateV1(state: WorkshopSessionStateV1): v
   ) {
     throw new Error('Persisted Workshop pending excerpt revision is not current');
   }
-  // A queued excerpt frame and a queued withdrawal are contradictory
-  // instructions to the same host turn; the aggregate clears one when it sets
-  // the other, and a checkpoint claiming both is corrupt.
-  if (state.revisions.pendingExcerptWithdrawal && state.revisions.pendingExcerpt !== undefined) {
-    throw new Error('Persisted Workshop state queues both an excerpt delivery and its withdrawal');
-  }
-  if (state.revisions.pendingExcerptChange !== undefined && state.revisions.pendingExcerpt === undefined) {
-    throw new Error('Persisted Workshop state names an excerpt delivery reason with nothing to deliver');
-  }
+  // `pendingExcerptWithdrawal` and `pendingExcerptChange` are deliberately NOT
+  // validated. ADR 2026-07-25 retired both; they survive in the grammar only
+  // so pre-lock checkpoints parse, and they are discarded on hydrate. Asserting
+  // consistency between fields we are about to throw away would fail a
+  // writer's real session open over state that no longer means anything.
   if (
     state.revisions.pendingContext !== undefined
     && (

--- a/packages/core/src/application/services/workshop/WorkshopSessionStateV1Migration.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionStateV1Migration.ts
@@ -1,0 +1,71 @@
+/**
+ * One-way compatibility normalization for checkpoints written before Workshop
+ * scope became immutable. Current code cannot write these states; saved writer
+ * sessions may still contain them.
+ */
+
+import type {
+  WorkshopSessionStateV1
+} from '@/application/services/workshop/WorkshopSessionStateV1';
+
+export type WorkshopSessionHydrationMigration =
+  | 'discarded-legacy-scope-transition'
+  | 'inferred-missing-scope'
+  | 'normalized-open-session-with-excerpt'
+  | 'restored-undelivered-withdrawal';
+
+export interface WorkshopSessionStateV1MigrationResult {
+  state: WorkshopSessionStateV1;
+  migrations: WorkshopSessionHydrationMigration[];
+}
+
+export function migrateWorkshopSessionStateV1ForHydration(
+  state: WorkshopSessionStateV1
+): WorkshopSessionStateV1MigrationResult {
+  const migrations: WorkshopSessionHydrationMigration[] = [];
+  const withdrawalNeverShipped =
+    state.revisions.pendingExcerptWithdrawal === true
+    && state.shelvedExcerpt !== undefined;
+  const openSessionWithExcerpt =
+    state.scope === 'open'
+    && state.excerpt !== undefined;
+
+  if (withdrawalNeverShipped) {
+    migrations.push('restored-undelivered-withdrawal');
+  } else if (openSessionWithExcerpt) {
+    migrations.push('normalized-open-session-with-excerpt');
+  }
+  if (state.scope === undefined) {
+    migrations.push('inferred-missing-scope');
+  }
+  if (
+    state.revisions.pendingExcerptChange !== undefined
+    || state.revisions.pendingExcerptWithdrawal !== undefined
+  ) {
+    migrations.push('discarded-legacy-scope-transition');
+  }
+
+  const excerpt = withdrawalNeverShipped
+    ? state.shelvedExcerpt
+    : state.excerpt;
+  const shelvedExcerpt = withdrawalNeverShipped
+    ? undefined
+    : state.shelvedExcerpt;
+  const scope = withdrawalNeverShipped || openSessionWithExcerpt
+    ? 'excerpt'
+    : state.scope ?? (excerpt ? 'excerpt' : null);
+  const revisions = { ...state.revisions };
+  delete revisions.pendingExcerptChange;
+  delete revisions.pendingExcerptWithdrawal;
+
+  return {
+    state: {
+      ...state,
+      excerpt,
+      scope,
+      shelvedExcerpt,
+      revisions
+    },
+    migrations
+  };
+}

--- a/packages/core/src/application/services/workshop/WorkshopSessionStateV1Shape.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionStateV1Shape.ts
@@ -199,6 +199,8 @@ function assertRevisions(value: unknown): void {
     ['excerpt', 'replacementCount', 'context'],
     [
       'pendingExcerpt',
+      // Legacy, retired by ADR 2026-07-25. Still accepted so pre-lock
+      // checkpoints parse; discarded on hydrate, never written again.
       'pendingExcerptChange',
       'pendingExcerptWithdrawal',
       'pendingContext'

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -63,7 +63,6 @@ import { WorkshopSessionsMenu } from './components/workshop/WorkshopSessionsMenu
 import { WorkshopPathChooser } from './components/workshop/WorkshopPathChooser';
 import { WorkshopScopeStrip } from './components/workshop/WorkshopScopeStrip';
 import {
-  WorkshopExcerptAdoptedNotice,
   WorkshopOpenChatStart
 } from './components/workshop/WorkshopOpenChatStart';
 import {
@@ -989,7 +988,7 @@ export const WorkshopApp: React.FC = () => {
               scope={workshop.scope}
               hostLabel={activePersona.label}
               isRunning={roomMutationLocked}
-              locked={workshop.hasHostConversation}
+              locked={workshop.roomHasMemory}
               onOpenPasteSheet={openPasteSheet}
               onChooseFile={openExcerptSelector}
               onRereadFile={workshop.rereadExcerpt}
@@ -1108,16 +1107,11 @@ export const WorkshopApp: React.FC = () => {
                 <WorkshopScopeStrip
                   scope={workshop.scope}
                   hostLabel={activePersona.label}
-                  excerptTitle={
-                    workshop.excerpt ? workshopExcerptTitle(workshop.excerpt.source) : undefined
-                  }
-                  excerptVersion={workshop.excerpt?.version}
+                  roomHasMemory={workshop.roomHasMemory}
                   shelvedExcerptTitle={shelvedExcerptTitle}
                   shelvedExcerptVersion={workshop.shelvedExcerpt?.version}
-                  withdrawalPending={workshop.excerptWithdrawalPending}
                   disabled={roomMutationLocked}
                   onAddExcerpt={addExcerptByPaste}
-                  onSetAside={startOpenConversation}
                   onRepinExcerpt={workshop.repinExcerpt}
                 />
               )}
@@ -1185,17 +1179,6 @@ export const WorkshopApp: React.FC = () => {
                 onCopy={copyTurn}
                 onSave={saveTurn}
               />
-
-              {/* §10: the scope divider is a real turn in the ledger; this is
-                  the block that follows it and answers "did I lose the
-                  conversation?". Shown only while it is the newest thing that
-                  happened, so it reads as an event rather than a banner. */}
-              {workshop.scope === 'open'
-                && !!workshop.excerpt
-                && workshop.turns.at(-1)?.artifact === 'scope_change'
-                && !showLiveTurn && (
-                  <WorkshopExcerptAdoptedNotice hostLabel={activePersona.label} />
-                )}
 
               {showLiveTurn && (
                 workshop.streamingChunkCount === 0 ? (
@@ -1293,6 +1276,7 @@ export const WorkshopApp: React.FC = () => {
               canMessage={workshop.canMessage && !roomMutationLocked}
               scope={workshop.scope}
               hasExcerpt={hasExcerpt}
+              roomHasMemory={workshop.roomHasMemory}
               draftSeed={draftSeed}
               onAddExcerpt={addExcerptByPaste}
               onGatedAction={announceGate}

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -988,7 +988,7 @@ export const WorkshopApp: React.FC = () => {
               scope={workshop.scope}
               hostLabel={activePersona.label}
               isRunning={roomMutationLocked}
-              locked={workshop.roomHasMemory}
+              roomHasMemory={workshop.roomHasMemory}
               onOpenPasteSheet={openPasteSheet}
               onChooseFile={openExcerptSelector}
               onRereadFile={workshop.rereadExcerpt}

--- a/packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx
@@ -36,6 +36,9 @@ import {
   workshopExcerptTitle
 } from '@messages';
 import { PROMPT_BUDGETS } from '@shared/constants/promptBudgets';
+import {
+  WORKSHOP_SCOPE_LOCK_RECOVERY_MESSAGE
+} from '@shared/constants/workshopScope';
 
 export const EXCERPT_WORD_BUDGET = PROMPT_BUDGETS.fileExcerpt.words;
 
@@ -55,7 +58,7 @@ interface ExcerptPanelProps {
    * the passage makes it live just as the host does — and, per ADR
    * 2026-07-25, settles the session path: the reversals below disappear.
    */
-  locked: boolean;
+  roomHasMemory: boolean;
   /** Open the shared Edit/Preview sheet to paste or type the passage. */
   onOpenPasteSheet: () => void;
   /** Ask the host to open its file picker and set the chosen file's content. */
@@ -102,7 +105,7 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
   scope,
   hostLabel,
   isRunning,
-  locked,
+  roomHasMemory,
   onOpenPasteSheet,
   onChooseFile,
   onRereadFile,
@@ -129,7 +132,7 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
             <Icon name="doc" size={14} /> No excerpt yet
           </div>
           <div className="pm-ws-no-excerpt-desc">
-            {locked
+            {roomHasMemory
               ? `${hostLabel} hasn’t read any pages, and this conversation has started without them. Context attachments below still ride along with every message.`
               : `${hostLabel} hasn’t read any pages. Add one whenever you’re ready — this conversation stays, and the session keeps its history. Context attachments below still ride along with every message.`}
           </div>
@@ -137,13 +140,12 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
               the host has been answering without one (ADR 2026-07-25). The
               card stops offering and names the way out instead — a new
               session carries the excerpt and context across. */}
-          {locked ? (
+          {roomHasMemory ? (
             <div className="pm-ws-no-excerpt-desc pm-ws-no-excerpt-locked">
-              {'Start a new session to work on a passage. Your excerpt'
-                + (shelvedExcerpt && shelvedTitle
-                  ? ` (${shelvedTitle} v${shelvedExcerpt.version})`
-                  : '')
-                + ' and context attachments carry over.'}
+              {WORKSHOP_SCOPE_LOCK_RECOVERY_MESSAGE}
+              {shelvedExcerpt && shelvedTitle
+                ? ` Set-aside passage: ${shelvedTitle} v${shelvedExcerpt.version}.`
+                : ''}
             </div>
           ) : (
             <>
@@ -264,7 +266,7 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
           <Icon name="doc" size={12} /> Excerpt
         </div>
         <span className="pm-ws-pill">Excerpt · v{excerpt.version}</span>
-        {locked ? <span className="pm-ws-pill pm-ws-pill-lock">Session live</span> : null}
+        {roomHasMemory ? <span className="pm-ws-pill pm-ws-pill-lock">Session live</span> : null}
       </div>
 
       <div className="pm-ws-provenance">{sourceLine(excerpt.source)}</div>
@@ -277,7 +279,7 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
         </p>
       )}
       <div className="pm-ws-excerpt-actions">
-        {locked && fileBacked ? (
+        {roomHasMemory && fileBacked ? (
           <button
             className="pm-ws-action-btn"
             type="button"
@@ -295,14 +297,14 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
               disabled={isRunning}
               onClick={onOpenPasteSheet}
               title={
-                locked
+                roomHasMemory
                   ? 'Replace the excerpt text; the room keeps its memory and sees a new version'
                   : undefined
               }
             >
-              <Icon name="pen" size={12} /> {locked ? 'Update text…' : 'Paste or type'}
+              <Icon name="pen" size={12} /> {roomHasMemory ? 'Update text…' : 'Paste or type'}
             </button>
-            {locked ? null : (
+            {roomHasMemory ? null : (
               <button
                 className="pm-ws-action-btn"
                 type="button"
@@ -321,10 +323,9 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
           {hostLabel} has read the passage, un-reading it is not something the
           product can honestly deliver, so the reversal becomes a new session
           (ADR 2026-07-25, superseding Sprint 13A §4). */}
-      {locked ? (
+      {roomHasMemory ? (
         <div className="pm-ws-excerpt-locked-note">
-          Start a new session to chat without this passage — it stays on the shelf, and your
-          context attachments carry over.
+          {WORKSHOP_SCOPE_LOCK_RECOVERY_MESSAGE}
         </div>
       ) : (
         <button

--- a/packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/ExcerptPanel.tsx
@@ -49,7 +49,12 @@ interface ExcerptPanelProps {
   hostLabel: string;
   /** Disables intake while a run is in flight (host guards too). */
   isRunning: boolean;
-  /** True once the host conversation exists — switches to locked affordances. */
+  /**
+   * True once ANY participant holds a conversation (the room has a memory).
+   * Switches the excerpt to its locked affordances — a tool sidecar that read
+   * the passage makes it live just as the host does — and, per ADR
+   * 2026-07-25, settles the session path: the reversals below disappear.
+   */
   locked: boolean;
   /** Open the shared Edit/Preview sheet to paste or type the passage. */
   onOpenPasteSheet: () => void;
@@ -124,41 +129,57 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
             <Icon name="doc" size={14} /> No excerpt yet
           </div>
           <div className="pm-ws-no-excerpt-desc">
-            {hostLabel} hasn’t read any pages. Add one whenever you’re ready — this conversation
-            stays, and the session keeps its history. Context attachments below still ride along
-            with every message.
+            {locked
+              ? `${hostLabel} hasn’t read any pages, and this conversation has started without them. Context attachments below still ride along with every message.`
+              : `${hostLabel} hasn’t read any pages. Add one whenever you’re ready — this conversation stays, and the session keeps its history. Context attachments below still ride along with every message.`}
           </div>
-          <div className="pm-ws-excerpt-actions">
-            <button
-              className="pm-ws-action-btn pm-ws-action-btn-grow"
-              type="button"
-              disabled={isRunning}
-              onClick={onOpenPasteSheet}
-            >
-              <Icon name="pen" size={13} /> Paste or type
-            </button>
-            <button
-              className="pm-ws-action-btn pm-ws-action-btn-grow"
-              type="button"
-              disabled={isRunning}
-              onClick={onChooseFile}
-            >
-              <Icon name="doc" size={13} /> From project…
-            </button>
-          </div>
-          {shelvedExcerpt && shelvedTitle ? (
-            <div className="pm-ws-excerpt-actions">
-              <button
-                className="pm-ws-action-btn pm-ws-action-btn-grow"
-                type="button"
-                disabled={isRunning}
-                onClick={onRepinExcerpt}
-                title="Bring the passage you set aside back into this conversation"
-              >
-                <Icon name="pin" size={13} /> Re-pin {shelvedTitle} v{shelvedExcerpt.version}
-              </button>
+          {/* Adding a passage is a path change, and the path is settled once
+              the host has been answering without one (ADR 2026-07-25). The
+              card stops offering and names the way out instead — a new
+              session carries the excerpt and context across. */}
+          {locked ? (
+            <div className="pm-ws-no-excerpt-desc pm-ws-no-excerpt-locked">
+              {'Start a new session to work on a passage. Your excerpt'
+                + (shelvedExcerpt && shelvedTitle
+                  ? ` (${shelvedTitle} v${shelvedExcerpt.version})`
+                  : '')
+                + ' and context attachments carry over.'}
             </div>
-          ) : null}
+          ) : (
+            <>
+              <div className="pm-ws-excerpt-actions">
+                <button
+                  className="pm-ws-action-btn pm-ws-action-btn-grow"
+                  type="button"
+                  disabled={isRunning}
+                  onClick={onOpenPasteSheet}
+                >
+                  <Icon name="pen" size={13} /> Paste or type
+                </button>
+                <button
+                  className="pm-ws-action-btn pm-ws-action-btn-grow"
+                  type="button"
+                  disabled={isRunning}
+                  onClick={onChooseFile}
+                >
+                  <Icon name="doc" size={13} /> From project…
+                </button>
+              </div>
+              {shelvedExcerpt && shelvedTitle ? (
+                <div className="pm-ws-excerpt-actions">
+                  <button
+                    className="pm-ws-action-btn pm-ws-action-btn-grow"
+                    type="button"
+                    disabled={isRunning}
+                    onClick={onRepinExcerpt}
+                    title="Bring the passage you set aside back into this session"
+                  >
+                    <Icon name="pin" size={13} /> Re-pin {shelvedTitle} v{shelvedExcerpt.version}
+                  </button>
+                </div>
+              ) : null}
+            </>
+          )}
         </div>
       </div>
     );
@@ -296,29 +317,33 @@ export const ExcerptPanel: React.FC<ExcerptPanelProps> = ({
         )}
       </div>
 
-      {/* Passage → open, in both directions of the sprint's copy (§4). The
-          passage is SHELVED: the button says what happens to it, and the
-          sub-line says what happens to the host's claim on it. */}
-      <button
-        className="pm-ws-chat-entry pm-ws-chat-entry-mini"
-        type="button"
-        disabled={isRunning}
-        onClick={onSetAside}
-      >
-        <span className="pm-ws-chat-entry-icon">
-          <Icon name="dialogue" size={15} />
-        </span>
-        <span>
-          <span className="pm-ws-chat-entry-name">
-            {scope === 'open' ? 'Unpin — back to open conversation' : 'Set this aside — just chat'}
+      {/* Passage → open. Offered only before the room has a memory: once
+          {hostLabel} has read the passage, un-reading it is not something the
+          product can honestly deliver, so the reversal becomes a new session
+          (ADR 2026-07-25, superseding Sprint 13A §4). */}
+      {locked ? (
+        <div className="pm-ws-excerpt-locked-note">
+          Start a new session to chat without this passage — it stays on the shelf, and your
+          context attachments carry over.
+        </div>
+      ) : (
+        <button
+          className="pm-ws-chat-entry pm-ws-chat-entry-mini"
+          type="button"
+          disabled={isRunning}
+          onClick={onSetAside}
+        >
+          <span className="pm-ws-chat-entry-icon">
+            <Icon name="dialogue" size={15} />
           </span>
-          <span className="pm-ws-chat-entry-sub">
-            {scope === 'open'
-              ? `Shelves the passage and keeps this conversation. ${hostLabel} stops treating it as read.`
-              : `Keeps the passage on the shelf. ${hostLabel} stops treating it as read.`}
+          <span>
+            <span className="pm-ws-chat-entry-name">Set this aside — just chat</span>
+            <span className="pm-ws-chat-entry-sub">
+              Keeps the passage on the shelf. {hostLabel} has not read it yet.
+            </span>
           </span>
-        </span>
-      </button>
+        </button>
+      )}
     </div>
   );
 };

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopComposer.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopComposer.tsx
@@ -44,6 +44,11 @@ interface WorkshopComposerProps {
   scope: WorkshopSessionScope;
   /** True when a passage is pinned; the ONLY thing that unlocks analysis tools. */
   hasExcerpt: boolean;
+  /**
+   * The scope lock (ADR 2026-07-25). Once the room has a memory the path is
+   * settled, so the composer's door into the passage path closes.
+   */
+  roomHasMemory: boolean;
   /** Prefill requested from outside (an open-chat starter chip); appended once. */
   draftSeed?: { text: string; token: number };
   /** Open the shared Edit/Preview sheet to add an excerpt mid-conversation. */
@@ -93,6 +98,7 @@ export const WorkshopComposer: React.FC<WorkshopComposerProps> = ({
   canMessage,
   scope,
   hasExcerpt,
+  roomHasMemory,
   draftSeed,
   onAddExcerpt,
   onGatedAction,
@@ -192,15 +198,16 @@ export const WorkshopComposer: React.FC<WorkshopComposerProps> = ({
   }, [draftSeed]);
 
   const openWithoutExcerpt = scope === 'open' && !hasExcerpt;
+  // The passage path is only reachable from here while nobody has been
+  // prompted yet; after that it is a new session, not a button.
+  const canAddExcerpt = openWithoutExcerpt && !roomHasMemory;
   const placeholder = scope === null
     ? 'Pick a starting path above to begin…'
     : openWithoutExcerpt
       ? `What would you like to brainstorm with ${recipientLabel}?`
       : hasConversation
         ? `Continue with ${recipientLabel}…`
-        : scope === 'open'
-          ? `Message ${recipientLabel} — excerpt now attached…`
-          : `Message ${recipientLabel} about this excerpt…`;
+        : `Message ${recipientLabel} about this excerpt…`;
 
   return (
     <div className="pm-ws-composer-wrap">
@@ -279,10 +286,11 @@ export const WorkshopComposer: React.FC<WorkshopComposerProps> = ({
           placeholder={placeholder}
           aria-label={`Message ${recipientLabel}`}
         />
-        {openWithoutExcerpt && (
+        {canAddExcerpt && (
           /* The composer's own door into the passage path (§4). It sits beside
              the attach button rather than in the action cluster, because it
-             changes what the room IS, not how this one message is sent. */
+             changes what the room IS, not how this one message is sent — which
+             is also why it closes once the room has a memory. */
           <button
             className="pm-ws-comp-add-excerpt"
             type="button"

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopOpenChatStart.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopOpenChatStart.tsx
@@ -56,25 +56,3 @@ export const WorkshopOpenChatStart: React.FC<WorkshopOpenChatStartProps> = ({
     </div>
   </div>
 );
-
-interface WorkshopExcerptAdoptedNoticeProps {
-  hostLabel: string;
-}
-
-/**
- * The "scope changed" block that follows the excerpt-added divider (§10). It
- * exists to answer the question the transition raises: did I just lose the
- * conversation? No — and it says which things changed instead.
- */
-export const WorkshopExcerptAdoptedNotice: React.FC<WorkshopExcerptAdoptedNoticeProps> = ({
-  hostLabel
-}) => (
-  <div className="pm-ws-open-start">
-    <div className="pm-ws-open-start-kicker">Scope changed</div>
-    <h3>{hostLabel} can read the passage now.</h3>
-    <p>
-      Everything you’ve said so far is still here. Analysis tools have unlocked on the left, and
-      the excerpt stays pinned while the conversation continues.
-    </p>
-  </div>
-);

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopScopeStrip.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopScopeStrip.tsx
@@ -4,9 +4,11 @@
  *
  * The room says out loud what it is. In open chat that includes the part the
  * writer most needs to know and a persona can least be trusted to volunteer:
- * "<Host> hasn't read any pages." When an excerpt arrives the same strip flips
- * to the passage treatment and names the version, so the transition is legible
- * without scrolling the transcript.
+ * "<Host> hasn't read any pages."
+ *
+ * Since ADR 2026-07-25 an open conversation stays open — it can gain an
+ * excerpt only before anyone has been prompted — so this strip describes ONE
+ * state and offers its path change only while the room has no memory.
  */
 
 import * as React from 'react';
@@ -16,70 +18,39 @@ import { Icon } from '@components/shared/Icon';
 interface WorkshopScopeStripProps {
   /**
    * The session's declared scope (Sprint 13A §1). This strip states what the
-   * session IS from `scope` alone — `excerptTitle` says only what is currently
-   * pinned, and a missing excerpt never means "open conversation" here any
-   * more than it does anywhere else in the room.
+   * session IS from `scope` alone — never from excerpt presence.
    */
   scope: WorkshopSessionScope;
   hostLabel: string;
-  /** The pinned passage's display title, when one is pinned. */
-  excerptTitle?: string;
-  excerptVersion?: number;
+  /**
+   * The scope lock (ADR 2026-07-25). Once the room has a memory the path is
+   * settled, so the strip becomes purely declarative.
+   */
+  roomHasMemory: boolean;
   /** The set-aside passage, when one is on the shelf. */
   shelvedExcerptTitle?: string;
   shelvedExcerptVersion?: number;
-  /**
-   * True while a shelved passage still has to be withdrawn from the retained
-   * host. Until that lands, "hasn't read any pages" would be false — the host
-   * read them and has not yet been told to stop.
-   */
-  withdrawalPending?: boolean;
   /** Blocked while a run or session operation holds the room. */
   disabled: boolean;
   onAddExcerpt: () => void;
-  onSetAside: () => void;
-  /** Bring the set-aside passage back without leaving the open conversation. */
+  /** Bring the set-aside passage back. Pre-lock only. */
   onRepinExcerpt: () => void;
 }
 
 export const WorkshopScopeStrip: React.FC<WorkshopScopeStripProps> = ({
   scope,
   hostLabel,
-  excerptTitle,
-  excerptVersion,
+  roomHasMemory,
   shelvedExcerptTitle,
   shelvedExcerptVersion,
-  withdrawalPending = false,
   disabled,
   onAddExcerpt,
-  onSetAside,
   onRepinExcerpt
 }) => {
-  if (excerptTitle !== undefined && excerptVersion !== undefined) {
-    return (
-      <div className="pm-ws-scope-strip pm-ws-scope-strip-passage" role="status">
-        <span className="pm-ws-scope-dot" aria-hidden="true" />
-        <span className="pm-ws-scope-text">
-          Passage session · {excerptTitle} v{excerptVersion}
-        </span>
-        <span className="pm-ws-scope-note">Analysis tools available</span>
-        <button
-          className="pm-ws-scope-btn"
-          type="button"
-          disabled={disabled}
-          onClick={onSetAside}
-          title="Set the passage aside and keep this conversation"
-        >
-          <Icon name="dialogue" size={13} /> Unpin excerpt
-        </button>
-      </div>
-    );
-  }
-
-  // The empty branch describes an OPEN conversation, and it is chosen by scope
-  // — never by a missing excerpt. A passage session with nothing pinned is not
-  // a state this strip can honestly describe, so it renders nothing rather
-  // than announcing the wrong session (Sprint 13A §1).
+  // The strip describes an OPEN conversation, and it is chosen by scope — never
+  // by a missing excerpt. A passage session is not a state this strip can
+  // honestly describe, so it renders nothing rather than announcing the wrong
+  // session (Sprint 13A §1).
   if (scope !== 'open') {
     return null;
   }
@@ -91,39 +62,42 @@ export const WorkshopScopeStrip: React.FC<WorkshopScopeStripProps> = ({
       <span className="pm-ws-scope-dot" aria-hidden="true" />
       <span className="pm-ws-scope-text">Open conversation · No excerpt yet</span>
       <span className="pm-ws-scope-note">
-        {withdrawalPending
-          ? `${hostLabel} still has the passage you set aside until your next message`
+        {roomHasMemory
+          ? `${hostLabel} hasn’t read any pages — start a new session to work on a passage`
           : `${hostLabel} hasn’t read any pages`}
       </span>
-      {/* With a passage on the shelf, re-pinning is the non-destructive route
-          back and it belongs beside the button that would replace it. Without
-          this, "Add excerpt" was the only affordance here and it discards the
-          set-aside passage (§4: the strip gets the re-pin the rail already
-          had). */}
-      {hasShelf ? (
-        <button
-          className="pm-ws-scope-btn"
-          type="button"
-          disabled={disabled}
-          onClick={onRepinExcerpt}
-          title="Bring the passage you set aside back into this conversation"
-        >
-          <Icon name="pin" size={13} /> Re-pin {shelvedExcerptTitle} v{shelvedExcerptVersion}
-        </button>
-      ) : null}
-      <button
-        className="pm-ws-scope-btn"
-        type="button"
-        disabled={disabled}
-        onClick={onAddExcerpt}
-        title={
-          hasShelf
-            ? `Pin a different excerpt — replaces the set-aside ${shelvedExcerptTitle}`
-            : 'Add an excerpt to this session'
-        }
-      >
-        <Icon name="plus" size={13} /> Add excerpt
-      </button>
+      {/* Both affordances are pre-lock only. Once the host has been answering
+          without a passage, handing it one would make everything already said
+          ambiguous — so the strip stops offering and names the way out
+          instead (ADR 2026-07-25). */}
+      {roomHasMemory ? null : (
+        <>
+          {hasShelf ? (
+            <button
+              className="pm-ws-scope-btn"
+              type="button"
+              disabled={disabled}
+              onClick={onRepinExcerpt}
+              title="Bring the passage you set aside back into this session"
+            >
+              <Icon name="pin" size={13} /> Re-pin {shelvedExcerptTitle} v{shelvedExcerptVersion}
+            </button>
+          ) : null}
+          <button
+            className="pm-ws-scope-btn"
+            type="button"
+            disabled={disabled}
+            onClick={onAddExcerpt}
+            title={
+              hasShelf
+                ? `Pin a different excerpt — replaces the set-aside ${shelvedExcerptTitle}`
+                : 'Add an excerpt to this session'
+            }
+          >
+            <Icon name="plus" size={13} /> Add excerpt
+          </button>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopScopeStrip.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopScopeStrip.tsx
@@ -14,6 +14,9 @@
 import * as React from 'react';
 import { WorkshopSessionScope } from '@messages';
 import { Icon } from '@components/shared/Icon';
+import {
+  WORKSHOP_SCOPE_LOCK_RECOVERY_MESSAGE
+} from '@shared/constants/workshopScope';
 
 interface WorkshopScopeStripProps {
   /**
@@ -63,7 +66,7 @@ export const WorkshopScopeStrip: React.FC<WorkshopScopeStripProps> = ({
       <span className="pm-ws-scope-text">Open conversation · No excerpt yet</span>
       <span className="pm-ws-scope-note">
         {roomHasMemory
-          ? `${hostLabel} hasn’t read any pages — start a new session to work on a passage`
+          ? `${hostLabel} hasn’t read any pages. ${WORKSHOP_SCOPE_LOCK_RECOVERY_MESSAGE}`
           : `${hostLabel} hasn’t read any pages`}
       </span>
       {/* Both affordances are pre-lock only. Once the host has been answering

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
@@ -148,9 +148,10 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
   const capabilityMetadata = capabilityMetadataRows(turn);
   const turnIdentity = { [WORKSHOP_TURN_ID_ATTRIBUTE]: turn.id };
 
-  // Scope transitions get the accent divider (Sprint 13A §10): "same session,
-  // conversation retained" is the reassurance the writer needs to actually read,
-  // so it must not blend into the quiet session-boundary treatment.
+  // Legacy scope-transition dividers (retired by ADR 2026-07-25). No new ones
+  // are minted, but transcripts written before the scope lock hold them and
+  // they stay on the accent treatment they were written with — rewriting how
+  // past history looks would be its own small dishonesty.
   if (turn.artifact === 'scope_change') {
     return (
       <div className="pm-ws-revision-divider pm-ws-scope-divider" role="separator">

--- a/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
@@ -686,7 +686,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
       setExcerpt(session.excerpt ?? null);
       setScopeState(session.scope);
       setShelvedExcerpt(session.shelvedExcerpt ?? null);
-      setRoomHasMemory(session.hasConversation);
+      setRoomHasMemory(session.roomHasMemory);
       setContextAttachments(session.contextAttachments ?? []);
       setPendingMessageAttachments(session.pendingMessageAttachments ?? []);
       setContextPending(session.pendingHostUpdate?.context ?? false);

--- a/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
@@ -108,7 +108,12 @@ export interface WorkshopState {
   /** The passage set aside for an open conversation; re-pinnable, never deleted. */
   shelvedExcerpt: WorkshopExcerptSnapshot | null;
   /** True when a shelved passage still has to be withdrawn from the host. */
-  excerptWithdrawalPending: boolean;
+  /**
+   * The scope lock (ADR 2026-07-25): true once ANY participant holds a
+   * conversation. Every surface offering to change the session path must hide
+   * that offer once this is true and point at a new session instead.
+   */
+  roomHasMemory: boolean;
   /** Attachment bodies fetched on demand for the Edit/Preview sheet. */
   attachmentContent: WorkshopAttachmentContentState | null;
   contextAttachments: WorkshopContextAttachmentSnapshot[];
@@ -278,7 +283,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
   const [excerpt, setExcerpt] = React.useState<WorkshopExcerptSnapshot | null>(null);
   const [scope, setScopeState] = React.useState<WorkshopSessionScope>(null);
   const [shelvedExcerpt, setShelvedExcerpt] = React.useState<WorkshopExcerptSnapshot | null>(null);
-  const [excerptWithdrawalPending, setExcerptWithdrawalPending] = React.useState(false);
+  const [roomHasMemory, setRoomHasMemory] = React.useState(false);
   const [attachmentContent, setAttachmentContent] =
     React.useState<WorkshopAttachmentContentState | null>(null);
   const [contextAttachments, setContextAttachments] = React.useState<WorkshopContextAttachmentSnapshot[]>([]);
@@ -681,7 +686,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
       setExcerpt(session.excerpt ?? null);
       setScopeState(session.scope);
       setShelvedExcerpt(session.shelvedExcerpt ?? null);
-      setExcerptWithdrawalPending(session.pendingHostUpdate?.excerptWithdrawn === true);
+      setRoomHasMemory(session.hasConversation);
       setContextAttachments(session.contextAttachments ?? []);
       setPendingMessageAttachments(session.pendingMessageAttachments ?? []);
       setContextPending(session.pendingHostUpdate?.context ?? false);
@@ -907,7 +912,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
     excerpt,
     scope,
     shelvedExcerpt,
-    excerptWithdrawalPending,
+    roomHasMemory,
     attachmentContent,
     contextAttachments,
     pendingMessageAttachments,

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -3707,6 +3707,21 @@
 [data-pm-surface="workshop"] .pm-ws-no-excerpt .pm-ws-excerpt-actions {
   margin-top: 12px;
 }
+/* The locked-path signpost (ADR 2026-07-25). It replaces an affordance, so it
+   is given the inset treatment of a thing you can act on elsewhere rather than
+   the faint treatment of body copy — a dead end the writer cannot see the way
+   out of is the one failure this copy exists to prevent. */
+[data-pm-surface="workshop"] .pm-ws-no-excerpt-locked,
+[data-pm-surface="workshop"] .pm-ws-excerpt-locked-note {
+  margin-top: 11px;
+  padding: 9px 11px;
+  border: 1px solid var(--pm-border);
+  border-radius: 9px;
+  background: var(--pm-inset);
+  font-size: 11px;
+  color: var(--pm-dim);
+  line-height: 1.55;
+}
 [data-pm-surface="workshop"] .pm-ws-action-btn-grow {
   flex: 1;
   justify-content: center;

--- a/packages/core/src/shared/constants/workshopScope.ts
+++ b/packages/core/src/shared/constants/workshopScope.ts
@@ -1,0 +1,9 @@
+/**
+ * The single writer-facing recovery path for an immutable Workshop scope.
+ *
+ * Both the host-side refusal and the proactive webview signposts use this
+ * sentence so the product cannot offer two different exits from the same
+ * locked room.
+ */
+export const WORKSHOP_SCOPE_LOCK_RECOVERY_MESSAGE =
+  'Start a new session to change this — your excerpt and context carry over.';

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -795,7 +795,7 @@ export interface WorkshopSessionSnapshot {
    * `session_start` marker before the writer acts, so a turn-based test would
    * report a locked room the instant one was created.
    */
-  hasConversation: boolean;
+  roomHasMemory: boolean;
   /** The public participant graph. Conversation ids remain host-private. */
   participants: WorkshopParticipantsSnapshot;
   /** The room's current writer-owned conversation behavior (ADR 2026-07-20). */

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -42,14 +42,17 @@ export type WorkshopPersonaId =
   | 'wren';
 
 /**
- * How this Workshop session was started (Sprint 13A).
+ * How this Workshop session was started (Sprint 13A; locked by ADR 2026-07-25).
  *
  * `null` means the writer has not chosen a path yet — the center shows the path
  * chooser. Scope is ASSIGNED by an explicit writer action (choosing a path,
  * pinning an excerpt, running a tool), never DERIVED from excerpt presence at
- * read time: an open conversation that later adopts an excerpt stays `open`,
- * and a passage session whose excerpt is shelved stays `excerpt`-free without
- * pretending the writer asked for open chat.
+ * read time.
+ *
+ * It is also IMMUTABLE once the room has a memory: a session that has been
+ * talked to keeps the path it was started on, because changing it would mean
+ * asking a participant to un-read what it holds. Changing path means a new
+ * session, which carries the excerpt and context attachments across.
  */
 export type WorkshopSessionScope = 'excerpt' | 'open' | null;
 
@@ -418,9 +421,11 @@ export type WorkshopTurnArtifact =
   | 'session_start'
   | 'session_resume'
   /**
-   * A session-scope transition inside ONE retained session (Sprint 13A):
-   * excerpt adopted mid-open-chat, passage shelved, or passage re-pinned. The
-   * conversation is retained across it — this divider says so out loud.
+   * LEGACY (Sprint 13A, retired by ADR 2026-07-25). A mid-conversation
+   * session-scope transition. Scope is now immutable once the room has a
+   * memory, so no new turn of this artifact is ever minted — but real
+   * transcripts written before the lock contain them, and they must keep
+   * parsing and rendering as the history they are.
    */
   | 'scope_change';
 
@@ -772,8 +777,6 @@ export interface WorkshopSessionSnapshot {
     excerptVersion?: number;
     /** True when the attachment list changed since the host last saw it. */
     context: boolean;
-    /** True when a shelved passage still has to be withdrawn from the host. */
-    excerptWithdrawn?: boolean;
   };
   /** Host-owned, defensively copied writer task list in explicit order. */
   todos: WorkshopTodoItem[];
@@ -783,8 +786,14 @@ export interface WorkshopSessionSnapshot {
   /** Older turns omitted from this snapshot's window. */
   truncatedTurns: number;
   /**
-   * True when any retained host or tool-sidecar conversation remains live.
-   * Composer enablement also requires a ready, non-empty pinned excerpt.
+   * True when any participant holds a conversation — host, tool sidecar, or
+   * persona guest. This is ALSO the scope lock (ADR 2026-07-25): every surface
+   * that offers to change the session path must hide that offer once this is
+   * true, and point at a new session instead.
+   *
+   * Deliberately not "does the room have turns": every session records a
+   * `session_start` marker before the writer acts, so a turn-based test would
+   * report a locked room the instant one was created.
    */
   hasConversation: boolean;
   /** The public participant graph. Conversation ids remain host-private. */


### PR DESCRIPTION
Implements [ADR 2026-07-25](../blob/sprint/workshop-editor-tab-13a_2-scope-immutability/docs/adr/2026-07-25-workshop-scope-immutability.md). Supersedes Sprint 13A §4.

## Why

Sprint 13A made the session path reversible at any moment. The [PR #86 review](../blob/sprint/workshop-editor-tab-13a_2-scope-immutability/docs/pr-reviews/pr-86-open-chat-session-scope-review.md) found three defects — a blocking one plus two HIGH — and **all three lived in the machinery that reversibility requires**: telling a model to stop believing something it had already read.

Those were fixed in #86 by *deriving* the right answer. This PR removes the question. Findings #1 and #3 become unreachable by construction rather than correct by computation.

It also fixes the confusion that prompted it: a session 54k tokens deep, where the host had demonstrably read the passage, still offered **two separate buttons** to un-read it.

## The lock

Scope is chosen freely while no conversation exists and is fixed once any participant — host, tool sidecar, or persona guest — holds one.

**The predicate is "any conversation exists", not "any turn exists", and that is load-bearing.** `resetSession()` records a `session_start` marker and `resumeSession()` a `session_resume`, so **every session holds a turn before the writer acts**. A turn-based lock would fire on session creation and strand the writer on the path chooser with no way to choose anything. `recordSessionMarker` never touches `participants`, so no temporal frame can move the lock — under test, and that test protects every future ledger-only event.

A tool run *does* lock (a sidecar genuinely read the passage). A first message that fails and leaves no conversation does **not**.

## Deleted

| Mechanism | Why it can't happen |
|---|---|
| `pendingExcerptWithdrawal` + the withdrawal frame | Nothing to withdraw from a host that hasn't read |
| `WorkshopExcerptDeliveryReason` (whole union) | Every surviving delivery is a revision |
| Mid-conversation `scope_change` divider + `WorkshopScopeTransition.dividerTurn` | A pre-memory transition is invisible to everyone |
| The open-conversation-with-an-excerpt hybrid | Pinning makes it a passage session, full stop |
| `WorkshopExcerptAdoptedNotice` | Announced a state that cannot occur |

`hostDeliveredExcerptVersion()` is **kept** — the honest answer to "what does the host hold", and still the guard against queueing a revision to a host never handed the original.

## Migration

Live checkpoints are tolerated, not rejected. `pendingExcerptChange` / `pendingExcerptWithdrawal` stay in the V1 grammar (the shape validator rejects unknown fields, so removing them would fail a real session open), are discarded on hydrate, and never written again. Their integrity checks go too — asserting consistency between fields we're about to throw away would reject files we promised to accept.

One real normalization: a checkpoint whose withdrawal **never shipped** means the host still holds the passage, so the room is restored to agree with what the host believes rather than with a reversal that never took effect. A withdrawal that *did* ship leaves an already-consistent room untouched. Both under test.

`scope_change` turns stay parseable and renderable, with their original accent treatment — real transcripts hold them, and restyling past history would be its own small dishonesty.

## Surfaces

Every disappearing affordance is replaced by the way out, never by silence: *"Start a new session to change this — your excerpt and context carry over."* The rail's signpost **names the set-aside passage** so the writer doesn't lose track of it.

`ExcerptPanel`'s `locked` now keys off room memory rather than the host conversation alone — a tool sidecar that read the passage makes it live just as the host does.

## Also fixed

`WorkshopHandler.replaceExcerpt` returns a boolean and routes refusals through `sendError`. The aggregate's throw previously escaped to the IPC boundary as an unhandled rejection — so a refusal that names its own recovery path reached nobody. Caught by a new test.

## Verification

- 127 suites / **1,338 tests** green
- `tsc --noEmit` clean on core, webview, and adapter
- `npm run lint` — 0 errors
- Superseded tests **removed rather than adapted**; survivors assert the refusal, which is the stronger claim

## Not done here

- Conversation forking — rejected in the ADR; the intended answer is [prior-conversation-as-resource](../blob/sprint/workshop-editor-tab-13a_2-scope-immutability/.todo/features/feature-prior-conversation-as-resource/README.md)
- God-file decomposition — [tracked](../blob/sprint/workshop-editor-tab-13a_2-scope-immutability/.todo/tech-debt/2026-07-25-workshop-god-files.md). This PR shrinks both by deletion, which is a side effect, not the goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)