### PR TITLE
Open Workshop rooms to persona guests

### DIFF
--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13-open-chat-guest-room-polish.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13-open-chat-guest-room-polish.md
@@ -1,6 +1,6 @@
 # Sprint 13 Delivery Plan: Open Chat, Guest Agency, and Room Polish
 
-**Status**: Planned — split into reviewable implementation sprints 13A–13D
+**Status**: Sprints 13A–13D merged; 13D_2 implementation complete with manual smoke pending
 **Priority**: High — release-polish work that makes Workshop useful before a
 writer has an excerpt and makes the participant room behave as it looks
 **Implementation branches**: one branch and PR per child sprint, all into
@@ -44,6 +44,7 @@ rollback needlessly opaque. Deliver them in order:
 | [13B](13b-run-local-analysis.md) | `sprint/workshop-editor-tab-13b-run-local-analysis` | Persona-chosen analysis inputs: per-input excerpt/context modes, prefilled asks, no writer picker. | 13A | In a non-excerpt session the host can run Stock & Signature on a passage it supplies, with the room unchanged. |
 | [13C](13c-guest-agency.md) | `sprint/workshop-editor-tab-13c-guest-agency` | Deliberate guest read-in plus participant-owned bounded capabilities. | 13A | Selecting a guest spends nothing; one explicit submit creates one guest that can use attributable, private instruments. |
 | [13D](13d-room-catchup-release-polish.md) | `sprint/workshop-editor-tab-13d-room-catchup-release-polish` | One room ledger with per-participant delivery offsets, a single delivery site, atomic turns, and final release validation. | 13C | Guest B receives Guest A's eligible unseen exchange without a hidden host call, a skipped turn, or a split quote. |
+| [13D_2](13d_2-open-room-participants.md) | `sprint/workshop-editor-tab-13d_2-open-room-participants` | Open-room persona guests, lifecycle-only catch-up status, and participant-owned context copy. | 13D | An excerpt-free room can invite and continue with a truthful guest without mislabeling its session marker as conversational catch-up. |
 
 13B and 13C may proceed after 13A, but 13D starts only after the guest
 ownership contract in 13C lands. If capability ownership proves materially
@@ -82,9 +83,9 @@ project. Sprints link the comp; they never re-sync or fork it.
 - Excerpt-dependent tools and excerpt-scoped capability operations stay
   unavailable in open chat. A writer may add an excerpt later; that is a
   visible, retained-conversation context transition, not a new session.
-- The first slice permits the chosen host in open chat. Guest invitation in an
-  excerpt-free room is deferred unless the guest join prompt can make the same
-  no-excerpt honesty guarantee without widening this sprint.
+- The first slice permits the chosen host in open chat. Guest invitation was
+  initially deferred; [Sprint 13D_2](13d_2-open-room-participants.md) supplies
+  the no-excerpt honesty envelope and opens the room to persona guests.
 
 ### The persona chooses a tool run's inputs; the writer just asks
 

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a-open-chat.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13a-open-chat.md
@@ -111,7 +111,9 @@ is persisted and surfaced in restore/browser metadata.
 
 ## Explicit non-goals
 
-- No guest invitation in an excerpt-free room.
+- No guest invitation in an excerpt-free room in 13A. This temporary boundary
+  is superseded by [Sprint 13D_2](13d_2-open-room-participants.md), which adds
+  the required no-excerpt guest honesty envelope.
 - No tool eligibility via a blank, fabricated, or implied excerpt.
 - No guest capability or room-catch-up changes.
 - No tool redesign — gating only.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13d_2-open-room-participants.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13d_2-open-room-participants.md
@@ -1,0 +1,70 @@
+# Sprint 13D_2: Open Room Participants
+
+**Status**: Implementation complete — manual Extension Development Host smoke pending
+**Priority**: High
+**Branch**: `sprint/workshop-editor-tab-13d_2-open-room-participants` -> PR into `epic/workshop-editor-tab`
+**Depends on**: Sprint 13D / PR #90
+**Parent**: [Sprint 13 delivery plan](13-open-chat-guest-room-polish.md)
+**Governed by**: [ADR 2026-07-26 — Workshop Open Rooms Admit Persona Guests](../../../../docs/adr/2026-07-26-workshop-open-room-participants.md)
+**Design load**: Low — existing invitation, scope, and context-meter surfaces
+
+## Goal
+
+Finish the open-room participant contract: let the writer invite and continue
+with persona guests without an excerpt, keep the guest's initial context
+truthful and symmetric with the host, and remove two misleading pieces of
+composer status copy.
+
+## Scope
+
+### Open the open room
+
+- Show **Invite guest** in a ready open conversation even when no excerpt is
+  pinned.
+- Admit host and persona-guest messages through one aggregate subject guard:
+  open scope or a valid excerpt.
+- Keep direct tool sidecars and writer-launched analysis tools excerpt-gated.
+- Build guest joins with the bounded room snapshot, either the pinned excerpt
+  or the open-conversation honesty frame, and the current standing context.
+- Seed the retained guest's context-source manifest with exactly the pin and/or
+  standing attachments delivered at join.
+
+### Fix lifecycle-only catch-up copy
+
+- Keep session-start and session-resume markers in the room ledger.
+- Do not show `Catching <participant> up on the room…` when those markers are
+  the only pending delivery.
+- Preserve that copy for actual unseen writer, participant, tool-report, or
+  context-change turns.
+
+### Name the context owner
+
+- In an excerpt-free open room, show the active participant's name in the
+  context meter (for example, `Jill`).
+- Leave the no-excerpt explanation to the existing header and scope strip.
+
+## Exit criteria
+
+- [x] A writer can invite a persona guest from an open room.
+- [x] The guest join prompt says no excerpt was provided and includes standing
+  context without pretending it is a passage.
+- [x] The guest can continue in that open room and use capabilities that are
+  valid without an excerpt.
+- [x] Direct tool sidecars remain unavailable without an excerpt.
+- [x] A session lifecycle marker alone uses ordinary streaming/continuation
+  status, while real pending room activity still uses catch-up status.
+- [x] The open-room context meter identifies the active participant without
+  repeating `No excerpt yet`.
+- [x] Focused tests, typecheck, lint, architecture checks, and the full suite
+  pass.
+
+## Verification
+
+- Focused Workshop contract: 267 tests passed.
+- Full Jest suite: 1,443 tests passed across 133 suites; snapshot passed.
+- `npm run typecheck`: passed for core, webview, and extension.
+- `npm run lint`: passed with the repository's existing warnings and no errors.
+- `npm run build`: production extension/webview bundles compiled and bundle
+  sentinel verification passed; webpack reported only its existing size
+  warnings.
+- `git diff --check`: passed.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13d_2-open-room-participants.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13d_2-open-room-participants.md
@@ -1,6 +1,6 @@
 # Sprint 13D_2: Open Room Participants
 
-**Status**: Implementation complete — manual Extension Development Host smoke pending
+**Status**: Complete — Extension Development Host smoke performed
 **Priority**: High
 **Branch**: `sprint/workshop-editor-tab-13d_2-open-room-participants` -> PR into `epic/workshop-editor-tab`
 **Depends on**: Sprint 13D / PR #90
@@ -69,3 +69,10 @@ composer status copy.
   sentinel verification passed; webpack reported only its existing size
   warnings.
 - `git diff --check`: passed.
+- Extension Development Host smoke exercised open-room invitation, target
+  switching, and the bare participant context label. The smoke exposed a
+  five-slot identity-dot collision; the final fix gives all twelve canonical
+  personas distinct stable slots and is covered by component/utility tests.
+- Final re-review hardening makes the guest join writer-source snapshot a
+  required adoption input; missing provenance can no longer silently become an
+  empty manifest.

--- a/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13d_2-open-room-participants.md
+++ b/.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13d_2-open-room-participants.md
@@ -60,8 +60,9 @@ composer status copy.
 
 ## Verification
 
-- Focused Workshop contract: 267 tests passed.
-- Full Jest suite: 1,443 tests passed across 133 suites; snapshot passed.
+- Focused Workshop contract after PR #91 review fixes: 308 tests passed.
+- Full Jest suite after PR #91 review fixes: 1,446 tests passed across 133
+  suites; snapshot passed.
 - `npm run typecheck`: passed for core, webview, and extension.
 - `npm run lint`: passed with the repository's existing warnings and no errors.
 - `npm run build`: production extension/webview bundles compiled and bundle

--- a/.todo/features/feature-workshop-participant-identity-colors/README.md
+++ b/.todo/features/feature-workshop-participant-identity-colors/README.md
@@ -1,0 +1,47 @@
+# Feature: Workshop Participant Identity Colors
+
+**Status**: Proposed
+**Priority**: Low
+**Date**: 2026-07-26
+**Origin**: PR #91 Extension Development Host smoke test
+**Related**: [Workshop Participant Rail](../feature-workshop-participant-rail/README.md)
+
+## Problem / Motivation
+
+Workshop assigns every persona a stable, collision-free identity-dot color,
+but the color currently stops at the context-budget dot. A participant's
+response-card border and corner name use shared neutral styling, so the
+identity signal does not carry through the conversation itself.
+
+Extending the same identity token would make multi-persona threads easier to
+scan without changing participant semantics or relying on color alone.
+
+## Proposal
+
+- Reuse the canonical participant identity-color slot for:
+  - the context-budget identity dot;
+  - the participant response-card border or border accent;
+  - the participant name in the response-card corner.
+- Keep the written participant name and existing participant icon so color is
+  supplementary, never the only identity cue.
+- Apply color through the shared `--pm-identity-*` tokens; do not duplicate the
+  palette or derive identity from display copy inside response components.
+- Preserve the current stable roster mapping across renders and reloads.
+
+## Related Files
+
+- `packages/core/src/presentation/webview/utils/contextBudget.ts`
+- `packages/core/src/presentation/webview/components/shared/ContextBudget.tsx`
+- Workshop response-card component and stylesheet
+
+## Completion Criteria
+
+- [ ] A participant uses the same deterministic color in its context dot,
+      response-card border treatment, and corner name.
+- [ ] Host and guest cards receive the same treatment from the same identity
+      mapping.
+- [ ] Labels remain visible, so participant identity never depends on color
+      perception.
+- [ ] Dark-theme contrast is checked for all twelve palette slots without
+      making borders visually louder than response content.
+- [ ] Component tests prove card accents and dots resolve to the same slot.

--- a/docs/adr/2026-07-26-workshop-open-room-participants.md
+++ b/docs/adr/2026-07-26-workshop-open-room-participants.md
@@ -42,9 +42,12 @@ An unchosen `scope: null` remains invalid. Direct tool sidecars and
 writer-launched analysis tools remain excerpt-gated. This change does not make
 a blank `WorkshopExcerpt` legal and does not widen filesystem access.
 
-The aggregate owns this invariant once as the participant-subject guard.
-Handlers may translate it into user-facing errors, but may not recreate a
-different host-versus-guest policy.
+The aggregate owns this invariant once as a typed participant-subject status.
+Its private guard enforces that status, handlers translate its refusal reason
+into user-facing errors, and the session snapshot exposes only the resulting
+`participantSubjectReady` boolean to the webview. Presentation code may combine
+that answer with local busy/readiness state; it may not recreate a different
+host-versus-guest policy.
 
 ### 2. A guest join receives one truthful subject envelope
 
@@ -55,17 +58,23 @@ history. Beside it, the guest receives exactly one current-subject frame:
 - open scope: the existing `<workshop-open-conversation>` honesty frame,
   addressed to that guest.
 
-The join also carries the session's standing context attachments. Those
-attachments are recorded in the new guest's context-source manifest because
-they were actually delivered. Resource catalog/search traffic remains private
-under the room-ledger ADR; evidence publication rules are unchanged.
+The join also carries the session's standing context attachments. Guest-join
+start atomically captures the excerpt and attachments used to build the
+provider envelope, plus the writer-source rows derived from them. Those rows
+ride the active run across the awaited provider call and seed the retained
+guest manifest at adoption; adoption never re-reads live room context.
+Resource catalog/search traffic remains private under the room-ledger ADR;
+evidence publication rules are unchanged.
 
 ### 3. Lifecycle markers do not impersonate conversation
 
 `session_start` and `session_resume` remain durable room turns and may remain
-in a delivered catch-up frame. A delivery containing only those lifecycle
-markers does not trigger `Catching <participant> up on the room…`. Any other
-eligible pending turn is conversational catch-up and keeps the existing copy.
+in a delivered catch-up frame. A complete eligible backlog containing only
+those lifecycle markers does not trigger
+`Catching <participant> up on the room…`. Any other eligible pending turn is
+conversational catch-up and keeps the existing copy. Classification happens
+before the runaway guard shapes the delivered prefix, so deferred conversation
+cannot be hidden behind lifecycle-only status.
 
 This is a status classification, not a new audience class or a second delivery
 cursor.
@@ -73,9 +82,10 @@ cursor.
 ### 4. Scope and participant identity have separate UI owners
 
 The scope strip and header own the explicit open-room/no-excerpt explanation.
-The context meter names the active participant. In an unmeasured open room it
-therefore shows the participant name (`Jill`), not another copy of the scope
-warning.
+The context meter names the active participant. Its caller supplies the
+participant label and an explicit `showsContextSuffix` flag; suffix presence
+is never inferred from string shape. In an unmeasured open room it therefore
+shows the participant name (`Jill`), not another copy of the scope warning.
 
 ## Consequences
 

--- a/docs/adr/2026-07-26-workshop-open-room-participants.md
+++ b/docs/adr/2026-07-26-workshop-open-room-participants.md
@@ -1,0 +1,89 @@
+# ADR 2026-07-26: Workshop Open Rooms Admit Persona Guests
+
+**Status:** Accepted
+**Date:** 2026-07-26
+**Extends:** [ADR 2026-07-11 — Workshop Guest Persona Sidecars](2026-07-11-workshop-guest-persona-sidecars.md), [ADR 2026-07-24 — The Workshop Room Ledger and Delivery Offsets](2026-07-24-workshop-room-ledger-and-delivery-offsets.md), and [ADR 2026-07-25 — Workshop Session Scope Is Immutable After Conversation Starts](2026-07-25-workshop-scope-immutability.md)
+**Implementing sprint:** [Sprint 13D_2 — Open Room Participants](../../.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13d_2-open-room-participants.md)
+
+## Context
+
+Sprint 13A made `open` a real Workshop scope: the host may retain a truthful
+conversation without a pinned excerpt, while excerpt-dependent tools remain
+unavailable. Guest invitation was deliberately left excerpt-only until the
+join envelope could make the same honesty guarantee.
+
+That temporary boundary now makes the room asymmetric. The UI hides the guest
+invitation, the handler rejects it, and the aggregate requires an excerpt for
+guest join and continuation even though:
+
+- the room ledger and delivery offsets are participant-based, not
+  excerpt-based;
+- guest resource and dictionary capabilities do not require an excerpt;
+- the existing open-conversation frame already states exactly what the persona
+  has and has not read; and
+- standing context is valid in an open conversation.
+
+A separate presentation defect makes the first ordinary host message say
+`Catching Jill up on the room…` when the only pending ledger turn is the
+session-start marker. The marker is legitimate durable history, but it is not
+conversational catch-up.
+
+## Decision
+
+### 1. Persona participation follows session scope
+
+Both the permanent host and persona guests may join and continue when the
+session has either:
+
+- `scope: excerpt` with a non-empty pinned excerpt; or
+- `scope: open`, with no fabricated or implied excerpt.
+
+An unchosen `scope: null` remains invalid. Direct tool sidecars and
+writer-launched analysis tools remain excerpt-gated. This change does not make
+a blank `WorkshopExcerpt` legal and does not widen filesystem access.
+
+The aggregate owns this invariant once as the participant-subject guard.
+Handlers may translate it into user-facing errors, but may not recreate a
+different host-versus-guest policy.
+
+### 2. A guest join receives one truthful subject envelope
+
+The existing bounded room snapshot remains the guest's shared conversation
+history. Beside it, the guest receives exactly one current-subject frame:
+
+- excerpt scope: the existing bounded `<pinned-excerpt>` frame; or
+- open scope: the existing `<workshop-open-conversation>` honesty frame,
+  addressed to that guest.
+
+The join also carries the session's standing context attachments. Those
+attachments are recorded in the new guest's context-source manifest because
+they were actually delivered. Resource catalog/search traffic remains private
+under the room-ledger ADR; evidence publication rules are unchanged.
+
+### 3. Lifecycle markers do not impersonate conversation
+
+`session_start` and `session_resume` remain durable room turns and may remain
+in a delivered catch-up frame. A delivery containing only those lifecycle
+markers does not trigger `Catching <participant> up on the room…`. Any other
+eligible pending turn is conversational catch-up and keeps the existing copy.
+
+This is a status classification, not a new audience class or a second delivery
+cursor.
+
+### 4. Scope and participant identity have separate UI owners
+
+The scope strip and header own the explicit open-room/no-excerpt explanation.
+The context meter names the active participant. In an unmeasured open room it
+therefore shows the participant name (`Jill`), not another copy of the scope
+warning.
+
+## Consequences
+
+- Open and excerpt rooms now have the same participant affordance.
+- Guests remain honest about missing prose while retaining room history and
+  writer-selected standing context.
+- No persistence schema or provider-conversation migration is required.
+- Existing saved sessions remain readable; the next guest invitation simply
+  uses the session's persisted scope.
+- Focused tests must cover open-room guest join/continuation, subject framing,
+  manifest seeding, and lifecycle-only catch-up status classification.

--- a/docs/pr-reviews/pr-91-open-room-participants-review.md
+++ b/docs/pr-reviews/pr-91-open-room-participants-review.md
@@ -1,0 +1,400 @@
+# MR Review — Open Workshop rooms to persona guests (Sprint 13D_2)
+
+**Author:** okeylanders · PR #91 · `sprint/workshop-editor-tab-13d_2-open-room-participants` → `epic/workshop-editor-tab`
+
+---
+
+## Resolution ledger
+
+Status is the reviewer's **initial recommendation**, not a verdict — update the `Status`
+column as findings are addressed so this file stays a living record. Legend: **Open** =
+act before merge · **Deferred** = real issue, safe to punt for a stated reason (track it)
+· **Addressed** = fixed · **Partially addressed** = fixed with a noted remainder · **N/A**
+= out of scope or superseded.
+
+| # | Sev | Finding | Reviewers | Consensus | Status |
+|---|-----|---------|-----------|-----------|--------|
+| 1 | 🟠 High | Guest manifest seeded from live state at completion, not from the join envelope actually sent | Marcus, Blake, Sam, Patricia, Oliver, Bria | 🎯🎯 Strong (6) | **Addressed** |
+| 2 | 🟠 High | Participant-subject policy now written in four places; newest copy (`canInviteGuest`) is the loosest | Marcus, Parker, Bria | 🎯🎯 Strong (3) | **Addressed** |
+| 3 | 🟠 High | Both new invite-guard refusal branches unexercised at both layers | Cal | — | **Addressed** |
+| 4 | 🟡 Standard | Catch-up status classified from post-guard `turns`, not eligible `pending` | Parker, Cal, Oliver, Sam, Bria | 🎯🎯 Strong (5) | **Addressed** |
+| 5 | 🟡 Standard | Semantic flag smuggled through string shape; `/\s+context$/i` written twice in one file | Stan, Parker, Marcus | 🎯🎯 Strong (3) | **Addressed** |
+| 6 | 🟡 Standard | Excerpt-scope joins now also ship standing context; mixed pin+context case untested | Cal, Tim | 🎯 (2) | **Addressed** |
+| 7 | 🟡 Standard | The one comment whose invariant changed lost its sprint/ADR traceability tag | Stan | — | **Addressed** |
+| 8 | 🟡 Standard | New status classification is invisible in the log | Oliver | — | **Addressed** |
+| 9 | 🟢 Praise | Gate flip from `target.kind !== 'host'` to `=== 'tool'` verified airtight across all nine combinations | Blake | — | **N/A** |
+| 10 | 🟢 Praise | Delivery-accounting log deliberately left gated on turn count, not the new classification | Oliver | — | **N/A** |
+| 11 | 🟢 Nit | Three suspected scaling concerns confirmed to genuinely not matter | Tim | — | **N/A** |
+
+### Resolution notes — 2026-07-26
+
+1. `beginPersonaGuestJoin` now captures the exact excerpt, standing-context
+   list, and derived writer-source rows used by the join envelope. The source
+   rows ride the active run and seed adoption after the provider await;
+   `adoptPersonaGuest` never re-reads live room state.
+2. `WorkshopSessionService.getParticipantSubjectStatus()` is the single policy
+   authority. The handler translates its typed reason, the session snapshot
+   exposes `participantSubjectReady`, the hook consumes that boolean, and the
+   invite gate reuses `workshop.canMessage`.
+3. The pure aggregate policy test exercises all four subject combinations;
+   guest-join and handler tests exercise unchosen-scope refusal and both
+   handler refusal messages.
+4. `WorkshopRoomDeliveryService.prepare()` classifies the complete eligible
+   `pending` backlog before applying the runaway guard. An injected guard test
+   proves deferred conversation still selects conversational catch-up.
+5. `ContextBudget` now accepts a bare `participantLabel` and explicit
+   `showsContextSuffix`; both suffix regexes were removed.
+6. Prompt-builder and manifest tests cover excerpt + standing context together.
+7. The capability invariant comment now cites Sprint 13D_2 / ADR 2026-07-26.
+8. The existing delivery-accounting log now records
+   `status=conversational|lifecycle-only`, with tests for both values.
+
+---
+
+## Blast Radius
+
+- 16 files changed · +374 / −44 lines
+- New files: 2 (ADR + sprint doc) · Migrations: no · New services/controllers: none
+- 6 source files, 6 test files, 4 docs. No persistence schema change, no new transport, no new state store.
+- Characterization: a **policy widening** (`requireHostSubject` → `requireParticipantSubject`) plus a **status-classification fix**, delivered on top of an already-landed delivery architecture. Small diff, high semantic leverage — it changes who may speak in a room and what the writer is told about it.
+
+---
+
+## Report Card
+
+| Category | Grade |
+| --- | --- |
+| 🏛️ Architecture | C |
+| 🛡️ Security | C+ |
+| 🧪 Tests | C |
+| 📖 Quality | B− |
+| ⚡ Performance | B+ |
+| 🎯 Domain | C |
+
+---
+
+## Executive Briefing
+
+🟠 **[6-reviewer Strong Consensus]** **The guest manifest can lie about what the guest was told.** `handleInviteGuest` snapshots context attachments at T0 to build the prompt; `adoptPersonaGuest` re-reads them live at T1 after the awaited LLM call, and *that* is what seeds the writer-facing manifest. The comment above the code asserts the invariant the code doesn't enforce. `rejectExcerptMutationWhileRunning()` exists in this very file and guards `handleSetExcerpt` — none of the five context-attachment handlers have it.
+
+🟠 **[Marcus, Parker, Bria]** **The ADR's central claim doesn't hold.** ADR §1 says the aggregate owns the participant-subject invariant "once" and handlers "may not recreate a different host-versus-guest policy." It now lives in four places, and the newest — `canInviteGuest` — checks `!!workshop.excerpt` where its sibling `canMessage` checks `!!excerpt?.text.trim()`.
+
+🟠 **[Cal]** **Neither new refusal branch is tested.** The PR split one flat check into two branches with distinct messages; neither string is asserted anywhere, because every test calls `pin()` or `chooseOpen()` first. A test was deleted and an assertion inverted in the same change.
+
+🟡 **[5-reviewer Strong Consensus]** **The catch-up classifier is asked the wrong pipeline stage** — `roomDelivery.turns` (post-guard) instead of `pending`. Blake dissented on reachability and was verified correct: it needs a single ~1M-character turn, which the prompt budgets prevent. Real reasoning error, currently masked by a budget that happens to hold.
+
+---
+
+## 🏛️ Marcus · Architecture & Design
+
+"The Cartographer of Layer Boundaries"
+
+### 🟠 High — Guest manifest seeded from live attachments, not the snapshot delivered at invitation [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopSessionService.ts:1093-1099`
+
+The ADR states the guest manifest is recorded "because they were actually delivered" (§2). But the two reads of `contextAttachments` happen at different clock ticks. `handleInviteGuest` snapshots `getContextAttachments()` at invitation time to build the prompt actually sent to the model. `adoptPersonaGuest` only runs later, inside `completeRun`, after the async `startWorkshopGuestConversation` call resolves — and it reads `this.contextAttachments` fresh.
+
+Worth noting: the host's pin-adoption path has the identical shape. This isn't a new failure mode invented here — it's an existing weak invariant now extended from one pin to an open-ended attachment list, which widens the blast radius.
+
+### 🟠 High — The participant-subject invariant is independently re-derived, not delegated [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:611-623` and `893-912`
+
+The ADR is explicit: "The aggregate owns this invariant once as the participant-subject guard." I searched for a shared predicate the handler could consult — `getScope()`/`getExcerpt()` are the only exposed accessors; grepped for `canAdmit`/`canSend`/`canInvite`, not found. Instead both handler methods independently re-derive the scope/excerpt boolean logic ahead of calling into the aggregate.
+
+I checked every `(scope, hasExcerpt, target)` combination and they currently agree. But "translate a thrown error's message" and "duplicate the branching logic that decides whether to throw" are different things, and the latter is what's happening. Add a third scope value or a new participant kind and four independently-maintained copies must move in lockstep.
+
+### 🟡 Standard — `ParticipantLabel` infers a semantic distinction from string shape [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/shared/ContextBudget.tsx:90-91, 108-113`
+
+`WorkshopApp.tsx` already knows, at the call site, whether it's passing a bare name or a measured "`<name> context`" label — that's exactly the `scope === 'open' && !hasExcerpt` branch it just evaluated. Instead of passing that explicitly, it collapses both into one ambiguous string and lets `ContextBudget` re-derive the distinction twice. A label whose suffix carries meaning is an illegal-state-shaped contract — what happens to a persona literally named "… Context"?
+
+> *"The invariant that matters here isn't wrong — it's just not living in one house, and a manifest that can't promise what it says it delivered isn't a UI bug, it's a broken contract wearing a UI costume."* — Marcus
+
+---
+
+## 🔥 Blake · Critical / Blocking Issues
+
+"She's Been Paged for This Before"
+
+### 🟡 Standard — Manifest seeded from a second read taken at run completion [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopSessionService.ts:1098`
+
+Two reads of the same mutable field at two different times, and the code comment asserts they are one. Nothing serializes them. `registerRoutes` wraps context mutations in `rejectRoomMutationDuringSessionOperation`, which returns early unless `isSessionOperationPending()` — a save/load lock, not a run lock. So `WORKSHOP_ADD_CONTEXT_RESOURCES` and `WORKSHOP_ADD_CONTEXT_TEXT` are accepted by the backend while a guest join is streaming.
+
+The manifest is frozen at adoption, so the lie is permanent for that guest. Fix is one line: capture the attachment list beside the frame in `handleInviteGuest` and pass it to `adoptPersonaGuest`. Rated MEDIUM confidence only because reachability depends on a modal-open race I could not walk end to end.
+
+### 🟢 Praise — The `!hasExcerpt` gate flip is airtight
+
+Enumerated all nine `(scope, hasExcerpt, target.kind)` combinations against `WorkshopHandler.ts:898-910`. `target.kind === 'tool'` errors first; host and personaGuest both fall through to `scope !== 'open'`, so `scope: 'excerpt'` with a blank or missing excerpt still rejects a guest exactly as before. No combination reaches code that dereferences a missing excerpt: `buildWorkshopGuestJoinMessage` guards `input.excerpt` at both use sites, `WorkshopPersonaCapability` already treats `turn.excerpt` as optional, and `WorkshopSessionStateV1Migration` normalizes persisted `scope: undefined` before restore, so the legacy-session path lands on `requireExcerpt`, not past it. Nothing here blocks merge.
+
+> *"One field, two reads, an await in between, and a comment swearing they're the same value — that's not a manifest, that's a memory of one."* — Blake
+
+---
+
+## 🔍 Sam · Bug Hunter
+
+"What if the list is empty, though?"
+
+### 🟠 High — Guard-truncated delivery can hide a real backlog behind "Streaming…" [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopRoomDeliveryService.ts:38-44`
+
+Concretely: pending = `[session_start, <huge real turn that alone exceeds the guard>]`. `guardWorkshopRoomDelivery` always keeps the first turn unconditionally, then breaks on the oversized second turn, so `turns = [session_start]` and `deferredTurns = 1`. The classifier returns `false`, so the writer sees `Streaming Jill…`.
+
+Meanwhile `buildWorkshopRoomCatchUp(turns, deferredTurns, …)` explicitly appends *"Some later room turns remain pending and have not been witnessed"* into the **model's** prompt. So the model is told a backlog exists, but the writer's status copy claims ordinary streaming — the exact inversion of the bug this PR sets out to fix.
+
+**Orchestrator adjudication:** Blake dissented and is correct on reachability — this requires a single turn near 1M characters, which `PROMPT_BUDGETS` makes unreachable today. Landed as Standard, not High. The reasoning error is real; the exposure is not.
+
+### 🟠 High — Manifest seeded from live attachments at run-completion [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopSessionService.ts:1093-1097`
+
+`handleAddContextText` (and the Edit/Preview sheet's `applyTextSheet` → `addContextText`/`updateContextText` path) has no `rejectExcerptMutationWhileRunning`-style guard, unlike every excerpt mutation handler in the same file. If the writer adds an attachment mid-stream, `adoptPersonaGuest` stamps it into the manifest even though it was never in the prompt. If they remove one that *was* in the prompt, the manifest silently drops it.
+
+> *"Two clocks measuring the same 'what did the guest actually get' question — one ticks at invite, one ticks at completion, and nobody's watching the gap between them."* — Sam
+
+---
+
+## 📖 Parker · Code Quality
+
+"Code is Communication, Not Instruction"
+
+### 🟡 Standard — Label-suffix decision encoded three times via string-shape sniffing [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/shared/ContextBudget.tsx:91, 108-112`
+
+Three places must agree: `WorkshopApp.tsx` builds the string, `participantName` strips the suffix with a regex, and `ParticipantLabel` re-tests the *same* regex against the *same* string to decide whether to render the word back. The boolean the component actually needs is known for a fact at the call site at the exact moment it's discarded into a string.
+
+Simpler: give `ContextBudget` an explicit `showsContextSuffix?: boolean` and delete both regexes.
+
+### 🟡 Standard — `canInviteGuest` reinvents (and weakens) `canMessage`'s subject check [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:399-404`
+
+`useWorkshop.ts:891-893` already computes exactly this concept for `canMessage`. `canInviteGuest` restates it and not identically — `!!workshop.excerpt` (object presence) instead of `!!excerpt?.text.trim()` (non-blank content), plus a `scope !== null` clause already implied by the union type. Safe today only because `handleSetExcerpt` rejects blank text upstream — an invariant the reader has to verify in a different file.
+
+### 🟡 Standard — `hasWorkshopConversationalCatchUp` reads the post-guard slice [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:929-931`
+
+The name and doc comment are about "is there real conversation to catch up on," which is a question about `pending`, but it's fed the delivery-shaped slice. Classify off `pending` (or thread `deferredTurns` into the boolean), and rename the parameter so a future caller doesn't pass the wrong pipeline stage.
+
+> *"I read `hasConversationalCatchUp` three times expecting it to ask 'is there unseen conversation,' and each time it turned out to be asking 'did the runaway guard let it through' instead."* — Parker
+
+---
+
+## 🧪 Cal · Test Coverage & Quality
+
+"Confidence Levels, Not Coverage Numbers"
+
+### 🟠 High — Both new invite-guard branches unexercised at both layers
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:613-622`
+
+This PR replaced a single flat `!excerpt` check with two distinct branches, each with its own user-facing message. Searched the diff and the whole test tree for `'Choose how to start this session'` and `'Pin an excerpt before inviting'` — neither string is asserted anywhere. Every `handleInviteGuest` call in the test file is preceded by `pin()` or `chooseOpen()`.
+
+The same gap exists one layer down: `beginPersonaGuestJoin` now calls `requireParticipantSubject`, whose `scope === null` throw is likewise untested for the guest-join path — only `beginPersonaMessage` and `beginToolRun` get that coverage.
+
+### 🟡 Standard — Excerpt-scope manifest change untested where pin and standing context coexist [🎯 Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopSessionService.ts:1096-1098`
+
+This spread is unconditional — it changes guest-manifest seeding for *excerpt*-scope guests too. The pre-existing test pins an excerpt but adds zero attachments (so the new spread contributes nothing and the test passes identically before and after); the new test has an attachment but no pin. **No test ever invites a guest into a room with both** — the actual mixed case this PR newly enables.
+
+### 🟡 Standard — Catch-up classification blind to guard-deferred turns [🎯🎯 Strong Consensus]
+
+`WorkshopRoomDeliveryService.test.ts` tests `guardWorkshopRoomDelivery`'s truncation in isolation and `hasWorkshopConversationalCatchUp` against hand-built arrays in isolation — never together. Both new handler catch-up tests use small, unguarded turn sets.
+
+> *"I don't need every line covered — I need to know that when the guard truncates, the status bar doesn't just shrug and say 'Streaming' over a queue it can't see."* — Cal
+
+---
+
+## 🗂️ Stan · Codebase Standards
+
+"He Has Every Pattern Memorized"
+
+### 🟡 Standard — Guest-capability comment dropped its sprint/ADR tag mid-edit
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:670`
+
+This file annotates every invariant comment with a traceable tag — `// Sprint 13A §1: what a turn needs depends on the session's SCOPE…` (line 883), `// Session scope (ADR 2026-07-25)…` (line 1475), `// … the scope lock (ADR 2026-07-25)…` (line 2626). The old comment here was tagged `// Sprint 13C:`; the reword strips the tag entirely instead of updating it to the sprint that actually changed this invariant. This is precisely the site whose behavior this PR changed, so it's the one comment in the diff that most needed a fresh reference — and it's the one that lost its reference.
+
+### 🟡 Standard — New suffix check duplicates `participantName`'s regex instead of a named predicate [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/shared/ContextBudget.tsx:111`
+
+Every other derivation this file needs in JSX is hoisted to a named function above the component — `kindLabel`, `originLabel`, `compressionLabel`, `compressionValueClass`, and `participantName` itself. The new suffix check inlines the same `/\s+context$/i` pattern raw inside the JSX ternary rather than adding a sibling predicate next to `participantName`.
+
+> *"Two copies of the same regex a page apart — the file already had a drawer for this labeled 'predicates go here,' and somebody set this one down on the counter instead."* — Stan
+
+---
+
+## ⚡ Tim · Performance
+
+"O(n²) at Scale is an Incident Waiting to Happen"
+
+### 🟡 Standard — Guest join now re-ships the full standing-context budget, once per invited guest [🎯 Consensus]
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:643`
+
+The math. `PROMPT_BUDGETS.contextAttachments` caps standing context at 50,000 words / 420,000 characters — at ~4 chars/token, worst case ~105k tokens. Against `guestJoinSnapshot` (100 turns / 100,000 chars ≈ 25k tokens) and `personaExcerpt` (≈ 30k tokens), a maximally-loaded excerpt-scope guest invite can approach ~160k tokens before the opening message.
+
+**Doesn't matter:** this is not new exposure in kind — the host's first turn already ships the identical call. And it does *not* double-ship: `recordContextChange` only pushes a short divider (`Added context: Story compass · 6 words`) into the room ledger, so the snapshot carries no attachment bodies.
+
+**Does matter, mildly:** before this PR, excerpt-scope guest invites shipped **zero** standing context. Now every guest invite pays up to that ~105k-token cost, and each persona guest is a separate OpenRouter conversation with no shared cache. Three guests against a context-heavy room pays it three times. Real, quantifiable, intended, and already bounded — worth knowing the number, not worth blocking on.
+
+### 🟢 Nit — The three flagged "does this scale" spots don't
+
+Checked all three explicitly. The `.some()` scan is bounded by the 1M-character guard — sub-millisecond, once per message. The `ContextBudget` double regex runs on a ~20-character string once per render — nanoseconds against React's own overhead. `adoptPersonaGuest`'s `.map()` runs once per adoption over a writer-curated list. No action needed on any of the three.
+
+> *"The budget was already doing its job before this diff showed up — the only new arithmetic here is guests now getting billed for it too, and that's a design choice with a number attached, not a leak."* — Tim
+
+---
+
+## 🛡️ Patricia · Security
+
+"She Reads Code Like an Attacker Would"
+
+### 🟠 High — Guest manifest seeded from live state, not from what was actually sent [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopSessionService.ts:1093-1099`
+
+Traced the full round trip. Between T0 (frame built) and T1 (manifest seeded) there is a real, unguarded window: `handleAddContextText`, `handleAddContextFile`, `handleAddContextResources`, `handleRemoveContextAttachment`, and `handleUpdateContextText` are all registered as plain `registerMutation`s with **no `rejectExcerptMutationWhileRunning()` check** — that guard exists only on excerpt-mutating handlers, and its own comment explains it exists precisely to close this class of mid-run race.
+
+Context attachments never got the same guard. Before this PR that omission was harmless for guest manifests, because `adoptPersonaGuest` only recorded `pin` (which *is* guarded). **This PR extends the completion-time-snapshot pattern to unguarded state, so the omission now has teeth.**
+
+**Practical judgment:** not a disclosure to an unauthorized party — all context attachments are room-wide by design, so no cross-participant confidentiality boundary is crossed. But it is a traceable violation of the ADR's own stated invariant and undermines the honesty guarantee the manifest exists to provide. Practical-but-narrow: requires the writer to edit context during an in-flight invitation, not attacker-controlled input. HIGH, not Blocking.
+
+*No prompt-injection or capability-widening findings.* The neutralization path holds on the new frames, and the guest capability minted with `excerpt: undefined` does not silently widen.
+
+> *"The manifest promises to say exactly what a guest was told, but it doesn't watch the moment the promise is made — it watches the moment the promise is checked, and those are not always the same instant."* — Patricia
+
+---
+
+## 🌙 Oliver · Observability & Debuggability
+
+"Would This Failure Leave a Trail at 2am?"
+
+### 🟠 High — Join content and its later manifest snapshot can diverge, with zero log to reconcile them [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopSessionService.ts:1093-1099`
+
+Searched the whole diff for any new `appendLine` call — not found. So if a writer ever files *"Felix keeps talking like he never saw my story compass note"* (or the reverse — quoting something he shouldn't know), there is no local record of either the join-time or completion-time attachment set to compare against. The PR's own body flags manual EDH smoke as still pending for exactly this invitation path; right now that smoke test would produce no trail at all if it silently mis-seeded the manifest.
+
+### 🟡 Standard — The new status decision is invisible in the log
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:1005-1007`
+
+Searched for any log of the `hasConversationalCatchUp` value or the chosen `statusMessage` — not found. The neighbouring `Room catch-up prepared` log still fires and still reports included/deferred counts correctly, so the raw numbers *are* on disk — but nothing ties those numbers to which status text the writer actually saw. A developer chasing "writer says nothing loaded but the log shows 12 deferred" has to reconstruct the classification by hand.
+
+### 🟢 Praise — The delivery-accounting log survives the status-copy change untouched
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:948-951`
+
+This log is gated on `deliveredTurnIds.length > 0`, not on `hasConversationalCatchUp`, so it keeps firing — with true included/deferred counts — even in the new lifecycle-only case where the user-facing copy deliberately goes quiet. That's the right split: quieter UI, unchanged ground truth on disk. It's the reason the finding above is Standard and not High.
+
+> *"I can forgive a status message for being calm; I can't forgive a codebase for being unable to tell me, after the fact, whether calm was the right call."* — Oliver
+
+---
+
+## 🎯 Bria · Domain Logic & Business Correctness
+
+"Does This Code Actually Do What the Ticket Asked?"
+
+### 🟠 High — Manifest seeded from live state at completion, not from the join envelope [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopSessionService.ts:1093-1097`
+
+ADR §2 justifies recording standing context "because they were actually delivered." The comment directly above asserts the invariant the code doesn't enforce. Is a completion-time snapshot intentional (e.g. because mutation is UI-gated by `roomMutationLocked` during any run), or should the join-time snapshot be threaded through and reused so the manifest can't drift from the actual envelope?
+
+### 🟡 Standard — `canInviteGuest` recreates a weaker copy of the participant-subject guard [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/WorkshopApp.tsx:399-401`
+
+ADR §1 says the aggregate owns the invariant "once" and handlers "may not recreate a different host-versus-guest policy." The codebase now has the same policy written three different ways — aggregate `requireParticipantSubject`, hook `canMessage`, and this new `canInviteGuest` — and the newest copy is the loosest. Was reusing `workshop.canMessage` for the invite gate considered?
+
+### 🟡 Standard — Catch-up status classified from the post-guard prefix [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/handlers/domain/WorkshopHandler.ts:929-930`
+
+It self-corrects on the very next turn, since the deferred content becomes the new "first" turn — so this is a narrow, one-turn edge case rather than a persistent one. Is that considered acceptable, or should classification use the pre-guard `pending` set?
+
+> *"The comment says the manifest 'must describe that exact input' — but it's reading `this.contextAttachments` fresh off the shelf at delivery time, not the box that actually shipped. Cute promise, wrong timestamp."* — Bria
+
+---
+
+## 🎓 Sensei · The Teacher
+
+"The Review Is the Lesson. The Code Is the Practice."
+
+### Lesson 1 — The Snapshot You Forgot to Take
+
+Illuminated by: Finding 1 (and its shadow in Finding 3's deleted test)
+
+When your code reads some state, then waits — an await, a network call, a few seconds of someone else's thinking — the world does not hold still for you. If what you tell the user afterward must describe *what you originally saw*, you have to carry that original view forward as data, not go back and ask the world again once you're done waiting. The comment in this code already knew the rule ("the retained manifest must describe that exact input") — it just didn't trust the code to keep the promise the words made. A comment stating an invariant the code doesn't enforce is not documentation. It's a wish.
+
+→ Carry forward: Whenever you see a `read → await → read again (same source)` shape, ask out loud: "is the second read guaranteed to equal the first?" If the honest answer is "usually," snapshot at the first read and use the snapshot.
+
+### Lesson 2 — Ask the Full Set, Not the Slice Someone Already Cut
+
+Illuminated by: Finding 4
+
+A pipeline often produces more than one shape of "the data" as it flows — the raw backlog, the truncated slice, the rendered prefix. Each shape was cut for a purpose. When a new question arrives, it's tempting to hand it whatever variable is closest at hand, especially if it already has the right type. But a variable filtered for a *different* reason may quietly answer a *different* question. This bug is real today and invisible today, because a budget constraint elsewhere happens to keep the two answers aligned. That's not safety, that's coincidence wearing safety's coat.
+
+→ Carry forward: Before feeding a variable into a new decision, trace it one hop upstream and ask what it was already filtered *for*. If the answer isn't "for this," go get the unfiltered set.
+
+### Lesson 3 — An Invariant Has One Home Address
+
+Illuminated by: Finding 2
+
+The ADR said the aggregate owns this rule once, and handlers may only translate it. And yet the rule now lives in four places, and the newest one is the loosest — checking "is there an object" where its neighbour checks "is there real content." This is how policy drift happens: not through one careless developer, but through each new caller reasonably assuming its own small check is close enough. Every unguarded copy is a place the rule can quietly relax without anyone deciding it should.
+
+→ Carry forward: Before writing a condition that smells like "can this participant do X," grep for the phrase first. If it already exists upstream, thread the answer through — don't re-derive it downstream, even approximately.
+
+### Lesson 4 — Don't Let a Boolean Go Underground
+
+Illuminated by: Finding 5
+
+Somewhere in this code, something *knew* — as a clean, unambiguous boolean — whether this participant carries context. And at the exact moment of knowing, it buried that fact inside a string and left the next reader to dig it back out with a regex. Worse, dug twice, with two separate shovels. Every time a fact crosses a boundary encoded as a weaker signal than it started as, someone downstream has to reconstruct it — imperfectly, and usually more than once.
+
+→ Carry forward: When you catch yourself formatting a fact into a string for display *and* another consumer needs the fact itself, ask whether the boolean should have crossed that boundary directly, with the string generated from it — not the other way around.
+
+### Lesson 5 — A Fork in the Road Needs Two Footprints
+
+Illuminated by: Finding 3
+
+Splitting one check into two distinguishable failure messages is a real improvement in honesty toward the user — but it's also a silent promise that both paths matter enough to name separately. If every test still walks the one paved road, the fork exists only in the code, not in anyone's verified understanding of it. And a checklist marked all `[x]` while manual smoke testing is still pending tells the same story at a larger scale: green and verified are not synonyms, they just went to school together.
+
+→ Carry forward: When a change turns one branch into two, write the test for the branch you *didn't* take before the one you did — the refusal path is the one nobody wants to type out, which is exactly why it's worth typing out.
+
+> *"The bug that slips past a green suite and a checked box is rarely hiding — it's usually standing in the one place nobody thought to ask a second question."* — Sensei
+
+---
+
+## The Closer
+
+### 🎋 Haiku
+
+```
+The guest arrives, told
+what the room holds — but the room
+kept changing its mind.
+```
+
+---
+
+## Summary
+
+**Nearly there.** The core move — letting scope rather than excerpt-presence decide who may speak — is sound, and Blake's nine-combination sweep confirms the gate flip introduces no reachable crash. The two documents are genuinely good: the ADR names its own supersession of the 13A holdout and the sprint file records real verification.
+
+What needs work sits in the seam this PR opens rather than in the policy it changes. Six reviewers independently landed on the same thing: the guest manifest is seeded from a second read taken after an awaited network call, while a comment three lines above swears it describes the first. Patricia found why that now matters — `rejectExcerptMutationWhileRunning()` guards the excerpt but was never applied to the five context-attachment handlers, an omission that was harmless until this PR started recording those attachments. The fix is small: capture the attachment list beside the frame in `handleInviteGuest` and pass it into `adoptPersonaGuest`, and consider extending the existing run guard to the context handlers.
+
+Given the domain is *honesty about what each participant knows*, findings 1 and 3 deserve to land before merge — a manifest that can misreport is a defect in the product's central promise, and the two new refusal messages are currently unverified in either direction. Finding 4 is a one-line correctness improvement worth taking even though Blake proved it unreachable today. The manual EDH smoke the PR body defers is exactly where the untested refusal branches would surface.
+
+---
+
+*Reviewed by: Marcus 🏛️ · Blake 🔥 · Sam 🔍 · Parker 📖 · Cal 🧪 · Stan 🗂️ · Tim ⚡ · Patricia 🛡️ · Oliver 🌙 · Bria 🎯 · Sensei 🎓*

--- a/docs/pr-reviews/pr-91-open-room-participants-review.md
+++ b/docs/pr-reviews/pr-91-open-room-participants-review.md
@@ -48,6 +48,14 @@ act before merge · **Deferred** = real issue, safe to punt for a stated reason 
 7. The capability invariant comment now cites Sprint 13D_2 / ADR 2026-07-26.
 8. The existing delivery-accounting log now records
    `status=conversational|lifecycle-only`, with tests for both values.
+9. Re-review hardening removed `adoptPersonaGuest`'s empty-manifest default.
+   Adoption now requires the delivered writer-source snapshot, and completion
+   fails loudly if a future join path reaches adoption without capturing one.
+10. EDH smoke exposed collisions in the five-slot label hash (`Jill` and
+    `Sister Agnes` both resolved to coral). The context meter now receives a
+    canonical participant identity, and all twelve personas have distinct,
+    stable roster slots. Carrying those colors into response-card borders and
+    names is tracked separately.
 
 ---
 

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -2597,6 +2597,27 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
       await handler.handleAddContextFile(message(MessageType.WORKSHOP_ADD_CONTEXT_FILE, {}) as any);
     };
 
+    it('explains both participant-subject refusal reasons before inviting a guest', async () => {
+      await handler.handleInviteGuest(message(
+        MessageType.WORKSHOP_INVITE_GUEST,
+        { personaId: 'felix', openingMessage: 'Read the room.' }
+      ) as any);
+      expect(posted(MessageType.ERROR).at(-1)?.payload.message)
+        .toBe('Choose how to start this session before inviting a guest.');
+
+      jest.spyOn(session, 'getParticipantSubjectStatus').mockReturnValue({
+        ready: false,
+        reason: 'excerpt-missing'
+      });
+      await handler.handleInviteGuest(message(
+        MessageType.WORKSHOP_INVITE_GUEST,
+        { personaId: 'felix', openingMessage: 'Read the room.' }
+      ) as any);
+      expect(posted(MessageType.ERROR).at(-1)?.payload.message)
+        .toBe('Pin an excerpt before inviting a guest.');
+      expect(service.startWorkshopGuestConversation).not.toHaveBeenCalled();
+    });
+
     it('starts a retained host conversation with no excerpt and no fabricated one', async () => {
       await chooseOpen();
       await send('Help me plan the next scene.');
@@ -2687,6 +2708,9 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
         .map((entry) => entry.payload.message);
       expect(statuses).toContain('Streaming Jill…');
       expect(statuses).not.toContain('Catching Jill up on the room…');
+      expect(log.appendLine).toHaveBeenCalledWith(
+        expect.stringContaining('status=lifecycle-only')
+      );
     });
 
     it('still announces catch-up for actual unseen room conversation', async () => {
@@ -2699,6 +2723,9 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
 
       expect(posted(MessageType.STATUS).map((entry) => entry.payload.message))
         .toContain('Catching Jill up on the room…');
+      expect(log.appendLine).toHaveBeenCalledWith(
+        expect.stringContaining('status=conversational')
+      );
     });
 
     /**

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -2574,8 +2574,8 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
   });
   /**
    * Sprint 13A — Open Chat at the handler boundary. The sprint's exit criteria
-   * live here: an excerpt-free host conversation is real and honest, tools and
-   * guests stay gated, both reversals reach the aggregate, and the shared
+   * live here: an excerpt-free participant conversation is real and honest,
+   * tools stay gated, both reversals reach the aggregate, and the shared
    * Edit/Preview sheet is served without shipping every attachment body in
    * every snapshot.
    */
@@ -2637,15 +2637,68 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
       expect(posted(MessageType.ERROR).at(-1)?.payload.message).toContain('Pin an excerpt');
     });
 
-    it('refuses a guest invitation in an excerpt-free room', async () => {
+    it('invites and continues an honest guest with open-room standing context', async () => {
       await chooseOpen();
+      await handler.handleAddContextText(message(
+        MessageType.WORKSHOP_ADD_CONTEXT_TEXT,
+        { text: '# Story compass\n\nThe middle should feel increasingly breathless.' }
+      ) as any);
       await handler.handleInviteGuest(message(
         MessageType.WORKSHOP_INVITE_GUEST,
         { personaId: 'felix', openingMessage: 'Read the room.' }
       ) as any);
 
-      expect(service.startWorkshopGuestConversation).not.toHaveBeenCalled();
-      expect(posted(MessageType.ERROR).at(-1)?.payload.message).toContain('Pin an excerpt');
+      const join = service.startWorkshopGuestConversation.mock.calls.at(-1)![0];
+      expect(join.personaId).toBe('felix');
+      expect(join.message).toContain('<workshop-open-conversation>');
+      expect(join.message).toContain('No excerpt has been provided.');
+      expect(join.message).toContain('The middle should feel increasingly breathless.');
+      expect(join.message).not.toContain('<pinned-excerpt>');
+      expect((capabilityFactory.create as jest.Mock).mock.calls.at(-1)?.[0])
+        .toMatchObject({
+          owner: { kind: 'personaGuest', personaId: 'felix' },
+          excerpt: undefined
+        });
+      expect(session.collectWriterSources({
+        kind: 'personaGuest',
+        personaId: 'felix'
+      })).toEqual([
+        expect.objectContaining({ kind: 'attachment', label: 'Story compass' })
+      ]);
+
+      service.continueConversation.mockClear();
+      await send('What rhythm would serve that shape?');
+      expect(service.continueConversation).toHaveBeenCalledWith(
+        'guest-conv',
+        expect.stringContaining('What rhythm would serve that shape?'),
+        expect.objectContaining({
+          capability: expect.objectContaining({ catalog: 'workshopPersona' })
+        })
+      );
+    });
+
+    it('does not call a session marker conversational catch-up', async () => {
+      await chooseOpen();
+      session.recordSessionMarker('start', 'Session started now.');
+
+      await send('Help me plan the next scene.');
+
+      const statuses = posted(MessageType.STATUS)
+        .map((entry) => entry.payload.message);
+      expect(statuses).toContain('Streaming Jill…');
+      expect(statuses).not.toContain('Catching Jill up on the room…');
+    });
+
+    it('still announces catch-up for actual unseen room conversation', async () => {
+      await chooseOpen();
+      session.adoptPersonaGuest('margot', 'margot-conv');
+      session.beginPersonaGuestMessage('margot', 'guest-run', 'What should the turn do?');
+      session.completeRun('guest-run', 'Let it narrow before it breaks.');
+
+      await send('What did Margot see?');
+
+      expect(posted(MessageType.STATUS).map((entry) => entry.payload.message))
+        .toContain('Catching Jill up on the room…');
     });
 
     /**

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -2715,7 +2715,7 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
 
     it('still announces catch-up for actual unseen room conversation', async () => {
       await chooseOpen();
-      session.adoptPersonaGuest('margot', 'margot-conv');
+      session.adoptPersonaGuest('margot', 'margot-conv', []);
       session.beginPersonaGuestMessage('margot', 'guest-run', 'What should the turn do?');
       session.completeRun('guest-run', 'Let it narrow before it breaks.');
 

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopConversationSettingsService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopConversationSettingsService.test.ts
@@ -64,7 +64,7 @@ describe('WorkshopConversationSettingsService', () => {
     session.setExcerpt({ text: 'Excerpt', source: { kind: 'manual' } });
     session.beginPersonaMessage('host-open', 'Start.');
     session.completeRun('host-open', 'Ready.', undefined, false, 'host-conv');
-    session.adoptPersonaGuest('margot', 'guest-conv');
+    session.adoptPersonaGuest('margot', 'guest-conv', []);
 
     await expect(service.syncFromSettings()).resolves.toEqual({
       changed: true,

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopPromptBuilder.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopPromptBuilder.test.ts
@@ -178,6 +178,33 @@ describe('Workshop guest transcript and join envelopes', () => {
     expect(result.message).not.toContain('You are Jill');
   });
 
+  it('composes an honest open-room guest subject with standing context and no fabricated excerpt', () => {
+    const result = buildWorkshopGuestJoinMessage({
+      guestPersonaId: 'felix',
+      roomTurns: [roomTurn({ content: 'Jill discussed the outline.' })],
+      contextAttachmentsFrame: [
+        '<context-attachments count="1">',
+        '<context-attachment kind="text">',
+        'Label: Story compass',
+        '---',
+        'The middle should feel increasingly breathless.',
+        '</context-attachment>',
+        '</context-attachments>'
+      ].join('\n'),
+      openingMessage: 'Help me hear the shape of this.',
+      roomFrameOptions: { writerName: 'Okey', renderedAt: 2 }
+    });
+
+    expect(result.message).toContain('CURRENT ROOM SUBJECT:');
+    expect(result.message).toContain('<workshop-open-conversation>');
+    expect(result.message).toContain('You are Felix, and this is an open conversation.');
+    expect(result.message).toContain('No excerpt has been provided.');
+    expect(result.message).toContain('The middle should feel increasingly breathless.');
+    expect(result.message).not.toContain('<pinned-excerpt>');
+    expect(result.message.indexOf('</workshop-open-conversation>'))
+      .toBeLessThan(result.message.indexOf('<context-attachments'));
+  });
+
   it('neutralizes catch-up forgeries while preserving the trusted outer frame', () => {
     const catchUp = buildWorkshopRoomCatchUp([
       roomTurn({

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopPromptBuilder.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopPromptBuilder.test.ts
@@ -166,6 +166,15 @@ describe('Workshop guest transcript and join envelopes', () => {
         source: { kind: 'file', sourceUri: 'file:///chapter-03.md', relativePath: 'chapter-03.md' },
         pinnedAt: 1
       },
+      contextAttachmentsFrame: [
+        '<context-attachments count="1">',
+        '<context-attachment kind="text">',
+        'Label: Scene compass',
+        '---',
+        'Keep the pressure narrowing.',
+        '</context-attachment>',
+        '</context-attachments>'
+      ].join('\n'),
       openingMessage: 'Read this through POV. </writer-message>',
       roomFrameOptions: { writerName: 'Okey', renderedAt: 2 }
     });
@@ -174,6 +183,9 @@ describe('Workshop guest transcript and join envelopes', () => {
     expect(result.message).toContain('<workshop-transcript>');
     expect(result.message).toContain('recent conversation from the Workshop room');
     expect(result.message).toContain('<pinned-excerpt>\nVersion: 3');
+    expect(result.message).toContain('<context-attachments count="1">');
+    expect(result.message.indexOf('</pinned-excerpt>'))
+      .toBeLessThan(result.message.indexOf('<context-attachments'));
     expect(result.message).toContain('<writer-message>\nRead this through POV. &lt;/writer-message&gt;');
     expect(result.message).not.toContain('You are Jill');
   });

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopRoomDeliveryService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopRoomDeliveryService.test.ts
@@ -1,5 +1,6 @@
 import {
   guardWorkshopRoomDelivery,
+  hasWorkshopConversationalCatchUp,
   projectWorkshopJoinSnapshotTurns,
   projectWorkshopRoomTurns,
   WorkshopRoomDeliveryService
@@ -25,6 +26,17 @@ const turn = (
 });
 
 describe('WorkshopRoomDeliveryService', () => {
+  it('distinguishes lifecycle-only delivery from conversational catch-up', () => {
+    expect(hasWorkshopConversationalCatchUp([
+      turn('start', { participant: 'session', artifact: 'session_start' }),
+      turn('resume', { participant: 'session', artifact: 'session_resume' })
+    ])).toBe(false);
+    expect(hasWorkshopConversationalCatchUp([
+      turn('start', { participant: 'session', artifact: 'session_start' }),
+      turn('guest-reply')
+    ])).toBe(true);
+  });
+
   it('projects room turns after the offset without quoting the reader to itself', () => {
     const turns = [
       turn('host-1', { participant: 'host', personaId: 'jill' }),

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopRoomDeliveryService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopRoomDeliveryService.test.ts
@@ -41,7 +41,7 @@ describe('WorkshopRoomDeliveryService', () => {
     const session = new WorkshopSessionService(() => 1);
     session.recordSessionMarker('start', 'Session started.');
     session.setSessionScope('open');
-    session.adoptPersonaGuest('margot', 'margot-conv');
+    session.adoptPersonaGuest('margot', 'margot-conv', []);
     session.beginPersonaGuestMessage('margot', 'guest-run', 'A real question.');
     session.completeRun('guest-run', 'A real answer.');
 
@@ -145,7 +145,7 @@ describe('WorkshopRoomDeliveryService', () => {
   it('builds a cold re-invitation snapshot from room history including the guest own prior turns', () => {
     const session = new WorkshopSessionService(() => 1);
     session.setExcerpt({ text: 'Passage.', source: { kind: 'manual' } });
-    session.adoptPersonaGuest('margot', 'margot-conv');
+    session.adoptPersonaGuest('margot', 'margot-conv', []);
     session.beginPersonaGuestMessage('margot', 'margot-run', 'Question.');
     session.completeRun('margot-run', 'Answer.');
     session.dismissPersonaGuest('margot');
@@ -181,7 +181,7 @@ describe('WorkshopRoomDeliveryService', () => {
   it('rejects a hole instead of advancing to the newest delivered turn', () => {
     const session = new WorkshopSessionService(() => 1);
     session.setExcerpt({ text: 'Passage.', source: { kind: 'manual' } });
-    session.adoptPersonaGuest('margot', 'margot-conv');
+    session.adoptPersonaGuest('margot', 'margot-conv', []);
     session.beginPersonaGuestMessage('margot', 'margot-run', 'Question.');
     session.completeRun('margot-run', 'Answer.');
 
@@ -205,7 +205,7 @@ describe('WorkshopRoomDeliveryService', () => {
   it('acknowledges the exact prefix and leaves a guarded suffix pending', () => {
     const session = new WorkshopSessionService(() => 1);
     session.setExcerpt({ text: 'Passage.', source: { kind: 'manual' } });
-    session.adoptPersonaGuest('margot', 'margot-conv');
+    session.adoptPersonaGuest('margot', 'margot-conv', []);
     session.beginPersonaGuestMessage('margot', 'margot-run', 'Question.');
     session.completeRun('margot-run', 'Answer.');
 
@@ -220,7 +220,7 @@ describe('WorkshopRoomDeliveryService', () => {
   it('advances through the delivered prefix rather than a newer ineligible ledger tail', () => {
     const session = new WorkshopSessionService(() => 1);
     session.setExcerpt({ text: 'Passage.', source: { kind: 'manual' } });
-    session.adoptPersonaGuest('margot', 'margot-conv');
+    session.adoptPersonaGuest('margot', 'margot-conv', []);
     session.beginPersonaGuestMessage('margot', 'margot-run', 'Question.');
     session.completeRun('margot-run', 'Answer.');
 
@@ -245,7 +245,7 @@ describe('WorkshopRoomDeliveryService', () => {
   }) => {
     const session = new WorkshopSessionService(() => 1);
     session.setExcerpt({ text: 'Passage.', source: { kind: 'manual' } });
-    session.adoptPersonaGuest('margot', 'margot-conv');
+    session.adoptPersonaGuest('margot', 'margot-conv', []);
     for (let index = 0; index < exchanges; index += 1) {
       session.beginPersonaGuestMessage('margot', `guest-${index}`, `Question ${index}.`);
       session.completeRun(`guest-${index}`, `${index}:${'x'.repeat(replyCharacters)}`);

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopRoomDeliveryService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopRoomDeliveryService.test.ts
@@ -37,6 +37,26 @@ describe('WorkshopRoomDeliveryService', () => {
     ])).toBe(true);
   });
 
+  it('classifies the complete pending backlog before the runaway guard defers conversation', () => {
+    const session = new WorkshopSessionService(() => 1);
+    session.recordSessionMarker('start', 'Session started.');
+    session.setSessionScope('open');
+    session.adoptPersonaGuest('margot', 'margot-conv');
+    session.beginPersonaGuestMessage('margot', 'guest-run', 'A real question.');
+    session.completeRun('guest-run', 'A real answer.');
+
+    const delivery = new WorkshopRoomDeliveryService(
+      session,
+      'Session started.'.length
+    ).prepare({ kind: 'host' });
+
+    expect(delivery.turns).toEqual([
+      expect.objectContaining({ artifact: 'session_start' })
+    ]);
+    expect(delivery.deferredTurns).toBe(2);
+    expect(delivery.hasConversationalCatchUp).toBe(true);
+  });
+
   it('projects room turns after the offset without quoting the reader to itself', () => {
     const turns = [
       turn('host-1', { participant: 'host', personaId: 'jill' }),
@@ -138,7 +158,7 @@ describe('WorkshopRoomDeliveryService', () => {
     const snapshot = new WorkshopRoomDeliveryService(session).prepareJoinSnapshot({
       kind: 'personaGuest',
       personaId: 'margot'
-    }, invitation.id);
+    }, invitation.turn.id);
 
     expect(snapshot.map((candidate) => candidate.content)).toEqual([
       'Question.',

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopRunCompletion.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopRunCompletion.test.ts
@@ -108,7 +108,7 @@ describe('completeWorkshopRun', () => {
   });
 
   it('attaches proposals to a guest turn and promotes them with guest provenance', () => {
-    session.adoptPersonaGuest('felix', 'felix-conv');
+    session.adoptPersonaGuest('felix', 'felix-conv', []);
     session.beginPersonaGuestMessage('felix', 'req-1', 'Turn the review into tasks.');
 
     const turn = completeWorkshopRun({

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
@@ -96,7 +96,7 @@ const buildCompleteState = (): WorkshopSessionStateV1 => {
     [{ key: 'finding-1', text: 'Tighten the second sentence.', ordinal: 1, priority: 'high' }]
   )!.turn;
   session.addTodoFromFinding(report.id, 'finding-1');
-  session.adoptPersonaGuest('margot', 'guest-runtime-before-save');
+  session.adoptPersonaGuest('margot', 'guest-runtime-before-save', []);
   session.setChatTarget({ kind: 'personaGuest', personaId: 'margot' });
   session.beginPersonaGuestMessage('margot', 'guest-message', 'How does the voice sound?');
   session.completeRun('guest-message', 'Close and controlled.');
@@ -125,7 +125,7 @@ describe('WorkshopSessionService committed persistence', () => {
   it('round-trips guest-origin next steps with their persona provenance', () => {
     const session = new WorkshopSessionService(() => 1);
     session.setExcerpt({ text: 'Pinned.', source: { kind: 'manual' } });
-    session.adoptPersonaGuest('felix', 'felix-before-save');
+    session.adoptPersonaGuest('felix', 'felix-before-save', []);
     session.beginPersonaGuestMessage('felix', 'felix-run', 'What should change?');
     const guestTurn = session.completeRun(
       'felix-run',

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts
@@ -11,6 +11,7 @@
 import {
   WorkshopScopeLockedError,
   WorkshopSessionService,
+  workshopParticipantSubjectStatus,
   workshopTextNoteLabel
 } from '@/application/services/workshop/WorkshopSessionService';
 import {
@@ -42,13 +43,26 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
   };
 
   describe('scope assignment', () => {
+    it('classifies every participant-subject policy branch in one place', () => {
+      expect(workshopParticipantSubjectStatus(null))
+        .toEqual({ ready: false, reason: 'scope-unchosen' });
+      expect(workshopParticipantSubjectStatus('excerpt'))
+        .toEqual({ ready: false, reason: 'excerpt-missing' });
+      expect(workshopParticipantSubjectStatus('excerpt', { text: 'Passage.' }))
+        .toEqual({ ready: true });
+      expect(workshopParticipantSubjectStatus('open'))
+        .toEqual({ ready: true });
+    });
+
     it('starts unchosen — an excerpt-free room is not automatically open chat', () => {
       expect(service.getScope()).toBeNull();
       expect(service.getSnapshot().scope).toBeNull();
     });
 
-    it('refuses a host turn until the writer chooses a path', () => {
+    it('refuses host and guest turns until the writer chooses a path', () => {
       expect(() => service.beginPersonaMessage('req-1', 'Hello?'))
+        .toThrow(/Choose how to start/);
+      expect(() => service.beginPersonaGuestJoin('felix', 'req-guest', 'Join me.'))
         .toThrow(/Choose how to start/);
     });
 
@@ -78,7 +92,7 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
     it('admits persona guests but still refuses tool sidecars without a passage', () => {
       service.setSessionScope('open');
       expect(() => service.beginToolRun('prose', 'req-tool')).toThrow(/without a pinned excerpt/);
-      expect(service.beginPersonaGuestJoin('felix', 'req-guest', 'Read the room.'))
+      expect(service.beginPersonaGuestJoin('felix', 'req-guest', 'Read the room.').turn)
         .toMatchObject({ participant: 'writer', personaId: 'felix' });
     });
   });
@@ -220,7 +234,7 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
         'margot',
         'guest-join',
         'Read this with me.'
-      );
+      ).turn;
       const guestTurn = service.completeRun(
         'guest-join',
         'The voice pulls away in the second paragraph.',

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionScope.test.ts
@@ -75,11 +75,11 @@ describe('WorkshopSessionService — session scope (Sprint 13A)', () => {
       expect(service.getExcerpt()).toBeUndefined();
     });
 
-    it('still refuses a tool run and a guest join without a passage', () => {
+    it('admits persona guests but still refuses tool sidecars without a passage', () => {
       service.setSessionScope('open');
       expect(() => service.beginToolRun('prose', 'req-tool')).toThrow(/without a pinned excerpt/);
-      expect(() => service.beginPersonaGuestJoin('felix', 'req-guest', 'Read the room.'))
-        .toThrow(/without a pinned excerpt/);
+      expect(service.beginPersonaGuestJoin('felix', 'req-guest', 'Read the room.'))
+        .toMatchObject({ participant: 'writer', personaId: 'felix' });
     });
   });
 

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionService.test.ts
@@ -1120,7 +1120,7 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
     expect(new WorkshopRoomDeliveryService(service).prepareJoinSnapshot({
       kind: 'personaGuest',
       personaId: 'margot'
-    }, invitation.id).map((turn) => turn.content)).toEqual([
+    }, invitation.turn.id).map((turn) => turn.content)).toEqual([
       'Host opening.',
       'Host reply.'
     ]);
@@ -1134,7 +1134,7 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
       'margot-conv'
     )!;
 
-    expect(invitation.personaId).toBe('margot');
+    expect(invitation.turn.personaId).toBe('margot');
     expect(reply.participant).toBe('guest');
     expect(service.getPersonaGuestConversationId('margot')).toBe('margot-conv');
     expect(service.getChatTarget()).toEqual({ kind: 'host' });
@@ -1270,18 +1270,36 @@ describe('writer-origin context sources (Phase 7)', () => {
     expect(session.collectWriterSources({ kind: 'host' }).filter((s) => s.kind === 'pin')).toHaveLength(1);
   });
 
-  it('seeds an open-room guest manifest with the standing context delivered at join', () => {
+  it('seeds an open-room guest manifest from the join snapshot, not completion-time state', () => {
     const session = new WorkshopSessionService(() => 7);
     session.setSessionScope('open');
-    session.addContextAttachment({
+    const delivered = session.addContextAttachment({
       kind: 'text',
       origin: 'writer',
       label: 'Story compass',
       words: 6,
       content: 'The middle should feel increasingly breathless.'
     });
+    expect(delivered.ok).toBe(true);
+    session.beginPersonaGuestJoin('felix', 'felix-join', 'Read the room.');
 
-    session.adoptPersonaGuest('felix', 'felix-conv');
+    if (delivered.ok) {
+      session.removeContextAttachment(delivered.attachment.id);
+    }
+    session.addContextAttachment({
+      kind: 'text',
+      origin: 'writer',
+      label: 'Late note',
+      words: 3,
+      content: 'This arrived later.'
+    });
+    session.completeRun(
+      'felix-join',
+      'I can help with the shape.',
+      undefined,
+      false,
+      'felix-conv'
+    );
 
     expect(session.collectWriterSources({
       kind: 'personaGuest',
@@ -1363,9 +1381,18 @@ describe('writer-origin context sources (Phase 7)', () => {
   it('stamps guests at join, clears them on dismissal, and routes shipped message attachments by target', () => {
     const session = new WorkshopSessionService(() => 7);
     pinned(session);
-    session.adoptPersonaGuest('margot', 'guest-conv');
+    session.addContextAttachment({
+      kind: 'text',
+      origin: 'writer',
+      label: 'Scene compass',
+      words: 4,
+      content: 'Keep the pressure narrowing.'
+    });
+    session.beginPersonaGuestJoin('margot', 'guest-join', 'Read this.');
+    session.completeRun('guest-join', 'The pin and compass agree.', undefined, false, 'guest-conv');
     expect(session.collectWriterSources({ kind: 'personaGuest', personaId: 'margot' })).toEqual([
-      expect.objectContaining({ kind: 'pin', excerptVersion: 1 })
+      expect.objectContaining({ kind: 'pin', excerptVersion: 1 }),
+      expect.objectContaining({ kind: 'attachment', label: 'Scene compass' })
     ]);
 
     session.addMessageAttachment({
@@ -1376,6 +1403,7 @@ describe('writer-origin context sources (Phase 7)', () => {
     session.commitMessageAttachments(['ta-1'], { kind: 'personaGuest', personaId: 'margot' });
     expect(session.collectWriterSources({ kind: 'personaGuest', personaId: 'margot' })).toEqual([
       expect.objectContaining({ kind: 'pin' }),
+      expect.objectContaining({ kind: 'attachment', label: 'Scene compass' }),
       expect.objectContaining({
         kind: 'message-attachment',
         origin: 'writer',

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionService.test.ts
@@ -797,8 +797,8 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
 
     it('publishes committed guest evidence to the host and other guests', () => {
       pin();
-      service.adoptPersonaGuest('margot', 'margot-conv');
-      service.adoptPersonaGuest('quinn', 'quinn-conv');
+      service.adoptPersonaGuest('margot', 'margot-conv', []);
+      service.adoptPersonaGuest('quinn', 'quinn-conv', []);
       service.beginPersonaGuestMessage('margot', 'guest-run', 'Look up liminal.');
 
       const completion = service.recordCapabilityArtifact({
@@ -829,7 +829,7 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
 
     it('pairs the writer prompt across several interleaved private artifacts and commits cleanly', () => {
       pin();
-      service.adoptPersonaGuest('margot', 'margot-conv');
+      service.adoptPersonaGuest('margot', 'margot-conv', []);
       service.beginPersonaGuestMessage('margot', 'guest-run', 'Check two words.');
       service.recordCapabilityArtifact({ requestId: 'guest-run', ...guestLookup('margot') });
       service.recordCapabilityArtifact({ requestId: 'guest-run', ...guestLookup('margot') });
@@ -884,8 +884,8 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
       })).toBeUndefined();
       service.completeRun('host-run', 'Host reply.', undefined, false, 'host-conv');
 
-      service.adoptPersonaGuest('margot', 'margot-conv');
-      service.adoptPersonaGuest('quinn', 'quinn-conv');
+      service.adoptPersonaGuest('margot', 'margot-conv', []);
+      service.adoptPersonaGuest('quinn', 'quinn-conv', []);
       service.beginPersonaGuestMessage('margot', 'guest-run', 'Guest asks.');
       expect(service.recordCapabilityArtifact({
         requestId: 'guest-run',
@@ -954,15 +954,15 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
     service.beginPersonaMessage('host-1', 'The room is open.');
     service.completeRun('host-1', 'Let us begin.', undefined, false, 'host-conv');
 
-    expect(() => service.adoptPersonaGuest('jill', 'jill-guest-conv')).toThrow(
+    expect(() => service.adoptPersonaGuest('jill', 'jill-guest-conv', [])).toThrow(
       'The Workshop host is already in the room'
     );
-    service.adoptPersonaGuest('margot', 'margot-conv');
-    service.adoptPersonaGuest('quinn', 'quinn-conv');
-    expect(() => service.adoptPersonaGuest('margot', 'duplicate-conv')).toThrow(
+    service.adoptPersonaGuest('margot', 'margot-conv', []);
+    service.adoptPersonaGuest('quinn', 'quinn-conv', []);
+    expect(() => service.adoptPersonaGuest('margot', 'duplicate-conv', [])).toThrow(
       'Margot is already in the room'
     );
-    expect(() => service.adoptPersonaGuest('wren', 'wren-conv')).toThrow(
+    expect(() => service.adoptPersonaGuest('wren', 'wren-conv', [])).toThrow(
       'Workshop supports at most 2 live guests'
     );
 
@@ -988,7 +988,7 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
     pin();
     service.beginPersonaMessage('host-1', 'Host opening.');
     service.completeRun('host-1', 'Host reply.', undefined, false, 'host-conv');
-    service.adoptPersonaGuest('margot', 'margot-conv');
+    service.adoptPersonaGuest('margot', 'margot-conv', []);
 
     service.beginPersonaMessage('host-2', 'A later host question.');
     service.completeRun('host-2', 'A later host answer.');
@@ -1053,7 +1053,7 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
 
   it('returns composer routing to the host when a tool run begins', () => {
     pin();
-    service.adoptPersonaGuest('margot', 'margot-conv');
+    service.adoptPersonaGuest('margot', 'margot-conv', []);
     expect(service.setChatTarget({ kind: 'personaGuest', personaId: 'margot' })).toBe(true);
 
     service.beginToolRun('prose', 'tool-run');
@@ -1063,7 +1063,7 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
 
   it('retains dismissed guest evidence, permits re-invitation, and unlocks host selection', () => {
     pin();
-    service.adoptPersonaGuest('margot', 'margot-conv');
+    service.adoptPersonaGuest('margot', 'margot-conv', []);
     const writerTurn = service.beginPersonaGuestMessage('margot', 'guest-1', 'What do you see?');
     const guestTurn = service.completeRun('guest-1', 'The narrative distance drifts.')!;
 
@@ -1087,8 +1087,8 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
 
   it('interleaves two guests in ledger order and advances the host offset once', () => {
     pin();
-    service.adoptPersonaGuest('margot', 'margot-conv');
-    service.adoptPersonaGuest('quinn', 'quinn-conv');
+    service.adoptPersonaGuest('margot', 'margot-conv', []);
+    service.adoptPersonaGuest('quinn', 'quinn-conv', []);
 
     const margotWriter = service.beginPersonaGuestMessage('margot', 'margot-1', 'Read the voice.');
     const margotReply = service.completeRun('margot-1', 'The voice pulls away here.')!;
@@ -1142,7 +1142,7 @@ describe('WorkshopSessionService — Sprint 06B sidecars and direct handoff', ()
 
   it('refuses a late guest completion after dismissal', () => {
     pin();
-    service.adoptPersonaGuest('margot', 'margot-conv');
+    service.adoptPersonaGuest('margot', 'margot-conv', []);
     service.beginPersonaGuestMessage('margot', 'guest-run', 'Read this.');
     service.dismissPersonaGuest('margot');
 

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionService.test.ts
@@ -1270,6 +1270,31 @@ describe('writer-origin context sources (Phase 7)', () => {
     expect(session.collectWriterSources({ kind: 'host' }).filter((s) => s.kind === 'pin')).toHaveLength(1);
   });
 
+  it('seeds an open-room guest manifest with the standing context delivered at join', () => {
+    const session = new WorkshopSessionService(() => 7);
+    session.setSessionScope('open');
+    session.addContextAttachment({
+      kind: 'text',
+      origin: 'writer',
+      label: 'Story compass',
+      words: 6,
+      content: 'The middle should feel increasingly breathless.'
+    });
+
+    session.adoptPersonaGuest('felix', 'felix-conv');
+
+    expect(session.collectWriterSources({
+      kind: 'personaGuest',
+      personaId: 'felix'
+    })).toEqual([
+      expect.objectContaining({
+        kind: 'attachment',
+        origin: 'writer',
+        label: 'Story compass'
+      })
+    ]);
+  });
+
   it('marks prior pin rows stale only when the revision frame actually ships', () => {
     const session = new WorkshopSessionService(() => 7);
     pinned(session);

--- a/packages/core/src/__tests__/presentation/webview/components/shared/ContextBudget.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/shared/ContextBudget.test.tsx
@@ -21,7 +21,7 @@ const snapshot: ContextBudgetSnapshot = {
 describe('ContextBudget', () => {
   it('renders retained context separately from last-request, processed-turn, cumulative, and compression details', () => {
     render(<ContextBudget
-      label="Jill context"
+      participantLabel="Jill"
       snapshot={snapshot}
       modelOptions={[
         { id: 'model/b', label: 'Newly selected Model B', contextLength: 1_000_000, liveDataAvailable: true },
@@ -48,14 +48,14 @@ describe('ContextBudget', () => {
 
   it('renders empty and unavailable states without a hardcoded context window', () => {
     const { rerender } = render(<ContextBudget
-      label="Quinn context"
+      participantLabel="Quinn"
       modelOptions={[]}
       cumulativeProcessedTokens={0}
     />);
     expect(screen.getByText(/Not measured yet — updates after the first reply/)).toBeTruthy();
 
     rerender(<ContextBudget
-      label="Quinn context"
+      participantLabel="Quinn"
       snapshot={snapshot}
       modelOptions={[{
         id: 'model/a', label: 'Offline Model A', contextLength: 200_000, liveDataAvailable: false
@@ -68,7 +68,8 @@ describe('ContextBudget', () => {
 
   it('renders a bare participant label without manufacturing a context suffix', () => {
     render(<ContextBudget
-      label="Jill"
+      participantLabel="Jill"
+      showsContextSuffix={false}
       modelOptions={[]}
       cumulativeProcessedTokens={0}
     />);
@@ -79,7 +80,7 @@ describe('ContextBudget', () => {
 
   it('renders the In-context manifest with parenthetical kinds, attribution, and stale dimming (Phase 7)', () => {
     render(<ContextBudget
-      label="Jill context"
+      participantLabel="Jill"
       snapshot={snapshot}
       modelOptions={[{ id: 'model/a', label: 'Model A', contextLength: 200_000, liveDataAvailable: true }]}
       cumulativeProcessedTokens={429_000}

--- a/packages/core/src/__tests__/presentation/webview/components/shared/ContextBudget.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/shared/ContextBudget.test.tsx
@@ -66,6 +66,17 @@ describe('ContextBudget', () => {
     expect(screen.getAllByText('Unavailable')).toHaveLength(2);
   });
 
+  it('renders a bare participant label without manufacturing a context suffix', () => {
+    render(<ContextBudget
+      label="Jill"
+      modelOptions={[]}
+      cumulativeProcessedTokens={0}
+    />);
+
+    expect(screen.getByText('Jill')).toBeTruthy();
+    expect(screen.queryByText('context')).toBeNull();
+  });
+
   it('renders the In-context manifest with parenthetical kinds, attribution, and stale dimming (Phase 7)', () => {
     render(<ContextBudget
       label="Jill context"

--- a/packages/core/src/__tests__/presentation/webview/components/shared/ContextBudget.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/shared/ContextBudget.test.tsx
@@ -21,6 +21,7 @@ const snapshot: ContextBudgetSnapshot = {
 describe('ContextBudget', () => {
   it('renders retained context separately from last-request, processed-turn, cumulative, and compression details', () => {
     render(<ContextBudget
+      participantIdentity="jill"
       participantLabel="Jill"
       snapshot={snapshot}
       modelOptions={[
@@ -48,6 +49,7 @@ describe('ContextBudget', () => {
 
   it('renders empty and unavailable states without a hardcoded context window', () => {
     const { rerender } = render(<ContextBudget
+      participantIdentity="quinn"
       participantLabel="Quinn"
       modelOptions={[]}
       cumulativeProcessedTokens={0}
@@ -55,6 +57,7 @@ describe('ContextBudget', () => {
     expect(screen.getByText(/Not measured yet — updates after the first reply/)).toBeTruthy();
 
     rerender(<ContextBudget
+      participantIdentity="quinn"
       participantLabel="Quinn"
       snapshot={snapshot}
       modelOptions={[{
@@ -66,8 +69,9 @@ describe('ContextBudget', () => {
     expect(screen.getAllByText('Unavailable')).toHaveLength(2);
   });
 
-  it('renders a bare participant label without manufacturing a context suffix', () => {
-    render(<ContextBudget
+  it('renders a bare participant label without changing its identity color', () => {
+    const { rerender } = render(<ContextBudget
+      participantIdentity="jill"
       participantLabel="Jill"
       showsContextSuffix={false}
       modelOptions={[]}
@@ -76,10 +80,22 @@ describe('ContextBudget', () => {
 
     expect(screen.getByText('Jill')).toBeTruthy();
     expect(screen.queryByText('context')).toBeNull();
+    const bareDotClass = document.querySelector('.pm-context-budget-dot')?.className;
+
+    rerender(<ContextBudget
+      participantIdentity="jill"
+      participantLabel="Jill"
+      showsContextSuffix
+      modelOptions={[]}
+      cumulativeProcessedTokens={0}
+    />);
+
+    expect(document.querySelector('.pm-context-budget-dot')?.className).toBe(bareDotClass);
   });
 
   it('renders the In-context manifest with parenthetical kinds, attribution, and stale dimming (Phase 7)', () => {
     render(<ContextBudget
+      participantIdentity="jill"
       participantLabel="Jill"
       snapshot={snapshot}
       modelOptions={[{ id: 'model/a', label: 'Model A', contextLength: 200_000, liveDataAvailable: true }]}

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
@@ -55,6 +55,7 @@ const sessionState = (session: Partial<WorkshopSessionSnapshot>): WorkshopSessio
         // Sprint 13A: scope is explicit session state. These fixtures describe
         // passage sessions unless a case overrides it.
         scope: 'excerpt',
+        participantSubjectReady: true,
         excerptVersion: 0,
         replacementCount: 0,
         contextAttachments: [],
@@ -1026,6 +1027,7 @@ describe('useWorkshop', () => {
 
       act(() => result.current.handleSessionState(sessionState({
         scope: 'open',
+        participantSubjectReady: true,
         excerpt: undefined
       })));
 
@@ -1037,6 +1039,7 @@ describe('useWorkshop', () => {
 
       act(() => result.current.handleSessionState(sessionState({
         scope: null,
+        participantSubjectReady: false,
         excerpt: excerptSnapshot()
       })));
 

--- a/packages/core/src/__tests__/presentation/webview/utils/contextBudget.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/utils/contextBudget.test.ts
@@ -2,8 +2,9 @@ import {
   contextBudgetTone,
   contextBudgetView,
   formatCompactTokens,
-  participantDotIndex
+  participantIdentityColorIndex
 } from '@utils/contextBudget';
+import { WORKSHOP_PERSONA_CATALOG } from '@shared/constants/workshopPersonas';
 import { ContextBudgetSnapshot, ModelOption } from '@shared/types';
 
 const snapshot = (contextTokens: number): ContextBudgetSnapshot => ({
@@ -51,11 +52,17 @@ describe('context budget formatting', () => {
     expect(formatCompactTokens(190_000)).toBe('190K');
   });
 
-  it('assigns each participant label a stable identity-dot slot', () => {
-    const jill = participantDotIndex('Jill context');
-    expect(jill).toBe(participantDotIndex('Jill context'));
-    expect(jill).toBeGreaterThanOrEqual(0);
-    expect(jill).toBeLessThan(5);
-    expect(participantDotIndex('')).toBe(0);
+  it('assigns every canonical persona a distinct stable identity-color slot', () => {
+    const slots = WORKSHOP_PERSONA_CATALOG.map(({ id }) =>
+      participantIdentityColorIndex(id)
+    );
+
+    expect(new Set(slots).size).toBe(WORKSHOP_PERSONA_CATALOG.length);
+    expect(participantIdentityColorIndex('jill')).toBe(
+      participantIdentityColorIndex('jill')
+    );
+    expect(participantIdentityColorIndex('tool:continuity')).toBe(
+      participantIdentityColorIndex('tool:continuity')
+    );
   });
 });

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -33,6 +33,7 @@ import {
 } from '@/application/services/workshop/WorkshopSessionService';
 import { RunWorkshopToolSidePass } from '@/application/services/workshop/RunWorkshopToolSidePass';
 import {
+  hasWorkshopConversationalCatchUp,
   WorkshopRoomDeliveryService
 } from '@/application/services/workshop/WorkshopRoomDeliveryService';
 import {
@@ -607,8 +608,16 @@ export class WorkshopHandler {
       return;
     }
 
+    const scope = this.session.getScope();
     const excerpt = this.session.getExcerpt();
-    if (!excerpt || excerpt.text.trim().length === 0) {
+    if (scope === null) {
+      this.sendError(
+        'workshop.invite_guest',
+        'Choose how to start this session before inviting a guest.'
+      );
+      return;
+    }
+    if (scope === 'excerpt' && (!excerpt || excerpt.text.trim().length === 0)) {
       this.sendError('workshop.invite_guest', 'Pin an excerpt before inviting a guest.');
       return;
     }
@@ -631,6 +640,9 @@ export class WorkshopHandler {
       const join = buildWorkshopGuestJoinMessage({
         guestPersonaId: personaId,
         excerpt,
+        contextAttachmentsFrame: buildWorkshopContextAttachmentsFrame(
+          this.session.getContextAttachments()
+        ),
         roomTurns: this.roomDelivery.prepareJoinSnapshot({
           kind: 'personaGuest',
           personaId
@@ -655,9 +667,9 @@ export class WorkshopHandler {
       this.sendStreamStarted(requestId);
       this.sendStatus(`Inviting ${workshopPersonaLabel(personaId)} into the room…`);
 
-      // Sprint 13C: the joining guest owns the same bounded instruments as
-      // the host — dictionary, configured resources, excerpt analysis — with
-      // its own principal persisted on every artifact.
+      // The joining guest owns the same bounded instruments as the host, with
+      // its own principal persisted on every artifact. Excerpt-dependent work
+      // remains unavailable when this open-room join has no excerpt.
       const guestCapability = this.capabilityFactory.create({
         requestId,
         personaId,
@@ -870,7 +882,7 @@ export class WorkshopHandler {
     }
     // Sprint 13A §1: what a turn needs depends on the session's SCOPE, not on
     // whether an excerpt happens to be present. An open conversation is a real
-    // room; tool sidecars and guests still require the passage they read.
+    // room; direct tool sidecars still require the passage they read.
     const scope = this.session.getScope();
     const excerpt = this.session.getExcerpt();
     const hasExcerpt = !!excerpt && excerpt.text.trim().length > 0;
@@ -886,10 +898,10 @@ export class WorkshopHandler {
       return;
     }
     if (!hasExcerpt) {
-      if (target.kind !== 'host') {
+      if (target.kind === 'tool') {
         this.sendError(
           'workshop.send_message',
-          'Add an excerpt before continuing with a tool or guest.'
+          'Add an excerpt before continuing with a tool.'
         );
         return;
       }
@@ -914,6 +926,9 @@ export class WorkshopHandler {
         })
       : undefined;
     const roomCatchUp = roomDelivery?.frame;
+    const hasConversationalCatchUp = roomDelivery
+      ? hasWorkshopConversationalCatchUp(roomDelivery.turns)
+      : false;
     const pendingHostUpdates = target.kind === 'host'
       ? this.session.collectPendingHostUpdates()
       : undefined;
@@ -987,7 +1002,7 @@ export class WorkshopHandler {
           threadArtifactFrames,
           ...(conversationId ? personaBehaviorFrames : {})
         });
-        statusMessage = roomCatchUp
+        statusMessage = hasConversationalCatchUp
           ? `Catching ${label} up on the room…`
           : `Streaming ${label}…`;
         break;
@@ -1020,7 +1035,7 @@ export class WorkshopHandler {
           threadArtifactFrames,
           personaBehaviorFrames
         );
-        statusMessage = roomCatchUp
+        statusMessage = hasConversationalCatchUp
           ? `Catching ${label} up on the room…`
           : `Continuing with ${label}…`;
         break;

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -33,7 +33,6 @@ import {
 } from '@/application/services/workshop/WorkshopSessionService';
 import { RunWorkshopToolSidePass } from '@/application/services/workshop/RunWorkshopToolSidePass';
 import {
-  hasWorkshopConversationalCatchUp,
   WorkshopRoomDeliveryService
 } from '@/application/services/workshop/WorkshopRoomDeliveryService';
 import {
@@ -608,16 +607,15 @@ export class WorkshopHandler {
       return;
     }
 
-    const scope = this.session.getScope();
-    const excerpt = this.session.getExcerpt();
-    if (scope === null) {
+    const subjectStatus = this.session.getParticipantSubjectStatus();
+    if (!subjectStatus.ready && subjectStatus.reason === 'scope-unchosen') {
       this.sendError(
         'workshop.invite_guest',
         'Choose how to start this session before inviting a guest.'
       );
       return;
     }
-    if (scope === 'excerpt' && (!excerpt || excerpt.text.trim().length === 0)) {
+    if (!subjectStatus.ready) {
       this.sendError('workshop.invite_guest', 'Pin an excerpt before inviting a guest.');
       return;
     }
@@ -632,28 +630,28 @@ export class WorkshopHandler {
         workshopGuestConversationKey(personaId)
       );
       const writerProfile = this.conversationSettingsService.getWriterProfile();
-      const userTurn = this.session.beginPersonaGuestJoin(
+      const joinStart = this.session.beginPersonaGuestJoin(
         personaId,
         requestId,
         openingMessage
       );
       const join = buildWorkshopGuestJoinMessage({
         guestPersonaId: personaId,
-        excerpt,
+        excerpt: joinStart.excerpt,
         contextAttachmentsFrame: buildWorkshopContextAttachmentsFrame(
-          this.session.getContextAttachments()
+          joinStart.contextAttachments
         ),
         roomTurns: this.roomDelivery.prepareJoinSnapshot({
           kind: 'personaGuest',
           personaId
-        }, userTurn.id),
+        }, joinStart.turn.id),
         openingMessage,
         roomFrameOptions: {
           writerName: workshopWriterPreferredAddress(writerProfile),
           renderedAt: Date.now()
         },
         timeFrame: timeNotice?.frame,
-        ...behaviorFramesFor(userTurn)
+        ...behaviorFramesFor(joinStart.turn)
       });
       this.activeRun = {
         requestId,
@@ -662,19 +660,19 @@ export class WorkshopHandler {
         controller
       };
 
-      this.postTurn(userTurn);
+      this.postTurn(joinStart.turn);
       this.postSessionState();
       this.sendStreamStarted(requestId);
       this.sendStatus(`Inviting ${workshopPersonaLabel(personaId)} into the room…`);
 
-      // The joining guest owns the same bounded instruments as the host, with
-      // its own principal persisted on every artifact. Excerpt-dependent work
-      // remains unavailable when this open-room join has no excerpt.
+      // Sprint 13D_2 / ADR 2026-07-26: the joining guest owns the same bounded
+      // instruments as the host. Excerpt-dependent work remains unavailable
+      // when this open-room join has no excerpt.
       const guestCapability = this.capabilityFactory.create({
         requestId,
         personaId,
         owner: { kind: 'personaGuest', personaId },
-        excerpt,
+        excerpt: joinStart.excerpt,
         excerptVersion: this.session.getExcerptVersion(),
         signal: controller.signal,
         events: {
@@ -691,7 +689,7 @@ export class WorkshopHandler {
         const result = await this.assistantToolService.startWorkshopGuestConversation({
           personaId,
           message: join.message,
-          behavior: userTurn.behavior!,
+          behavior: joinStart.turn.behavior!,
           writerProfile
         }, {
           signal: controller.signal,
@@ -883,14 +881,14 @@ export class WorkshopHandler {
     // Sprint 13A §1: what a turn needs depends on the session's SCOPE, not on
     // whether an excerpt happens to be present. An open conversation is a real
     // room; direct tool sidecars still require the passage they read.
-    const scope = this.session.getScope();
     const excerpt = this.session.getExcerpt();
     const hasExcerpt = !!excerpt && excerpt.text.trim().length > 0;
+    const subjectStatus = this.session.getParticipantSubjectStatus();
     // Scope first, and independently of excerpt presence: a new session
     // deliberately CARRIES the previous room's passage across the boundary
     // (§3), so "an excerpt exists" is not evidence that the writer has chosen
     // what this room is for.
-    if (scope === null) {
+    if (!subjectStatus.ready && subjectStatus.reason === 'scope-unchosen') {
       this.sendError(
         'workshop.send_message',
         'Choose how to start this session — workshop an excerpt, or start an open conversation.'
@@ -905,7 +903,7 @@ export class WorkshopHandler {
         );
         return;
       }
-      if (scope !== 'open') {
+      if (!subjectStatus.ready) {
         this.sendError('workshop.send_message', 'Pin an excerpt before messaging the Workshop.');
         return;
       }
@@ -926,9 +924,7 @@ export class WorkshopHandler {
         })
       : undefined;
     const roomCatchUp = roomDelivery?.frame;
-    const hasConversationalCatchUp = roomDelivery
-      ? hasWorkshopConversationalCatchUp(roomDelivery.turns)
-      : false;
+    const hasConversationalCatchUp = roomDelivery?.hasConversationalCatchUp ?? false;
     const pendingHostUpdates = target.kind === 'host'
       ? this.session.collectPendingHostUpdates()
       : undefined;
@@ -947,7 +943,7 @@ export class WorkshopHandler {
     }
     if (roomDelivery && roomDelivery.deliveredTurnIds.length > 0) {
       this.outputChannel.appendLine(
-        `[WorkshopHandler] Room catch-up prepared (${roomReader?.kind === 'host' ? 'host' : `guest=${roomReader?.personaId}`}): ${roomDelivery.deliveredTurnIds.length} whole turns included, ${roomDelivery.deferredTurns} deferred`
+        `[WorkshopHandler] Room catch-up prepared (${roomReader?.kind === 'host' ? 'host' : `guest=${roomReader?.personaId}`}): ${roomDelivery.deliveredTurnIds.length} whole turns included, ${roomDelivery.deferredTurns} deferred, status=${hasConversationalCatchUp ? 'conversational' : 'lifecycle-only'}`
       );
     }
     const { conversationId, label, requestType, toolId, guestPersonaId } = targetDetails;

--- a/packages/core/src/application/services/workshop/WorkshopPromptBuilder.ts
+++ b/packages/core/src/application/services/workshop/WorkshopPromptBuilder.ts
@@ -27,7 +27,10 @@ import {
   WorkshopRoomFrameRenderOptions,
   WorkshopTranscript
 } from '@/application/services/workshop/WorkshopRoomFrameRenderer';
-import { neutralizeReservedPersonaPromptDelimiters } from '@/utils/workshopPromptFrames';
+import {
+  buildWorkshopOpenConversationFrame,
+  neutralizeReservedPersonaPromptDelimiters
+} from '@/utils/workshopPromptFrames';
 import { trimToWordLimit } from '@/utils/textUtils';
 
 export {
@@ -81,7 +84,9 @@ export function buildWorkshopAnalysisScopeFrame(
 
 export interface WorkshopGuestJoinInput {
   guestPersonaId: WorkshopPersonaId;
-  excerpt: WorkshopExcerpt;
+  excerpt?: WorkshopExcerpt;
+  /** Standing context delivered beside either valid session subject. */
+  contextAttachmentsFrame?: string;
   roomTurns: Parameters<typeof buildWorkshopGuestTranscript>[0];
   openingMessage: string;
   roomFrameOptions?: WorkshopRoomFrameRenderOptions;
@@ -351,6 +356,9 @@ export function buildWorkshopGuestJoinMessage(
     input.roomFrameOptions
   );
   const guestLabel = workshopPersonaLabel(input.guestPersonaId);
+  const subjectFrame = input.excerpt
+    ? buildGuestExcerptFrame(input.excerpt)
+    : buildWorkshopOpenConversationFrame(guestLabel);
   const message = [
     ...(input.timeFrame ? [input.timeFrame, ''] : []),
     ...(input.transitionFrame ? [input.transitionFrame, ''] : []),
@@ -359,9 +367,10 @@ export function buildWorkshopGuestJoinMessage(
     '',
     transcript.message,
     '',
-    'CURRENT PINNED EXCERPT:',
-    buildGuestExcerptFrame(input.excerpt),
+    input.excerpt ? 'CURRENT PINNED EXCERPT:' : 'CURRENT ROOM SUBJECT:',
+    subjectFrame,
     '',
+    ...(input.contextAttachmentsFrame ? [input.contextAttachmentsFrame, ''] : []),
     ...(input.activationFrame ? [input.activationFrame, ''] : []),
     '<writer-message>',
     neutralizeReservedPersonaPromptDelimiters(input.openingMessage),

--- a/packages/core/src/application/services/workshop/WorkshopRoomDeliveryService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopRoomDeliveryService.ts
@@ -29,6 +29,8 @@ export interface WorkshopPreparedRoomDelivery {
   frame?: string;
   deliveredTurnIds: string[];
   deferredTurns: number;
+  /** Classification of the complete eligible backlog, before runaway shaping. */
+  hasConversationalCatchUp: boolean;
 }
 
 /**
@@ -113,7 +115,10 @@ export function guardWorkshopRoomDelivery(
 }
 
 export class WorkshopRoomDeliveryService {
-  constructor(private readonly session: WorkshopSessionService) {}
+  constructor(
+    private readonly session: WorkshopSessionService,
+    private readonly characterGuard = WORKSHOP_ROOM_DELIVERY_RUNAWAY_CHARACTERS
+  ) {}
 
   prepareJoinSnapshot(
     reader: WorkshopCapabilityPrincipal,
@@ -137,7 +142,7 @@ export class WorkshopRoomDeliveryService {
       reader,
       state.lastSeenRoomTurnId
     );
-    const turns = guardWorkshopRoomDelivery(pending);
+    const turns = guardWorkshopRoomDelivery(pending, this.characterGuard);
     return {
       reader: { ...reader },
       startingOffset: state.lastSeenRoomTurnId,
@@ -148,7 +153,8 @@ export class WorkshopRoomDeliveryService {
         frameOptions
       ),
       deliveredTurnIds: turns.map((turn) => turn.id),
-      deferredTurns: pending.length - turns.length
+      deferredTurns: pending.length - turns.length,
+      hasConversationalCatchUp: hasWorkshopConversationalCatchUp(pending)
     };
   }
 

--- a/packages/core/src/application/services/workshop/WorkshopRoomDeliveryService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopRoomDeliveryService.ts
@@ -31,6 +31,18 @@ export interface WorkshopPreparedRoomDelivery {
   deferredTurns: number;
 }
 
+/**
+ * Session lifecycle markers are durable room history, but delivering only
+ * those markers is not conversational catch-up worth announcing to the user.
+ */
+export function hasWorkshopConversationalCatchUp(
+  turns: readonly WorkshopTurn[]
+): boolean {
+  return turns.some(
+    (turn) => turn.artifact !== 'session_start' && turn.artifact !== 'session_resume'
+  );
+}
+
 export function projectWorkshopRoomTurns(
   turns: readonly WorkshopTurn[],
   reader: WorkshopCapabilityPrincipal,

--- a/packages/core/src/application/services/workshop/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionService.ts
@@ -138,6 +138,8 @@ interface ActiveRun {
   behaviorTransition?: WorkshopConversationBehaviorTransition;
   /** Provisional evidence finalized only if this participant reply commits. */
   capabilityTurnIds?: string[];
+  /** Writer-origin rows captured from the exact fresh-guest join envelope. */
+  guestJoinWriterSources?: ContextSourceEntry[];
 }
 
 /**
@@ -152,6 +154,31 @@ export interface WorkshopContextAttachment extends WorkshopContextAttachmentSnap
 }
 
 export type WorkshopContextAttachmentInput = Omit<WorkshopContextAttachment, 'id' | 'addedAt'>;
+
+export type WorkshopParticipantSubjectStatus =
+  | { ready: true }
+  | { ready: false; reason: 'scope-unchosen' | 'excerpt-missing' };
+
+export function workshopParticipantSubjectStatus(
+  scope: WorkshopSessionScope,
+  excerpt?: Pick<WorkshopExcerpt, 'text'>
+): WorkshopParticipantSubjectStatus {
+  if (scope === null) {
+    return { ready: false, reason: 'scope-unchosen' };
+  }
+  if (scope === 'open') {
+    return { ready: true };
+  }
+  return excerpt && excerpt.text.trim().length > 0
+    ? { ready: true }
+    : { ready: false, reason: 'excerpt-missing' };
+}
+
+export interface WorkshopPersonaGuestJoinStart {
+  turn: WorkshopTurn;
+  excerpt?: WorkshopExcerpt;
+  contextAttachments: WorkshopContextAttachment[];
+}
 
 export type WorkshopContextAttachmentResult =
   | { ok: true; attachment: WorkshopContextAttachment; eventTurn?: WorkshopTurn }
@@ -907,12 +934,12 @@ export class WorkshopSessionService {
     ];
   }
 
-  /** The current pin as a manifest row; undefined before the first pin. */
-  private pinEntry(): ContextSourceEntry | undefined {
-    if (!this.excerpt) {
+  /** One captured pin as a manifest row; current pin by default. */
+  private pinEntry(excerpt = this.excerpt): ContextSourceEntry | undefined {
+    if (!excerpt) {
       return undefined;
     }
-    const source = this.excerpt.source;
+    const source = excerpt.source;
     return {
       kind: 'pin',
       origin: 'writer',
@@ -920,10 +947,10 @@ export class WorkshopSessionService {
       configuredResource: source.kind !== 'manual' && source.configuredResource
         ? { ...source.configuredResource }
         : undefined,
-      sizeChars: this.excerpt.text.length,
+      sizeChars: excerpt.text.length,
       isEstimate: true,
-      excerptVersion: this.excerpt.version,
-      deliveredAt: this.excerpt.pinnedAt
+      excerptVersion: excerpt.version,
+      deliveredAt: excerpt.pinnedAt
     };
   }
 
@@ -1078,7 +1105,11 @@ export class WorkshopSessionService {
   }
 
   /** Adopt a successful fresh guest conversation at the join snapshot's head. */
-  adoptPersonaGuest(personaId: WorkshopPersonaId, conversationId: string): void {
+  adoptPersonaGuest(
+    personaId: WorkshopPersonaId,
+    conversationId: string,
+    deliveredWriterSources: readonly ContextSourceEntry[] = []
+  ): void {
     this.validatePersonaGuestInvitation(personaId);
     if (!conversationId.trim()) {
       throw new Error('Cannot retain a guest without a conversation id');
@@ -1090,13 +1121,12 @@ export class WorkshopSessionService {
       lastSeenRoomTurnId: roomHead,
       liveness: 'live'
     });
-    // The join envelope delivered the current subject and standing context
-    // (ADR 2026-07-26). The retained manifest must describe that exact input.
-    const pin = this.pinEntry();
-    this.guestWriterSources.set(personaId, [
-      ...(pin ? [pin] : []),
-      ...this.contextAttachments.map((attachment) => this.attachmentEntry(attachment))
-    ]);
+    // Never re-read live room state here: adoption follows an awaited provider
+    // call, so only the join-time snapshot can truthfully describe what shipped.
+    this.guestWriterSources.set(
+      personaId,
+      deliveredWriterSources.map(cloneSourceEntry)
+    );
   }
 
   /** Dispose one guest while preserving its historical thread attribution. */
@@ -1409,10 +1439,24 @@ export class WorkshopSessionService {
     personaId: WorkshopPersonaId,
     requestId: string,
     displayText: string
-  ): WorkshopTurn {
+  ): WorkshopPersonaGuestJoinStart {
     this.requireParticipantSubject();
     this.validatePersonaGuestInvitation(personaId);
-    return this.beginMessage(requestId, displayText, 'personaGuest', undefined, personaId);
+    const excerpt = this.getExcerpt();
+    const contextAttachments = this.getContextAttachments();
+    const turn = this.beginMessage(
+      requestId,
+      displayText,
+      'personaGuest',
+      undefined,
+      personaId
+    );
+    const pin = this.pinEntry(excerpt);
+    this.activeRun!.guestJoinWriterSources = [
+      ...(pin ? [pin] : []),
+      ...contextAttachments.map((attachment) => this.attachmentEntry(attachment))
+    ];
+    return { turn, excerpt, contextAttachments };
   }
 
   /** Begin a direct follow-up to a retained tool sidecar. */
@@ -1492,7 +1536,11 @@ export class WorkshopSessionService {
     }
     if (isGuest && active.guestPersonaId && conversationId) {
       if (!this.isLivePersonaGuest(active.guestPersonaId)) {
-        this.adoptPersonaGuest(active.guestPersonaId, conversationId);
+        this.adoptPersonaGuest(
+          active.guestPersonaId,
+          conversationId,
+          active.guestJoinWriterSources
+        );
       }
       const guest = this.participants.personaGuests.get(active.guestPersonaId);
       if (guest?.liveness === 'live') {
@@ -1948,6 +1996,7 @@ export class WorkshopSessionService {
     return {
       excerpt: this.excerpt ? excerptSnapshot(this.excerpt) : undefined,
       scope: this.scope,
+      participantSubjectReady: this.getParticipantSubjectStatus().ready,
       shelvedExcerpt: this.shelvedExcerpt ? excerptSnapshot(this.shelvedExcerpt) : undefined,
       excerptVersion: this.excerptVersion,
       replacementCount: this.replacementCount,
@@ -2065,11 +2114,16 @@ export class WorkshopSessionService {
    * whose path is still unchosen has no subject at all — the writer has not
    * told us what this room is for yet.
    */
+  getParticipantSubjectStatus(): WorkshopParticipantSubjectStatus {
+    return workshopParticipantSubjectStatus(this.scope, this.excerpt);
+  }
+
   private requireParticipantSubject(): void {
-    if (this.scope === 'open') {
+    const status = this.getParticipantSubjectStatus();
+    if (status.ready) {
       return;
     }
-    if (this.scope === null) {
+    if (status.reason === 'scope-unchosen') {
       throw new Error('Choose how to start this Workshop session before messaging');
     }
     this.requireExcerpt();

--- a/packages/core/src/application/services/workshop/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionService.ts
@@ -1108,7 +1108,7 @@ export class WorkshopSessionService {
   adoptPersonaGuest(
     personaId: WorkshopPersonaId,
     conversationId: string,
-    deliveredWriterSources: readonly ContextSourceEntry[] = []
+    deliveredWriterSources: readonly ContextSourceEntry[]
   ): void {
     this.validatePersonaGuestInvitation(personaId);
     if (!conversationId.trim()) {
@@ -1536,6 +1536,12 @@ export class WorkshopSessionService {
     }
     if (isGuest && active.guestPersonaId && conversationId) {
       if (!this.isLivePersonaGuest(active.guestPersonaId)) {
+        if (!active.guestJoinWriterSources) {
+          throw new Error(
+            `Cannot adopt Workshop guest ${workshopPersonaLabel(active.guestPersonaId)} ` +
+            'without a join-time writer-source snapshot'
+          );
+        }
         this.adoptPersonaGuest(
           active.guestPersonaId,
           conversationId,

--- a/packages/core/src/application/services/workshop/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionService.ts
@@ -1090,9 +1090,13 @@ export class WorkshopSessionService {
       lastSeenRoomTurnId: roomHead,
       liveness: 'live'
     });
-    // The join envelope delivered the current pin (Phase 7).
+    // The join envelope delivered the current subject and standing context
+    // (ADR 2026-07-26). The retained manifest must describe that exact input.
     const pin = this.pinEntry();
-    this.guestWriterSources.set(personaId, pin ? [pin] : []);
+    this.guestWriterSources.set(personaId, [
+      ...(pin ? [pin] : []),
+      ...this.contextAttachments.map((attachment) => this.attachmentEntry(attachment))
+    ]);
   }
 
   /** Dispose one guest while preserving its historical thread attribution. */
@@ -1382,7 +1386,7 @@ export class WorkshopSessionService {
     displayText: string,
     messageAttachments?: readonly WorkshopMessageAttachmentSnapshot[]
   ): WorkshopTurn {
-    this.requireHostSubject();
+    this.requireParticipantSubject();
     return this.beginMessage(requestId, displayText, 'host', undefined, undefined, messageAttachments);
   }
 
@@ -1393,7 +1397,7 @@ export class WorkshopSessionService {
     displayText: string,
     messageAttachments?: readonly WorkshopMessageAttachmentSnapshot[]
   ): WorkshopTurn {
-    this.requireExcerpt();
+    this.requireParticipantSubject();
     if (!this.isLivePersonaGuest(personaId)) {
       throw new Error(`Cannot message Workshop guest ${workshopPersonaLabel(personaId)} without a live sidecar`);
     }
@@ -1406,7 +1410,7 @@ export class WorkshopSessionService {
     requestId: string,
     displayText: string
   ): WorkshopTurn {
-    this.requireExcerpt();
+    this.requireParticipantSubject();
     this.validatePersonaGuestInvitation(personaId);
     return this.beginMessage(requestId, displayText, 'personaGuest', undefined, personaId);
   }
@@ -2056,12 +2060,12 @@ export class WorkshopSessionService {
   }
 
   /**
-   * What a HOST turn needs to exist (Sprint 13A §1): a pinned passage, or an
-   * open conversation, which is a real scope rather than a blank excerpt. A
-   * session whose path is still unchosen has no subject at all — the writer
-   * has not told us what this room is for yet.
+   * What a participant turn needs to exist: a pinned passage, or an open
+   * conversation, which is a real scope rather than a blank excerpt. A session
+   * whose path is still unchosen has no subject at all — the writer has not
+   * told us what this room is for yet.
    */
-  private requireHostSubject(): void {
+  private requireParticipantSubject(): void {
     if (this.scope === 'open') {
       return;
     }

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -396,9 +396,7 @@ export const WorkshopApp: React.FC = () => {
   // Live run bubble: visible from run start until the assistant turn lands.
   const showLiveTurn = workshop.isRunning || workshop.isStreaming || workshop.streamingContent.length > 0;
   // Invite appears once context is ready and the room has an open guest seat.
-  const canInviteGuest = workshop.scope !== null
-    && (workshop.scope === 'open' || !!workshop.excerpt)
-    && workshop.sessionReady
+  const canInviteGuest = workshop.canMessage
     && !roomMutationLocked
     && workshop.personaGuests.filter((guest) => guest.liveness === 'live').length
       < WORKSHOP_GUEST_CAPACITY;
@@ -1289,11 +1287,8 @@ export const WorkshopApp: React.FC = () => {
             {/* Scope copy belongs to the header and scope strip. This gauge
                 names the participant whose retained context it measures. */}
             <ContextBudget
-              label={
-                workshop.scope === 'open' && !hasExcerpt
-                  ? chatTargetLabel
-                  : workshop.contextBudget?.label ?? `${chatTargetLabel} context`
-              }
+              participantLabel={chatTargetLabel}
+              showsContextSuffix={!(workshop.scope === 'open' && !hasExcerpt)}
               snapshot={workshop.contextBudget?.snapshot}
               modelOptions={modelsSettings.modelOptions}
               cumulativeProcessedTokens={tokenTracking.usage.totalTokens}

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -378,6 +378,11 @@ export const WorkshopApp: React.FC = () => {
         ?? guestTargetPersonaId
         ?? 'Guest'
       : activePersona.label;
+  const chatTargetIdentity = workshop.chatTarget.kind === 'tool'
+    ? `tool:${workshop.chatTarget.toolId}`
+    : workshop.chatTarget.kind === 'personaGuest'
+      ? guestTargetPersonaId ?? 'guest:unknown'
+      : activePersona.id;
 
   // Recomputing a full word split per streamed token was O(excerpt) work on
   // the token clock (PR #67 review #11) — the excerpt only changes on re-pin.
@@ -1287,6 +1292,7 @@ export const WorkshopApp: React.FC = () => {
             {/* Scope copy belongs to the header and scope strip. This gauge
                 names the participant whose retained context it measures. */}
             <ContextBudget
+              participantIdentity={chatTargetIdentity}
               participantLabel={chatTargetLabel}
               showsContextSuffix={!(workshop.scope === 'open' && !hasExcerpt)}
               snapshot={workshop.contextBudget?.snapshot}

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -396,7 +396,8 @@ export const WorkshopApp: React.FC = () => {
   // Live run bubble: visible from run start until the assistant turn lands.
   const showLiveTurn = workshop.isRunning || workshop.isStreaming || workshop.streamingContent.length > 0;
   // Invite appears once context is ready and the room has an open guest seat.
-  const canInviteGuest = !!workshop.excerpt
+  const canInviteGuest = workshop.scope !== null
+    && (workshop.scope === 'open' || !!workshop.excerpt)
     && workshop.sessionReady
     && !roomMutationLocked
     && workshop.personaGuests.filter((guest) => guest.liveness === 'live').length
@@ -1285,14 +1286,12 @@ export const WorkshopApp: React.FC = () => {
               onInviteGuest={openGuestModal}
               onDismissGuest={workshop.dismissGuest}
             />
-            {/* §10: the composer's context line reports SCOPE while the room
-                has no passage. "<Host> context" would be true but useless
-                there — what the writer needs to see is that no excerpt is in
-                it. Once one is pinned it returns to the participant gauge. */}
+            {/* Scope copy belongs to the header and scope strip. This gauge
+                names the participant whose retained context it measures. */}
             <ContextBudget
               label={
                 workshop.scope === 'open' && !hasExcerpt
-                  ? 'Open conversation · No excerpt yet'
+                  ? chatTargetLabel
                   : workshop.contextBudget?.label ?? `${chatTargetLabel} context`
               }
               snapshot={workshop.contextBudget?.snapshot}

--- a/packages/core/src/presentation/webview/components/shared/ContextBudget.tsx
+++ b/packages/core/src/presentation/webview/components/shared/ContextBudget.tsx
@@ -13,7 +13,9 @@ import {
 } from '@utils/contextBudget';
 
 interface ContextBudgetProps {
-  label: string;
+  participantLabel: string;
+  /** Scope copy lives elsewhere; false renders only the participant's name. */
+  showsContextSuffix?: boolean;
   snapshot?: ContextBudgetSnapshot;
   modelOptions: readonly ModelOption[];
   cumulativeProcessedTokens: number;
@@ -87,9 +89,6 @@ const compressionValueClass = (value: ContextBudgetSnapshot['contextCompression'
   unknown: 'pm-ctx-dim'
 })[value];
 
-/** Most measured labels include "context"; the footer wants the bare name. */
-const participantName = (label: string): string => label.replace(/\s+context$/i, '');
-
 const Chevron: React.FC = () => (
   <span className="pm-context-budget-chev" aria-hidden="true">
     <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
@@ -105,27 +104,37 @@ const IdentityDot: React.FC<{ label: string }> = ({ label }) => (
   />
 );
 
-const ParticipantLabel: React.FC<{ label: string }> = ({ label }) => (
+const ParticipantLabel: React.FC<{
+  participantLabel: string;
+  showsContextSuffix: boolean;
+}> = ({ participantLabel, showsContextSuffix }) => (
   <span className="pm-context-budget-name">
-    <b>{participantName(label)}</b>
-    {/\s+context$/i.test(label) ? <>&nbsp;context</> : null}
+    <b>{participantLabel}</b>
+    {showsContextSuffix ? <>&nbsp;context</> : null}
   </span>
 );
 
 export const ContextBudget: React.FC<ContextBudgetProps> = ({
-  label,
+  participantLabel,
+  showsContextSuffix = true,
   snapshot,
   modelOptions,
   cumulativeProcessedTokens,
   sources,
   requesterLabel
 }) => {
+  const accessibleLabel = showsContextSuffix
+    ? `${participantLabel} context`
+    : participantLabel;
   if (!snapshot) {
     return (
-      <div className="pm-context-budget pm-context-budget-empty" role="status" aria-label={`${label}: not measured yet`}>
+      <div className="pm-context-budget pm-context-budget-empty" role="status" aria-label={`${accessibleLabel}: not measured yet`}>
         <div className="pm-context-budget-row">
-          <IdentityDot label={label} />
-          <ParticipantLabel label={label} />
+          <IdentityDot label={participantLabel} />
+          <ParticipantLabel
+            participantLabel={participantLabel}
+            showsContextSuffix={showsContextSuffix}
+          />
           <span className="pm-context-budget-track" />
           <span className="pm-context-budget-nums">Not measured yet — updates after the first reply</span>
         </div>
@@ -139,7 +148,7 @@ export const ContextBudget: React.FC<ContextBudgetProps> = ({
   const primary = view.usableInputTokens === undefined
     ? `Context ${formatCompactTokens(snapshot.contextTokens)} · Window unavailable`
     : `Context ${formatCompactTokens(snapshot.contextTokens)} / ${formatCompactTokens(view.usableInputTokens)} · ${percent}%`;
-  const accessible = `${label}. ${primary}. ${snapshot.callsThisTurn} calls this turn, ` +
+  const accessible = `${accessibleLabel}. ${primary}. ${snapshot.callsThisTurn} calls this turn, ` +
     `${snapshot.turnProcessedTokens.toLocaleString()} tokens processed. Compression ${compressionLabel(snapshot.contextCompression)}.`;
 
   return (
@@ -149,8 +158,11 @@ export const ContextBudget: React.FC<ContextBudgetProps> = ({
         aria-label={accessible}
         title="Retained context after the last committed reply — click for details"
       >
-        <IdentityDot label={label} />
-        <ParticipantLabel label={label} />
+        <IdentityDot label={participantLabel} />
+        <ParticipantLabel
+          participantLabel={participantLabel}
+          showsContextSuffix={showsContextSuffix}
+        />
         <span className="pm-context-budget-track">
           {percent !== undefined && (
             <span
@@ -199,7 +211,7 @@ export const ContextBudget: React.FC<ContextBudgetProps> = ({
         <InContextSources sources={sources} requesterLabel={requesterLabel} />
       )}
       <div className="pm-context-budget-foot">
-        Context measured on <b>{participantName(label)}</b>&rsquo;s last committed reply. Each participant keeps
+        Context measured on <b>{participantLabel}</b>&rsquo;s last committed reply. Each participant keeps
         its own conversation; switching targets never resets it.
       </div>
     </details>

--- a/packages/core/src/presentation/webview/components/shared/ContextBudget.tsx
+++ b/packages/core/src/presentation/webview/components/shared/ContextBudget.tsx
@@ -87,7 +87,7 @@ const compressionValueClass = (value: ContextBudgetSnapshot['contextCompression'
   unknown: 'pm-ctx-dim'
 })[value];
 
-/** The gauge label is "<participant> context"; the footer wants the bare name. */
+/** Most measured labels include "context"; the footer wants the bare name. */
 const participantName = (label: string): string => label.replace(/\s+context$/i, '');
 
 const Chevron: React.FC = () => (
@@ -107,7 +107,8 @@ const IdentityDot: React.FC<{ label: string }> = ({ label }) => (
 
 const ParticipantLabel: React.FC<{ label: string }> = ({ label }) => (
   <span className="pm-context-budget-name">
-    <b>{participantName(label)}</b>&nbsp;context
+    <b>{participantName(label)}</b>
+    {/\s+context$/i.test(label) ? <>&nbsp;context</> : null}
   </span>
 );
 

--- a/packages/core/src/presentation/webview/components/shared/ContextBudget.tsx
+++ b/packages/core/src/presentation/webview/components/shared/ContextBudget.tsx
@@ -9,10 +9,12 @@ import {
 import {
   contextBudgetView,
   formatCompactTokens,
-  participantDotIndex
+  participantIdentityColorIndex
 } from '@utils/contextBudget';
 
 interface ContextBudgetProps {
+  /** Canonical persona id or a namespaced non-persona participant key. */
+  participantIdentity: string;
   participantLabel: string;
   /** Scope copy lives elsewhere; false renders only the participant's name. */
   showsContextSuffix?: boolean;
@@ -97,9 +99,9 @@ const Chevron: React.FC = () => (
   </span>
 );
 
-const IdentityDot: React.FC<{ label: string }> = ({ label }) => (
+const IdentityDot: React.FC<{ identity: string }> = ({ identity }) => (
   <span
-    className={`pm-context-budget-dot pm-context-budget-dot-${participantDotIndex(label)}`}
+    className={`pm-context-budget-dot pm-context-budget-dot-${participantIdentityColorIndex(identity)}`}
     aria-hidden="true"
   />
 );
@@ -115,6 +117,7 @@ const ParticipantLabel: React.FC<{
 );
 
 export const ContextBudget: React.FC<ContextBudgetProps> = ({
+  participantIdentity,
   participantLabel,
   showsContextSuffix = true,
   snapshot,
@@ -130,7 +133,7 @@ export const ContextBudget: React.FC<ContextBudgetProps> = ({
     return (
       <div className="pm-context-budget pm-context-budget-empty" role="status" aria-label={`${accessibleLabel}: not measured yet`}>
         <div className="pm-context-budget-row">
-          <IdentityDot label={participantLabel} />
+          <IdentityDot identity={participantIdentity} />
           <ParticipantLabel
             participantLabel={participantLabel}
             showsContextSuffix={showsContextSuffix}
@@ -158,7 +161,7 @@ export const ContextBudget: React.FC<ContextBudgetProps> = ({
         aria-label={accessible}
         title="Retained context after the last committed reply — click for details"
       >
-        <IdentityDot label={participantLabel} />
+        <IdentityDot identity={participantIdentity} />
         <ParticipantLabel
           participantLabel={participantLabel}
           showsContextSuffix={showsContextSuffix}

--- a/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
@@ -282,6 +282,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
     React.useState<WorkshopConversationDegradation[]>([]);
   const [excerpt, setExcerpt] = React.useState<WorkshopExcerptSnapshot | null>(null);
   const [scope, setScopeState] = React.useState<WorkshopSessionScope>(null);
+  const [participantSubjectReady, setParticipantSubjectReady] = React.useState(false);
   const [shelvedExcerpt, setShelvedExcerpt] = React.useState<WorkshopExcerptSnapshot | null>(null);
   const [roomHasMemory, setRoomHasMemory] = React.useState(false);
   const [attachmentContent, setAttachmentContent] =
@@ -685,6 +686,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
       );
       setExcerpt(session.excerpt ?? null);
       setScopeState(session.scope);
+      setParticipantSubjectReady(session.participantSubjectReady);
       setShelvedExcerpt(session.shelvedExcerpt ?? null);
       setRoomHasMemory(session.roomHasMemory);
       setContextAttachments(session.contextAttachments ?? []);
@@ -885,12 +887,11 @@ export const useWorkshop = (): UseWorkshopReturn => {
   const currentRequestId = liveRun?.phase === 'streaming' ? liveRun.requestId : null;
   const isRunning = currentRequestId !== null || activeToolId !== null;
   const hiddenTurns = Math.max(0, totalTurns - turns.length);
-  // Sprint 13A §1: an open conversation is a real, messageable room; a session
-  // whose path is unchosen is not, even when an excerpt carried over from the
-  // previous one — the writer has not said what this room is for yet.
+  // ADR 2026-07-26: the aggregate owns subject validity. The webview combines
+  // that host decision only with local readiness/run state.
   const canMessage = sessionReady
     && !isRunning
-    && (scope === 'open' || (scope === 'excerpt' && !!excerpt?.text.trim()));
+    && participantSubjectReady;
   const isPersonaSelectionLocked = hasHostConversation || isRunning;
 
   return {

--- a/packages/core/src/presentation/webview/index.css
+++ b/packages/core/src/presentation/webview/index.css
@@ -53,11 +53,18 @@ summary.pm-context-budget-row:focus-visible {
   flex: none;
   background: var(--pm-dim);
 }
-.pm-context-budget-dot-0 { background: var(--pm-accent); }
-.pm-context-budget-dot-1 { background: var(--pm-blue); }
-.pm-context-budget-dot-2 { background: var(--pm-green); }
-.pm-context-budget-dot-3 { background: var(--pm-amber); }
-.pm-context-budget-dot-4 { background: var(--pm-link); }
+.pm-context-budget-dot-0 { background: var(--pm-identity-0); }
+.pm-context-budget-dot-1 { background: var(--pm-identity-1); }
+.pm-context-budget-dot-2 { background: var(--pm-identity-2); }
+.pm-context-budget-dot-3 { background: var(--pm-identity-3); }
+.pm-context-budget-dot-4 { background: var(--pm-identity-4); }
+.pm-context-budget-dot-5 { background: var(--pm-identity-5); }
+.pm-context-budget-dot-6 { background: var(--pm-identity-6); }
+.pm-context-budget-dot-7 { background: var(--pm-identity-7); }
+.pm-context-budget-dot-8 { background: var(--pm-identity-8); }
+.pm-context-budget-dot-9 { background: var(--pm-identity-9); }
+.pm-context-budget-dot-10 { background: var(--pm-identity-10); }
+.pm-context-budget-dot-11 { background: var(--pm-identity-11); }
 
 .pm-context-budget-name {
   font-size: 12.5px;

--- a/packages/core/src/presentation/webview/utils/contextBudget.ts
+++ b/packages/core/src/presentation/webview/utils/contextBudget.ts
@@ -1,4 +1,5 @@
 import { ContextBudgetSnapshot, ModelOption } from '@shared/types';
+import { WORKSHOP_PERSONA_CATALOG } from '@shared/constants/workshopPersonas';
 
 export type ContextBudgetTone = 'normal' | 'watch' | 'high' | 'critical' | 'unknown';
 
@@ -33,17 +34,24 @@ export const contextBudgetView = (
   };
 };
 
+const PARTICIPANT_IDENTITY_COLOR_COUNT = WORKSHOP_PERSONA_CATALOG.length;
+const PERSONA_IDENTITY_COLOR_INDEX: ReadonlyMap<string, number> = new Map(
+  WORKSHOP_PERSONA_CATALOG.map((persona, index) => [persona.id, index])
+);
+
 /**
- * Deterministic identity color slot for a participant label. Conversation ids
- * never reach the webview, so the label is the only stable identity — a hash
- * keeps each participant's dot color steady across renders and reloads.
+ * Deterministic identity color slot. Canonical Workshop personas receive
+ * collision-free roster slots; other participant kinds retain a stable hash.
  */
-export const participantDotIndex = (label: string): number => {
+export const participantIdentityColorIndex = (identity: string): number => {
+  const personaIndex = PERSONA_IDENTITY_COLOR_INDEX.get(identity);
+  if (personaIndex !== undefined) return personaIndex;
+
   let hash = 0;
-  for (let i = 0; i < label.length; i += 1) {
-    hash = (hash * 31 + label.charCodeAt(i)) | 0;
+  for (let i = 0; i < identity.length; i += 1) {
+    hash = (hash * 31 + identity.charCodeAt(i)) | 0;
   }
-  return Math.abs(hash) % 5;
+  return Math.abs(hash) % PARTICIPANT_IDENTITY_COLOR_COUNT;
 };
 
 export const formatCompactTokens = (tokens: number): string => {

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -44,6 +44,22 @@
   --pm-amber:  #e2b24a;
   --pm-red:    #ef7d66;
 
+  /* Stable participant identity palette. Roster slots are assigned in
+     WORKSHOP_PERSONA_CATALOG order; these tokens can later travel from the
+     context dot into participant-card accents without re-deriving identity. */
+  --pm-identity-0:  #ee7d49;
+  --pm-identity-1:  #5aa2f0;
+  --pm-identity-2:  #6fc98a;
+  --pm-identity-3:  #e0589e;
+  --pm-identity-4:  #e2b24a;
+  --pm-identity-5:  #a78bfa;
+  --pm-identity-6:  #4fc3c8;
+  --pm-identity-7:  #f08aa6;
+  --pm-identity-8:  #a8c95f;
+  --pm-identity-9:  #7db7e8;
+  --pm-identity-10: #d99a62;
+  --pm-identity-11: #c69cf4;
+
   --pm-r-card: 12px;
   --pm-r-tile: 9px;
   --pm-r-input: 8px;

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -769,6 +769,12 @@ export interface WorkshopSessionSnapshot {
    */
   scope: WorkshopSessionScope;
   /**
+   * Aggregate-owned participant-subject policy (ADR 2026-07-26): true when a
+   * host or persona guest may speak in the current scope. The webview consumes
+   * this result; it does not re-derive scope/excerpt validity.
+   */
+  participantSubjectReady: boolean;
+  /**
    * The passage the writer set aside when switching to open conversation.
    * Shelved, not deleted: re-pinning restores this exact version.
    */


### PR DESCRIPTION
## Summary

- allow persona guests to join and continue in excerpt-free open rooms
- give a joining guest the bounded room snapshot, the existing no-excerpt honesty frame, and writer-selected standing context
- seed the guest context manifest with the material actually delivered at join
- keep direct tool sidecars excerpt-gated
- treat session-start/session-resume-only delivery as lifecycle context rather than conversational catch-up
- show the active participant name in the context meter instead of repeating the no-excerpt warning

## Why

Sprint 13A intentionally left guest invitation excerpt-only until the join prompt could make the same honesty guarantee as the host. After 13D unified room delivery, those temporary UI, handler, and aggregate guards made open rooms unnecessarily asymmetric.

The misleading `Catching Jill up on the room…` message had a separate cause: the status path treated any pending delivery frame—including a lone durable session marker—as conversational catch-up.

The implementation extends the existing participant-subject invariant and room-delivery policy. It does not introduce another transcript store, visibility class, cursor, or WorkshopApp state.

## Review fixes

- capture the exact guest-join excerpt, attachments, and writer-source manifest before the provider await; adoption never re-reads mutable room state
- centralize participant-subject policy in the aggregate and publish its decision to the webview
- classify catch-up from the complete eligible backlog before runaway shaping and log the selected classification
- replace context-label suffix sniffing with an explicit presentation flag
- cover both refusal reasons, mixed excerpt/context joins, join-time snapshot fidelity, and guard-deferred conversation
- update the ADR, sprint record, and living review ledger

## Validation

- focused Workshop contract: 308 tests passed
- full Jest suite: 1,446 tests across 133 suites; snapshot passed
- `npm run typecheck`: passed for core, webview, and extension
- `npm run lint`: zero errors; existing repository warnings only
- `npm run build`: production bundles compiled and sentinel verification passed; existing webpack size warnings only
- `git diff --check`: passed

## Documentation

- `docs/adr/2026-07-26-workshop-open-room-participants.md`
- `.todo/epics/epic-workshop-editor-tab-2026-07-03/sprints/13d_2-open-room-participants.md`
- `docs/pr-reviews/pr-91-open-room-participants-review.md`

## Manual follow-up

Extension Development Host smoke remains pending for the open-room invitation flow and final copy/visual confirmation.