### PR TITLE
feat(workshop): add web research setting

### DIFF
--- a/.todo/tech-debt/2026-07-27-workshop-web-research-budget-and-citation-contract.md
+++ b/.todo/tech-debt/2026-07-27-workshop-web-research-budget-and-citation-contract.md
@@ -1,0 +1,28 @@
+# Workshop web-research budget and citation-link contract
+
+- **Status:** Deferred from PR #93 review
+- **Priority:** High
+- **Related:** PR #93, `docs/pr-reviews/pr-93-workshop-web-research-review.md`
+
+## Problem
+
+Workshop enables OpenRouter's server-side web-search tool per persona turn. The current provider response does not expose a durable, authoritative count of server-tool invocations, so a session-wide budget cannot be enforced honestly without a product contract for what is counted, when it resets, and what the room does after it is exhausted.
+
+The provider's URL annotations also identify sources but do not reliably map a model-authored inline `[n]` marker to an annotation. The current, user-directed UI keeps independently numbered clickable source pills; it must not imply that those numbers are a canonical mapping for inline markers.
+
+The room-settings coordinator now owns a third guarded setting. If this feature gains a visible budget or additional controls, the web-research state should be extracted into a dedicated service rather than adding more coordinator-owned persistence fields.
+
+## Related files
+
+- `packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts`
+- `packages/core/src/application/services/workshop/RunWorkshopToolSidePass.ts`
+- `packages/core/src/infrastructure/api/providers/OpenRouterClient.ts`
+- `packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx`
+
+## Completion criteria
+
+- Define a user-visible per-session budget, reset behavior, and exhausted-state UX.
+- Base accounting on provider-reported tool usage/cost when available; document any conservative fallback.
+- Persist and display the remaining budget without charging disabled or non-search turns.
+- Preserve source title/URL pills and add inline citation anchors only when provider annotations can prove the mapping.
+- Extract web-research settings ownership into a dedicated service if the control surface expands beyond the current enablement toggle.

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -405,6 +405,23 @@
           "description": "Optional global writer profile shared only with Workshop personas. It is not session memory and is not copied into project data.",
           "order": 51
         },
+        "proseMinion.workshop.webResearch": {
+          "type": "object",
+          "scope": "application",
+          "default": {
+            "enabled": false
+          },
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Allow Workshop personas to use OpenRouter server-side web research when current information helps. May add latency and provider charges."
+            }
+          },
+          "required": ["enabled"],
+          "additionalProperties": false,
+          "description": "Optional live-web research for Workshop persona conversations. Workshop tools remain unchanged.",
+          "order": 52
+        },
         "proseMinion.publishingStandards.preset": {
           "type": "string",
           "default": "none",

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -407,19 +407,18 @@
         },
         "proseMinion.workshop.webResearch": {
           "type": "object",
-          "scope": "application",
           "default": {
             "enabled": false
           },
           "properties": {
             "enabled": {
               "type": "boolean",
-              "description": "Allow Workshop personas to use OpenRouter server-side web research when current information helps. May add latency and provider charges."
+              "description": "Allow Workshop personas to use live web research when current information helps. Queries can draw on room context and are processed by OpenRouter and search providers; enable only for material you are comfortable sharing. May add latency and charges."
             }
           },
           "required": ["enabled"],
           "additionalProperties": false,
-          "description": "Optional live-web research for Workshop persona conversations. Workshop tools remain unchanged.",
+          "description": "Optional per-window live-web research for Workshop persona conversations. Research may share active conversation context with OpenRouter and search providers. Workshop tools remain unchanged.",
           "order": 52
         },
         "proseMinion.publishingStandards.preset": {

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -207,16 +207,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     platform.settings,
     outputChannel
   );
-  const workshopToolSidePass = new RunWorkshopToolSidePass(
-    assistantToolService,
-    workshopAnalysisSidePass,
-    workshopSessionService,
-    workshopRoomDeliveryService,
-    workshopPersonaCapabilityFactory,
-    outputChannel,
-    workshopWriterProfileService
-  );
-  const workshopContextResourceService = new WorkshopContextResourceService(contextResourceResolver);
   const workshopConversationSettingsService = new WorkshopConversationSettingsService(
     workshopSessionService,
     assistantToolService,
@@ -224,6 +214,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     outputChannel,
     workshopWriterProfileService
   );
+  const workshopToolSidePass = new RunWorkshopToolSidePass(
+    assistantToolService,
+    workshopAnalysisSidePass,
+    workshopSessionService,
+    workshopRoomDeliveryService,
+    workshopPersonaCapabilityFactory,
+    outputChannel,
+    workshopWriterProfileService,
+    () => workshopConversationSettingsService.getWebResearch().enabled
+  );
+  const workshopContextResourceService = new WorkshopContextResourceService(contextResourceResolver);
   const workshopSessionTimeService = new WorkshopSessionTimeService();
   const workshopSessionStore = new WorkshopSessionStore(
     platform.fileSystem,

--- a/docs/pr-reviews/pr-93-workshop-web-research-review.md
+++ b/docs/pr-reviews/pr-93-workshop-web-research-review.md
@@ -1,0 +1,546 @@
+# MR Review — Workshop web research setting
+
+**Author:** Okey Landers · PR [#93](https://github.com/okeylanders/prose-minion-vscode/pull/93) · `feat/workshop-web-research` → `epic/workshop-editor-tab`
+
+---
+
+## Resolution ledger
+
+Status is the reviewer's **initial recommendation**, not a verdict — update the `Status` column as
+findings are addressed so this file stays a living record. Legend: **Open** = act before merge ·
+**Deferred** = real issue, safe to punt for a stated reason (track it) · **Addressed** = fixed ·
+**Partially addressed** = fixed with a noted remainder · **N/A** = out of scope or superseded.
+
+| # | Sev | Finding | Reviewers | Consensus | Status |
+|---|-----|---------|-----------|-----------|--------|
+| 1 | 🔴 Blocking | `npm test` is red — modal suite fails to compile, `MessageHandler` test throws `getWebResearch is not a function` | Cal, Bria | 🎯🎯 | **Open** |
+| 2 | 🔴 Blocking | `[open, webResearch]` dep array wipes half-typed Conversation Settings drafts on every session-state push | Blake, Tim, Bria | 🎯🎯 | **Open** |
+| 3 | 🔴 Blocking | `assertCitation` accepts any string as a URL; `new URL()` in render then takes out the whole thread pane | Sam, Patricia, Blake | 🎯🎯 | **Open** |
+| 4 | 🔴 Blocking | `webResearch` skips the pending-persistence guard PR #83 added — failed write silently reverts | Marcus, Stan | 🎯 | **Open** |
+| 5 | 🟠 High | `citations: last.citations` drops every source found before the final turn of a multi-turn run | Blake | — | **Open** |
+| 6 | 🟠 High | `RunWorkshopToolSidePass` host tool-synthesis turn never receives `webResearch` | Bria | — | **Open** |
+| 7 | 🟠 High | No session-level cap on web-search spend or latency; attached to every persona turn | Tim | — | **Open** |
+| 8 | 🟠 High | `scope: "application"` on a network capability — no per-workspace opt-out, syncs across machines | Patricia | — | **Open** |
+| 9 | 🟠 High | Disclosure names latency and provider charges, never the second data recipient | Patricia | — | **Open** |
+| 10 | 🟠 High | First-wins citation merge silently discards a richer duplicate's title | Sam | — | **Open** |
+| 11 | 🟠 High | Pill numbers can disagree with the model's own inline `[n]` markers | Sam | — | **Open** |
+| 12 | 🟠 High | `WorkshopConversationSettingsService` web-research logic untested — and the existing mock would mask a backwards wiring | Cal | — | **Open** |
+| 13 | 🟠 High | The default-off case — the whole point of the feature — is never asserted | Cal | — | **Open** |
+| 14 | 🟠 High | Citation parse failures are indistinguishable from "the model cited nothing" | Oliver | — | **Open** |
+| 15 | 🟠 High | `createAnalysisResult` reaches 8 positional params; 3 call sites pad slot 7 with a literal `undefined` | Parker | — | **Open** |
+| 16 | 🟡 Standard | `readWebResearchSetting` drops the rejection-logging convention its writer-profile sibling adopted | Stan, Oliver | 🎯 | **Open** |
+| 17 | 🟡 Standard | Nothing logs that a turn attached the web-search tool; a research-only toggle logs nothing at all | Oliver | — | **Open** |
+| 18 | 🟡 Standard | Dedicated-service pattern not extended — web research is a bare private field on the coordinator | Marcus | — | **Open** |
+| 19 | 🟡 Standard | `changed: result.changed \|\| webResearchChanged` spelled out 3×, plus a rename that never diverges | Parker | — | **Open** |
+| 20 | 🟡 Standard | One feature, four names — Advanced / Research / `webResearch` / "live web research" | Parker | — | **Open** |
+| 21 | 🟢 Nit | `UrlCitation` forks the `TokenUsage` precedent for where cross-cutting provider types live | Marcus | — | **Open** |
+| 22 | 🟢 Nit | New `coerce`/`equal` pair ships without the doc comments both siblings carry; lone optional param | Stan | — | **Open** |
+
+---
+
+## Blast Radius
+
+- 26 files changed · +524 / −55 lines · 6 commits
+- New files: 1 (`shared/types/citations.ts`) · Migrations: no · New services: 0
+- New settings triple: 1 (`proseMinion.workshop.webResearch`, application-scoped)
+- New persisted field on the `WorkshopSessionStateV1` turn shape: `citations`
+- New provider capability: `openrouter:web_search` server tool — **this PR opens a new outbound network path for manuscript-derived content**
+- Reviewer-run verification: `npx jest` → **2 suites failed, 135 passed** · **1 test failed, 1467 passed**
+
+---
+
+## Report Card
+
+| Category | Grade |
+| --- | --- |
+| 🏛️ Architecture | D |
+| 🛡️ Security | D |
+| 🧪 Tests | F |
+| 📖 Quality | C |
+| ⚡ Performance | C+ |
+| 🎯 Domain | D |
+
+---
+
+## Executive Briefing
+
+🔴🎯🎯 **[Cal + Bria]** **`npm test` is red on this branch.** `WorkshopConversationBehaviorModal.test.tsx` fails to *compile* (TS2322 — `webResearch` became a required prop and the sibling suite was never updated), and `MessageHandler.test.ts` throws `getWebResearch is not a function` because `sendSessionState` now calls a method the test's settings-service stub doesn't define. Confirmed by running the suite. Note that `npm run typecheck` **deliberately excludes** `src/__tests__`, and the PR's stated validation was a *targeted* 60-test run — so both green checks were honest and both were blind to this.
+
+🔴🎯🎯 **[Blake + Tim + Bria]** **The Conversation Settings modal now eats in-progress drafts.** The reset effect's dep array went from `[open]` to `[open, webResearch]`, but `webResearch` is a freshly-allocated object on every push (`getWebResearch()` spreads; `postSessionState()` has 34 call sites; `coerceWorkshopWebResearchSettings` allocates in both branches). Leave the modal open during a live turn and a 900-word writer-profile bio is silently replaced and the user is snapped back to the Behavior tab. `writerProfile` has the identical churn and was deliberately kept *out* of that array.
+
+🔴🎯🎯 **[Sam + Patricia + Blake]** **A malformed persisted citation takes out the entire conversation, permanently.** `toUrlCitations` enforces `/^https?:\/\//` on the provider path; `assertCitation` — the gate for untrusted on-disk state — checks only `typeof url === 'string'`. Verified: `"anthropic.com"` passes `assertCitation`, and `citationLabel`'s unguarded `new URL()` throws during render, escalating to the thread-level ErrorBoundary. The bad row is on disk, so it survives reloads.
+
+🔴🎯 **[Marcus + Stan]** **This is PR #83's blocker #2, reborn on the third setting in the same file.** `applyFromWebview` commits `this.webResearch` *before* attempting persistence, but unlike behavior and profile it records no pending-persistence value — so a failed write plus any later config change silently reverts the user's toggle. The fix for the other two settings is nine lines up.
+
+🟠 **[Patricia]** **The disclosure describes the invoice, not the second recipient.** All three user-facing strings frame this as OpenRouter latency and provider charges. None say that manuscript excerpts and the writer profile become search queries executed against infrastructure beyond the LLM provider — and `scope: "application"` means a toggle flipped on a hobby project is already on when an NDA'd manuscript opens elsewhere.
+
+---
+
+## 🏛️ Marcus · Architecture & Design
+
+"The Cartographer of Layer Boundaries"
+
+### 🔴 Blocking — Web-research setting reintroduces the exact persistence-echo revert bug PR #83 fixed [🎯 Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts:166`
+
+```ts
+this.webResearch = this.readWebResearchSetting();
+```
+
+Trace it: `applyFromWebview` sets `this.webResearch = nextWebResearch` (line 94) *before* attempting `settings.update(...)` for it (lines 128–138). If that write throws — the same failure mode already mocked and asserted for behavior/profile in this file's own test suite — `persistenceErrors.webResearch` is set but the in-memory value is left holding the applied-but-unpersisted state.
+
+So far this mirrors `apply()`'s optimistic commit for behavior and profile. But those two then get `pendingBehaviorPersistence`/`pendingProfilePersistence` recorded on failure (lines 110–113, 122–125), and every `syncFromSettings`/`flushDeferredSettingsSync` resolves through `resolveBehaviorSetting`/`resolveProfileSetting` (lines 290–314), which re-apply the pending value instead of the stale disk value. `webResearch` has no such guard — both sync methods unconditionally call `this.readWebResearchSetting()`, discarding the applied value the very next time *any* of the three watched keys fires `onDidChangeConfiguration`.
+
+This is the literal shape of Blake's confirmed blocking finding #2 in `docs/pr-reviews/pr-83-writer-profile-settings-review.md` — *"Partial persistence failure silently reverts the applied value… the successful key's `onDidChangeConfiguration` fires `syncFromSettings()`, which re-reads the key that just failed to save and commits the stale value back over the live one"* — which that PR's remediation explicitly closed by adding the pending-persistence tracking this new setting doesn't have.
+
+Concretely: toggle web research on, hit a transient settings-write failure, then merely change the Behavior tab in the same session — the sync it triggers quietly turns research back off, with no error and no signal, after the modal told the user it applied. Give `webResearch` the same `pendingWebResearchPersistence` + `resolveWebResearchSetting` treatment.
+
+### 🟡 Standard — The dedicated-service pattern that would have prevented the above wasn't extended
+
+`packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts:59`
+
+```ts
+private webResearch: WorkshopWebResearchSettings;
+```
+
+`WorkshopWriterProfileService` exists for a stated reason, and this class's own docstring frames the arrangement: *"Behavior remains session-owned while the injected profile service owns the separate global Writer Profile; this class gives their live prompt effects one serialized, guarded commit boundary."* That's a real seam — the profile service owns read/coerce/commit/persist, and the coordinator only orchestrates timing.
+
+Web research gets neither a session-model home nor a dedicated service. It's a bare private field the coordinator reads, coerces, and writes inline, duplicating — and under-implementing — machinery the profile service already encapsulates. That isn't abstract taste; it's the direct mechanism behind the blocking finding above. Extending the discipline to a new setting currently means hand-copying three call sites' worth of guard logic rather than composing something that already carries it. A fourth setting arriving the same way grows another parallel field and another near-identical trio of sync edits.
+
+### 🟢 Nit — `UrlCitation` skips this codebase's own precedent for cross-cutting provider types
+
+`packages/core/src/shared/types/citations.ts:2`
+
+`TokenUsage` is the closest existing precedent — a provider-response-derived fact that flows through message payloads (`WorkshopTurn.usage`), domain models, and infra contracts alike — and it lives in `shared/types/messages/tokenUsage.ts`, explicitly grouped under "Cross-cutting concerns" in the messages barrel. `UrlCitation` has an identical footprint (`WorkshopTurn.citations`, `AnalysisResult.citations`, `ExecutionResult.citations`) but gets a brand-new top-level sibling file instead of joining `tokenUsage.ts` at its established address. Low stakes — both locations are defensible, and `WorkshopWebResearchSettings` correctly followed the `messages/workshop.ts` SETTING-triple pattern right next to it — but it quietly forks the answer to "where does a cross-cutting provider-fact type live" one file over from where that answer already sat.
+
+> *"The room-settings coordinator already has a scar from this exact wound — behavior and profile both carry the stitches — and the new setting walked in without checking the chart."* — Marcus
+
+---
+
+## 🔥 Blake · Critical / Blocking Issues
+
+"She's Been Paged for This Before"
+
+### 🔴 Blocking — Adding `webResearch` to the draft-reset effect wipes half-typed drafts on every session-state push [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx:133`
+
+```tsx
+  }, [open, webResearch]);
+```
+
+The dep array was `[open]` on purpose. `webResearch` is a fresh object on every host push, so this effect now refires while the modal is open and blows away everything the user typed.
+
+Trace it:
+
+1. `WorkshopHandler.postSessionState()` is called from 34 sites — run completion, todo edits, context attach, excerpt swap, guest invite.
+2. It sends `webResearch: this.conversationSettingsService.getWebResearch()`, and `getWebResearch()` returns `{ ...this.webResearch }` — a new object every call.
+3. `useWorkshop.ts:711` does `setWebResearch(coerceWorkshopWebResearchSettings(message.payload.webResearch))`. **Both** branches of that coercer construct a new object literal, so `Object.is` is always false and the prop identity always changes.
+4. Dep comparison fails → effect body runs → `open` is true → `setTab('behavior')`, `setBehaviorDraft`, `setProfileDraft`, `setWebResearchDraft`, `setPending(null)`, `setConfirmClear(false)`.
+
+The user is on the "About you" tab, 900 characters into the bio textarea. A persona run finishes in the background. `postSessionState` fires. Their bio is silently replaced by the host's stored profile and they're yanked back to the Behavior tab with no indication anything happened. No confirm, no undo, no local persistence — the text is gone.
+
+`writerProfile` has the *exact same* identity churn (`coerceWorkshopWriterProfile` also returns a fresh object) and was deliberately kept out of this array. Adding `webResearch` reintroduces the bug for all three drafts at once.
+
+This isn't theoretical for the mid-run case: the existing test *"locks Apply during a response while leaving inspection and drafts available"* asserts as a contract that drafts stay editable during a run — `editingLocked` is `pending !== null` only; `isRunning` disables Apply, not the textarea. The codebase explicitly promises "type while it runs," and this change breaks that promise at the moment the run lands.
+
+Fix: revert the dep array to `[open]`. If the modal must notice an external `settings.json` edit that lands while open, gate on the *value*, not the identity — a separate effect keyed on `webResearch.enabled` that touches nothing else.
+
+### 🟠 High — `citations: last.citations` silently drops every source found before the final turn
+
+`packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts:462`
+
+```ts
+        citations: last.citations,
+```
+
+`last` is reassigned on every capability round — `last = await runInstructedTurn(last, evidence)` (line 372), `last = await recoverInvalidRequest(last)` (line 382), and again in the forced-final block. Only the surviving `last` contributes citations.
+
+Failure path: research is enabled, a persona turn searches the web and the provider returns `url_citation` annotations on turn 1. The persona then emits a capability request (fetch a source, read an excerpt). The engine runs an instructed turn 2 to consume the evidence. Turn 2 is a plain synthesis reply with no annotations, so `last.citations` is `undefined`. Every source from turn 1 is discarded before it reaches `createAnalysisResult` → `completeWorkshopRun` → `WorkshopTurn.citations`.
+
+The user-visible result is worse than "no pills." This PR's own comment on `WorkshopTurn.citations` says *"model-authored [n] markers remain ordinary text"* — so the reply renders with `[1]`, `[2]` inline and no "Web sources" block underneath. Dangling reference markers pointing at nothing, silently. The forced-final path is the worst case: a re-prompt to stop calling tools and answer will essentially never carry annotations, so a run that hits its capability limit reliably loses all of its citations.
+
+Look two lines up in the same return object for the pattern this file already uses: `usage: totalUsage` is accumulated across turns; `usedGuides` and `requestedResources` are deduped unions. Citations are the only per-turn signal read off the last turn alone. Hoist a `runCitations: UrlCitation[]` beside `totalUsage` and merge each turn's citations into it.
+
+### 🟠 High — `assertCitation` accepts any string as a URL, but the renderer calls `new URL()` on it [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx:52`
+
+Two validators for the same field, and the one guarding untrusted input is the weaker one. See Sam's and Patricia's write-ups below for the full trace — the short version is that `WorkshopSessionStateV1Shape.ts` exists specifically to validate untrusted on-disk JSON, and for `citation.url` it validates only that the value is a string.
+
+> *"Every one of these ships fine on a quiet laptop and then eats a user's 900-word bio the first time a run lands mid-edit — I've cleaned up this exact incident, and the dep array was `[open]` for a reason."* — Blake
+
+---
+
+## 🔍 Sam · Bug Hunter
+
+"What if the list is empty, though?"
+
+### 🔴 Blocking — A bare `https://` citation URL crashes the entire turn thread, not just one pill [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx:52`
+
+```ts
+return title && !/^\d+$/.test(title) ? title : new URL(citation.url).hostname;
+```
+
+I traced the validation gap between where citation URLs are accepted and where they're rendered. `toUrlCitations` only checks `/^https?:\/\//.test(value.url)` — a prefix test, not a well-formedness test.
+
+Confirmed in Node:
+
+| input | passes producer regex | `new URL()` |
+| --- | --- | --- |
+| `"https://"` | ✅ | 💥 `TypeError` |
+| `"https:///path"` | ✅ | `hostname=path` |
+| `"anthropic.com"` | ❌ | 💥 `TypeError` |
+
+A string like `"https://"` passes the regex and throws when constructed. It flows untouched through `mergeUrlCitations`, into `completeRun`, into the persisted turn, and into `WorkshopTurnBubble`'s `citations` memo — which only dedupes by URL and does nothing to validate. When such a citation has no title (or a numeric-only one, e.g. a year), `citationLabel` falls through to `new URL(...).hostname` and throws during render.
+
+There's no local error handling and no ErrorBoundary around just the pills — the nearest boundary wraps the whole thread panel in `WorkshopApp.tsx`. So one malformed citation doesn't break its own pill; it replaces the *entire visible conversation* with "Something went wrong," for every turn, until the user hits Try Again. None of the new tests exercise a URL without an authority — searched the diff, not found; the fixtures are all well-formed. Tighten the ingestion check to attempt `new URL()` in a try/catch rather than relying on a loose regex that a rendering-side `new URL()` implicitly trusts.
+
+### 🟠 High — First-wins citation merge silently discards a richer duplicate
+
+`packages/core/src/infrastructure/api/providers/OpenRouterClient.ts:353`
+
+```ts
+if (!merged.some((existing) => existing.url === citation.url)) {
+  merged.push(citation);
+```
+
+`mergeUrlCitations` dedupes purely on `url`, first-occurrence wins, with no reconciliation of fields on a later match. This runs both within a single non-streaming response and across streaming frames. If the model cites the same URL twice — extremely ordinary for a grounded answer referencing one source at two points — and the first annotation arrives without a `title` while a later one for the same URL carries it, the title is silently dropped forever. The user sees a bare hostname pill instead of the actual source title, even though the richer data was in the same payload.
+
+The new `'accumulates citations reported across streaming frames'` test only exercises two *different* URLs, so this path is untested. Merge field-by-field — keep the first `startIndex`/`endIndex`, prefer whichever occurrence has a non-empty `title` — or at minimum backfill a missing title when a duplicate arrives with one.
+
+### 🟠 High — Citation pill numbers can disagree with the model's own `[n]` markers
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx:437`
+
+```tsx
+<span className="pm-ws-turn-citation-number">{index + 1}</span>
+```
+
+The pill number is the post-dedup array index, entirely disconnected from the `[n]` markers the model writes inline in `turn.content` — the OpenRouterClient test literally produces `'Grounded answer [1]'` as plain text, and nothing in this diff parses or links those markers. In the common case the two happen to line up by coincidence. But because `mergeUrlCitations` collapses same-URL annotations, the moment a model re-cites a source it already used — text reads `…as noted [1]… confirms this [2]… circling back [3]` where `[1]` and `[3]` are the same URL — the merged array has two entries. The reader sees an inline `[3]` with no pill numbered 3.
+
+The notice modal's new copy promises replies "show each source as a clickable citation pill," which reads as an implicit numbering contract this code doesn't maintain. Either don't render a number at all, or parse and renumber against the model's markers so the two schemes can't diverge.
+
+> *"Found the trap door: cite the same source twice in one reply, and the pill numbers stop matching the brackets in the text — the second citation gets deduped right out of existence."* — Sam
+
+---
+
+## 📖 Parker · Code Quality
+
+"Code is Communication, Not Instruction"
+
+### 🟠 High — `createAnalysisResult` grows to 8 positional params; three call sites pad with a meaningless `undefined`
+
+`packages/core/src/domain/models/AnalysisResult.ts:29`
+
+```ts
+static createAnalysisResult(toolName: string, content: string, usedGuides?: string[], usage?: TokenUsage, finishReason?: string, conversationId?: string, requestedResources?: string[], citations?: UrlCitation[]): AnalysisResult {
+```
+
+This factory was already six positional params deep; it's now eight. The new `citations` slot lands after `requestedResources`, so every Workshop call site that wants citations but has no `requestedResources` writes a literal `undefined` just to hold the seventh slot open — `AssistantToolService.ts` lines 567–576, 629–638, and 685–694, each ending `executionResult.conversationId, undefined, executionResult.citations`.
+
+A reader has to count commas against the declaration to know what that bare `undefined` means, and the next person adding a ninth field will either repeat the trick or silently shift someone else's argument into the wrong slot — there's no compiler check tying field names to call-site position.
+
+Convert to an options object: `createAnalysisResult(toolName, content, { usedGuides, usage, finishReason, conversationId, requestedResources, citations })`. Migration is mechanical and bounded — 16 call sites in `AssistantToolService.ts`, all constructible from locals already in scope, and TypeScript flags anything missed. Worth doing before a ninth field shows up.
+
+### 🟡 Standard — `changed: result.changed || webResearchChanged` repeated three times, plus a rename that adds nothing
+
+`packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts:92-142`
+
+`persistWebResearch` is assigned `webResearchChanged` and never diverges from it anywhere in the method — unlike `persistBehavior`/`persistProfile`, which fold in genuinely different pending-persistence logic. The rename buys nothing but an extra name to chase down and confirm is really just the other name.
+
+Meanwhile `changed: result.changed || webResearchChanged` is spelled out identically at the early return and at both branches of the persistence-errors check — three chances to drift if someone edits one and not the others. Drop `persistWebResearch`, and compute the merged `changed` once right after `webResearchChanged` is derived.
+
+### 🟡 Standard — One feature, four names — Advanced / Research / `webResearch` / "live web research"
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx:256`
+
+The tab is labeled **Advanced**, the footer note under it calls the same thing **Research** (twice), the toggle says "Allow live web research," the wire setting is `webResearch`, and `WorkshopNoticeModal.tsx` tells the user to look "In **Advanced**… research the live web." A user reads three different words for one on/off switch and has to infer they're the same thing.
+
+"Advanced" is also weak on its own merits — it says nothing about what's inside, and if a second unrelated setting lands in that tab the name becomes actively misleading about scope. Rename the tab to **Research** so the label, the footer copy, and the setting name all say the same word; reserve "Advanced" for a tab that's genuinely a junk drawer, if that ever happens.
+
+> *"One setting, four aliases — I had to cross-reference the tab, the footer, and the wire type just to convince myself they weren't three different features."* — Parker
+
+---
+
+## 🧪 Cal · Test Coverage & Quality
+
+"Confidence Levels, Not Coverage Numbers"
+
+### 🔴 Blocking — The modal test suite doesn't compile; Advanced tab, Switch, and tab navigation are entirely unverified [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx:95`
+
+```ts
+webResearch: WorkshopWebResearchSettings;
+```
+
+Searched diff for `WorkshopConversationBehaviorModal.test.tsx` — not found. The diff makes `webResearch` a required prop and a required third argument on `onApply`, but the test file is untouched. Its `renderModal` helper builds `props` typed as `React.ComponentProps<typeof WorkshopConversationBehaviorModal>` and never sets `webResearch`.
+
+**Confirmed by running the suite:**
+
+```
+FAIL packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.test.tsx
+  ● Test suite failed to run
+    TS2322: Type '{ … webResearch?: WorkshopWebResearchSettings | undefined … }'
+    is not assignable to type 'WorkshopConversationBehaviorModalProps'.
+```
+
+Every test in that file — tab navigation, profile clearing, pending-apply reconciliation — now fails to compile. `packages/core/tsconfig.json` explicitly excludes `src/__tests__`, so `npm run typecheck` never sees it; ts-jest type-checks by default, so `npm test` does.
+
+Set the compile question aside and the coverage gap is just as real: nothing renders the Advanced tab, clicks the `Switch`, asserts the new three-tab wraparound (Home→behavior, End→advanced, ArrowLeft/Right modulo 3), or exercises `submittedWebResearch` in the pending-apply reconciliation. I'd write *"cycles through Behavior → About you → Advanced on ArrowRight from the last tab"* and *"keeps the modal open when the applied webResearch echo doesn't match the submitted draft"* — mirroring the existing behavior/profile pending-apply tests, which have no webResearch analog.
+
+### 🟠 High — The settings service's new logic has zero coverage, and the existing mock would mask it
+
+`packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts:247`
+
+Searched diff for `WorkshopConversationSettingsService.test.ts` — not found. This file gained the constructor read, `getWebResearch()`, `readWebResearchSetting()`, the `applyFromWebview` persist branch, the `settings.update` failure branch, and changed-detection in *both* external-sync methods. None of it is driven.
+
+It's worse than a coverage gap. The existing `settings.get` mock (`key === 'workshop.writerProfile' ? configuredProfile : configured`) returns the *behavior* fixture for any other key, including `workshop.webResearch`. That object has 4 keys, so `coerceWorkshopWebResearchSettings`'s `Object.keys(raw).length === 1` guard silently falls back to the default — meaning if someone wired the new logic backwards, this suite would still pass green.
+
+Add a `describe('webResearch')` block: `applyFromWebview(behavior, profile, { enabled: true })` calls `settings.update('proseMinion', 'workshop.webResearch', { enabled: true })` and `getWebResearch()` reflects it; a rejected `settings.update` populates `persistenceErrors.webResearch`; and `syncFromSettings()` reports `changed: true` when only the research setting moved underneath it.
+
+### 🟠 High — The default-off case — the entire point of this feature — is never asserted
+
+`packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts:697`
+
+Searched `AssistantToolService.test.ts` for `webResearch` / `web_search` / `tools:` — not found, and the diff doesn't touch that file. `workshopWebSearchTools` is the single gate deciding whether `openrouter:web_search` ever reaches a request; it returns `undefined` for `false` and — critically — for `undefined`, which is what every call site that doesn't thread the option sends.
+
+The new OpenRouterClient tests prove the *enabled* case forwards the tool object unchanged, but that's a different seam: it starts from an already-built `OpenRouterWebSearchTool[]`, so it can't catch a regression where `workshopWebSearchTools` starts returning a tool for the false branch. Add a test that calls the Workshop entry points with `webResearch` omitted and separately `false`, and asserts the engine received `tools: undefined`. Without it, "default-off" is a comment and a `package.json` default, not a verified behavior.
+
+> *"Happy path only, again — you tested that the light turns on, never that it stays off when nobody flips the switch."* — Cal
+
+---
+
+## 🗂️ Stan · Codebase Standards
+
+"He Has Every Pattern Memorized"
+
+### 🔴 Blocking — `webResearch` skips the pending-persistence guard PR #83 added specifically to prevent this [🎯 Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts:128`
+
+This is the same class, the same method, nine lines below a working example of how to do it correctly. When `persistBehavior`'s `settings.update` throws, the catch sets `this.pendingBehaviorPersistence = { storedValue, appliedValue }`; same for the profile catch. That pending record exists so the sync methods can call `resolveBehaviorSetting`/`resolveProfileSetting` and keep serving the *applied* value instead of the stale one still in the settings store.
+
+The webResearch catch does none of that, and `this.webResearch = nextWebResearch` is applied optimistically before the persistence attempt even runs. Toggle research on, the write throws, the live room correctly keeps running with research enabled — until any other config change fires `syncFromSettings()` (it watches all three keys together, per `MessageHandler.ts`'s `affects(…) || affects(…) || affects(…)`), which calls `this.webResearch = this.readWebResearchSetting()` with no pending check and silently reverts the user's toggle.
+
+This is pr-83's blocker #2 reborn on the third setting, in the same file, after the fix for the first two landed right there for reference. `WorkshopConversationSettingsService.test.ts` has zero `webResearch` occurrences — I grepped it — so this branch shipped with no coverage, same as pr-83's finding #4 flagged before the fix.
+
+### 🟡 Standard — `readWebResearchSetting` drops the rejection-logging convention pr-83 explicitly added [🎯 Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts:247`
+
+pr-83 finding #9 (*"Coercion fails closed with no trail"*) flagged that `WorkshopWriterProfileService` had no `LogSink`, so a hand-edited over-limit bio silently reset to disabled with nothing logged. It was addressed — `readSetting()` now logs `'[WorkshopWriterProfileService] Rejected invalid writer profile setting; using the disabled default'`.
+
+`readWebResearchSetting` has no such check, even though `this.outputChannel` is already a constructor dependency of this exact class and already carries two other log lines in this file. A stray key in a hand-edited `settings.json`, or a future field added without updating the coercer, silently resets the whole object to `{ enabled: false }` — indistinguishable in the logs from the writer deliberately turning research off. Same failure mode pr-83 already named and fixed one setting over; the fix didn't travel with the pattern it should have informed.
+
+### 🟢 Nit — The new triple doesn't read like a sibling of the other two in the same file
+
+`packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts:72`
+
+`rawBehavior` and `rawWriterProfile` are required `unknown` params on this signature; `rawWebResearch` is the only one marked `?`, despite its coercer degrading `undefined` to the default exactly as its peers do. `WorkshopSetConversationSettingsPayload` declares `webResearch` **required**, matching its siblings — so the optional marker exists only on this one call boundary, for no functional reason.
+
+Same story in `shared/types/messages/workshop.ts`: `coerceWorkshopWriterProfile` and `coerceWorkshopConversationBehavior` both carry doc comments explaining the fail-closed contract. `coerceWorkshopWebResearchSettings` and `workshopWebResearchSettingsEqual`, added directly beneath them, get none — a future reader skimming for "how do we validate a settings triple here" hits two documented examples and one undocumented one, side by side.
+
+> *"We already fixed this exact revert-on-partial-failure bug in PR #83, in this exact file, nine lines above where it just happened again — like watching someone re-lay a landmine right next to the sign that says where the last one went off."* — Stan
+
+---
+
+## ⚡ Tim · Performance
+
+"O(n²) at Scale is an Incident Waiting to Happen"
+
+### 🟠 High — Bounded web-search tool is offered on every persona turn, with no session-level spend or latency cap
+
+`packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts:697-702`
+
+```ts
+private workshopWebSearchTools(enabled: boolean | undefined): OpenRouterWebSearchTool[] | undefined {
+  return enabled ? [{ type: 'openrouter:web_search', parameters: { engine: 'auto', max_uses: 2, max_total_results: 10 } }] : undefined;
+}
+```
+
+Called from `startWorkshopPersonaConversation`, `startWorkshopGuestConversation`, and `continueConversation` — so it's attached to *every* host turn, guest turn, and continuation for the life of the room, driven by nothing but a boolean. No per-turn opt-out, no session counter, no budget. Searched the diff for a session-level cap or running-cost counter — not found.
+
+The math: `max_uses: 2, max_total_results: 10` with `engine: 'auto'`. Per OpenRouter's published pricing, generic web-search billing is $4/1000 results — up to $0.04/turn at the ceiling — while the Parallel-Turbo path is ~$0.001/request for the first 10 results, ~$0.002/turn at 2 uses. Because `engine: 'auto'` leaves resolution to OpenRouter, the code can't even predict which it's paying per turn.
+
+At N=1 turn this is a rounding error. At N=100 turns in a long multi-persona room — exactly what Workshop rooms are *for* — that's silent, undifferentiated spend of roughly $0.20 to $4, plus real wall-clock latency: two search round-trips is not free, and it's now stacked onto every exchange, not just the ones needing current information. That directly undercuts the responsive `conversational` mode this same PR is trying to preserve.
+
+To be fair to the design: `TokenUsage.costUsd` (via `toTokenUsage`, reading `raw.cost`) does fold OpenRouter's total per-request cost — including tool charges — into the number already surfaced through `emitUsage`, so this isn't invisible to the money pipeline. But nothing distinguishes "this turn cost more because research fired" from ordinary token cost, and nothing bounds how many turns in a row pay the tax.
+
+### 🟠 High — Reset effect now fires on every session-state broadcast [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx:124-133`
+
+Worth stating what is *not* the problem here: the render cost of the identity churn in isolation is nothing to worry about. This modal is unmemoized and re-renders on every `WorkshopApp` pass regardless, and the pre-existing `writerProfile` prop has the identical churn pattern via `getProfile()`'s own spread — it simply wasn't in the dep array.
+
+The defect is what the *effect* does with that churn. At N=1 broadcast while closed: free. At N=1 broadcast while open, mid-edit: it's already the incident. You don't need scale for this one, you need the modal open during a live turn, which is an ordinary Workshop room. Drop `webResearch` from the array and diff its *value* via `workshopWebResearchSettingsEqual` — object-literal identity is not a substitute for value equality upstream of a dependency array.
+
+> *"Two search calls times every turn in a growing room is not a rounding error, it's a metered API with the meter turned toward the wall — and an effect array keyed on a freshly-allocated object is just a scheduled amnesia attack with extra steps."* — Tim
+
+---
+
+## 🛡️ Patricia · Security
+
+"She Reads Code Like an Attacker Would"
+
+### 🔴 Blocking — Persisted citations bypass URL validation entirely [🎯🎯 Strong Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopSessionStateV1Shape.ts:399-401`
+
+```ts
+function assertCitation(value: unknown, path: string): void {
+  const citation = exactObject(value, path, ['url'], ['title', 'startIndex', 'endIndex']);
+  stringAt(citation.url, `${path}.url`);
+```
+
+The live path validates twice — `toUrlCitations` rejects anything failing `/^https?:\/\//`. But `assertCitation`, the gate for citations read back off disk, only checks `typeof url === 'string'`. `"not-a-url"`, `"javascript:alert(1)"`, `"file:///etc/passwd"`, and `""` all pass.
+
+That matters because this isn't a throwaway parse — it's the shape validator for the persisted session state file, a trust-sensitive boundary: session docs survive reloads, get hand-edited during debugging, can be truncated by an interrupted write, and in a shared project can be committed and pulled by a teammate.
+
+A corrupted citation with no title and a non-well-formed URL reaches `citationLabel`, whose `new URL(...)` throws a `TypeError` during render — uncaught, and only caught by the coarse region ErrorBoundary wrapping the whole thread pane. One bad citation in one turn takes down the entire conversation view.
+
+Separately, a well-formed-but-non-http(s) URL that *has* a title skips the `new URL()` call entirely and lands straight in `href={citation.url}` with no scheme check. The CSP's nonce-only `script-src` likely blocks `javascript:` execution, but nothing stops `file://` or an arbitrary protocol handler being handed to VS Code's external-open flow. Give `assertCitation` the same `/^https?:\/\//` check the producer already has, and make `citationLabel` total.
+
+### 🟠 High — A network capability is scoped like a personal profile setting
+
+`apps/vscode-extension/package.json:408-424`
+
+`webResearch` copies `"scope": "application"` from `proseMinion.workshop.writerProfile`. But they aren't the same kind of thing. `writerProfile` is inert data you author once; application scope for it means "my bio travels with me," which is reasonable. `webResearch` is a live switch determining whether manuscript excerpts, room context, and the writer profile get formulated into search queries and sent off-machine on every persona turn.
+
+Application scope means User-settings-only — no workspace or folder override is possible — and it syncs to every machine via Settings Sync. Concretely: a writer turns this on for a low-stakes hobby project, then opens an embargoed manuscript or an NDA'd client project in a different workspace on the same or a synced machine. Research is silently already on, with no per-workspace way to turn it off. `conversationBehavior` deliberately has no `scope` override and stays window-scoped for exactly this reason. A capability deciding what leaves the machine should get at minimum `window` scope.
+
+### 🟠 High — Disclosure names OpenRouter and cost, not the second destination for manuscript content
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx:467-469`
+
+> Persona conversations may search current web information when it helps. This can add latency and provider charges; Grok can also search X when supported.
+
+Every user-facing description — the `package.json` description, this modal copy, and the notice-modal copy — frames the consequence as "OpenRouter" plus latency and cost. None say that the model formulates search queries seeded by conversation content that per this PR's own description includes manuscript excerpts, the About You profile, and room context, and that those queries execute against search infrastructure that is *not* the LLM provider the user already implicitly trusts. OpenRouter's `web_search` tool proxies to a third-party search backend for models without native search — that's a second data recipient, not a detail of "provider charges."
+
+Compare the bar this codebase already sets: `writerProfile`'s description explicitly warns *"Stored globally; do not include sensitive information"* precisely because that data leaves the machine. `webResearch` creates a strictly larger exposure — not opt-in text carefully written once, but live conversation content turned into search queries every turn — and gets a weaker warning than the feature it's more dangerous than.
+
+> *"You put a regex on the front door and left the disk-read path wide open — the attacker doesn't care which one you forgot, they just walk in through the other."* — Patricia
+
+---
+
+## 🌙 Oliver · Observability & Debuggability
+
+"Would This Failure Leave a Trail at 2am?"
+
+### 🟠 High — Citation parsing failures are indistinguishable from "model found nothing"
+
+`packages/core/src/infrastructure/api/providers/OpenRouterClient.ts:329-344`
+
+`toUrlCitations` silently drops every annotation failing its shape check or the `https?://` test — no log, no counter. Searched the diff for any log statement in this function or its call sites — not found. The only `appendLine` added in the entire 1,469-line diff is the persistence-error branch in `WorkshopHandler`.
+
+Walk the failure: the model returns prose with `[1] [2] [3]` markers plus three annotations. If OpenRouter emits a `url_citation` with a relative path, a non-`url_citation` type, or a shape OpenRouter changes upstream, that entry vanishes with `return []`. The user sees a reply with three markers and one or zero pills — a broken-looking, half-grounded answer. When they report "the citations were wrong," the author has nothing: no way to tell *"the model didn't cite anything"* (working as intended) from *"we're mis-parsing OpenRouter's payload"* (a real bug, possibly an upstream schema change). Log at debug level when `raw.length > 0` but the filtered result is shorter, including the annotation `type` values seen — enough to separate the two cases from a bug report alone.
+
+### 🟡 Standard — The web-research setting reads and commits silently, unlike its writer-profile sibling [🎯 Consensus]
+
+`packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts:247-252`
+
+See Stan's write-up for the pr-83 lineage. Worth adding a second gap in the same file: the one commit log line for this service (`apply()`: `'[WorkshopConversationSettingsService] Conversation settings committed (mode=…, profileEnabled=…)'`) fires only when `behaviorChanged || profileChanged`. Because `webResearch` is applied *outside* `apply()`, a research-only toggle — the common case, since it's a standalone Advanced-tab switch — produces no log line at all, even on a fully successful persist. Add `researchEnabled=${nextWebResearch.enabled}` to the existing commit log.
+
+### 🟡 Standard — No record that a persona turn ever requested web search
+
+`packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts:697-701`
+
+Searched the diff for any log tied to attaching or using `openrouter:web_search` — not found. `workshopWebSearchTools` decides per turn whether to attach the tool, and the client passes it straight through, but nothing logs that it was attached, and nothing logs the finish reason or citation count when the response returns. The only observable side effect is the pills.
+
+A user reports "the web research thing didn't work" with a screenshot. The Output Channel — this project's stated diagnostic surface per `AGENTS.md` — has nothing: no line confirming research was enabled for that turn, no line confirming the tool was sent, no citation count. The author is reduced to asking the user to re-enable a setting and try again while watching. One `appendLine` recording persona id, enabled state, and resulting citation count turns a guessing game into a two-line diagnosis.
+
+> *"Three ways to fail — bad settings, no search, or dropped citations — and every single one of them fails the same way: silently. See you in the incident retro."* — Oliver
+
+---
+
+## 🎯 Bria · Domain Logic & Business Correctness
+
+"Does This Code Actually Do What the Ticket Asked?"
+
+### 🔴 Blocking — Making `webResearch` a required modal prop breaks the untouched sibling suite [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx:95`
+
+I ran the suite directly rather than guess — see Cal's section for the output. The point I'd add is about the *validation claim*: the PR description lists `npm run typecheck` and "Targeted Workshop/OpenRouter Jest tests (60 tests)." `packages/core/tsconfig.json` explicitly excludes `src/__tests__` from typecheck, and this pre-existing suite for the exact component being changed apparently wasn't in the targeted set. Both checks were honest; neither could see this.
+
+### 🟠 High — Host tool-synthesis turn never gets `webResearch` — the settings service isn't even injected
+
+`packages/core/src/application/services/workshop/RunWorkshopToolSidePass.ts:228`
+
+The PR description claims it "threads the enabled state through Workshop host and guest turns." `workshopWebSearchTools` reads `streamingOptions.webResearch` at exactly three call sites, and `WorkshopHandler.ts` passes the setting into all three of *its* calls (guest ~line 700, continuation ~1083, new-persona ~1103).
+
+But `RunWorkshopToolSidePass` — the class running the host's turn synthesizing a just-completed deterministic tool's report, `owner: { kind: 'host' }` — calls `continueConversation` (line 228) and `startWorkshopPersonaConversation` (line 233) with no `webResearch` option at all. Its constructor holds `writerProfileService` but no `WorkshopConversationSettingsService`, so this call site structurally *cannot* know the room's setting. That's a legitimate host turn by the PR's own language, and a user who flips the toggle would reasonably expect the host's tool-report synthesis to research too. Instead it silently never gets the tool, regardless of the setting.
+
+### 🟠 High — New `webResearch` dependency wipes in-progress drafts and snaps the tab back [🎯🎯 Strong Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx:133`
+
+See Blake's trace. The domain angle I'd add: the modal can be opened *while a run is active* — the Conversation Controller trigger isn't gated on `roomMutationLocked` — and `postSessionState()` is wired into the streaming-progress callback. So leaving the modal open during a streaming persona turn refires this effect on essentially every token. The deliberate contract a few lines below (*"the old mode stays visible"* until the next `WORKSHOP_SESSION_STATE`) says in-flight edits were meant to survive incoming prop updates.
+
+> *"'Threads the enabled state through host and guest turns' — true for two of the three host code paths; the one where the host actually synthesizes a tool's report never got the memo. Technically correct. Whether it's correct correct is a different question."* — Bria
+
+---
+
+## 🎓 Sensei · The Teacher
+
+"The Review Is the Lesson. The Code Is the Practice."
+
+### Lesson 1 — Ask the Siblings Before You Move In
+
+Illuminated by: Blake/Tim/Bria #1, Marcus & Stan #4, Patricia (scope + disclosure), Blake (last-turn citations), Stan/Oliver (logging), Marcus (service pattern)
+
+Nearly every blocking finding here is the same shape: a third sibling added beside two existing ones, differing from them in a way nobody chose. `webResearch` gained a dep-array slot `writerProfile` was deliberately denied; it lacked the pending-persistence guard both peers carry; it inherited `scope: "application"` from a setting that never touches the network; `citations` was read off the last turn while `usage` and `usedGuides` — two lines above, in the same return literal — were accumulated. A cabinetmaker fitting a fourth door to a run of three doesn't measure from the wall; they measure from the doors already hanging. Existing siblings are not just precedent, they are accumulated decisions, and some of those decisions are scar tissue — PR #83 had already fixed #4 for the other two settings in that exact file.
+
+→ Carry forward: When adding the Nth case beside N−1 existing ones, diff yours against a sibling line by line and write a one-word reason for every difference. If a difference has no reason, it's a bug in one direction or the other. And run `git log -p` on the sibling first — an *absence* in old code is often a fix you're about to undo.
+
+### Lesson 2 — Green Is a Scope, Not a Verdict
+
+Illuminated by: Cal, Bria #2, Cal (default-off untested), Cal (the fixture mock)
+
+Two checks reported success over a red suite, and neither lied — `npm run typecheck` deliberately excludes `src/__tests__`, and a targeted 60-test run is by definition targeted. The danger isn't a false green; it's a true green whose scope you've quietly stopped tracking, so its confidence spends further than it earns. The same drift runs deeper into the tests themselves: the enabled path is asserted, the default-off path is only a comment and a JSON default; and a `settings.get` stub that returns the behavior fixture for any key will answer every question the same way, which makes it a yes-man, not a witness. A test that cannot fail is a decoration in the shape of a proof.
+
+→ Carry forward: When you cite a passing check as validation, say in the same breath what it structurally *cannot* see — and before merging, run the unscoped thing once. Then for each new branch ask: "which assertion goes red if I invert this condition?" If the answer is none, you've tested the presence of a feature, not its behavior.
+
+### Lesson 3 — A Field's Invariant Is Its Weakest Gate
+
+Illuminated by: Sam, Patricia, Blake #3, Oliver
+
+Two validators guarded `citation.url`; the producer enforced `^https?://`, the persisted-load path checked only `typeof === 'string'`. When one field has two gates, its real invariant is whichever gate is weakest — and the weak one is almost always on the path you think of as "ours." Data on disk is data from a stranger: past-you wrote it, but past-you had different bugs. Note too that even the strong gate was shape-checking, not parsing — `"https://"` satisfies the regex and still throws in `new URL()` — which is how an unguarded `new URL()` inside a render function takes down an entire conversation, permanently, from a bad row on disk. And when a boundary does reject something, silence is its own defect: Oliver's bare `return []` makes "the schema changed upstream" indistinguishable from "nothing was found."
+
+→ Carry forward: For any field with more than one entry path, list every path and validate at the weakest, not the friendliest. Prefer parsing over shape-checking — construct the real object at the boundary and carry *that* inward, so no render function is ever the first code to learn the value was malformed. And when you drop something, log that you dropped it.
+
+### Lesson 4 — A Toggle Is a Doorway, Not a Preference
+
+Illuminated by: Patricia (scope + disclosure), Tim (no budget), the feature's framing
+
+This setting was built with the ergonomics of a preference — copied scope, copied coercer shape, copied UI slot — but what it actually does is open a door in a wall. Once it's on, manuscript excerpts and the writer profile leave as search queries to infrastructure beyond the LLM provider, unmetered, for the life of the room. Every knob that changes *who is in the room* or *what the room costs* needs three things a cosmetic preference doesn't: a scope that matches the blast radius (`application` means a hobby-project toggle is already on when the NDA'd manuscript opens elsewhere), a disclosure naming the second recipient rather than the invoice, and a ceiling. Telling a user "this may add latency and cost" when the true consequence is "your draft becomes a search query" isn't understatement — it's the wrong sentence entirely.
+
+→ Carry forward: Before shipping any user-facing toggle, finish this sentence in plain words: "When this is on, ______ can now see or spend ______, until ______." If the answer names another party, a recurring cost, or has no natural end, the design isn't done — scope, warning text, and budget all need to say so.
+
+> *"Code written beside other code is always in conversation with it, and most bugs are simply the moment it stopped listening."* — Sensei
+
+---
+
+## The Closer
+
+### 🔮 Fortune Cookie
+
+*You built a door to let the world in, and forgot that doors swing both ways.*
+
+---
+
+## Summary
+
+This is a well-shaped feature with a genuinely careful spine — the setting is default-off, the tool config is deliberately bounded, deterministic Workshop tools stay offline, citations get a normalized type and a persisted shape, and the `SETTING`/`coerce`/`equal` triple follows the house pattern faithfully. The intent is right and most of the plumbing is right with it.
+
+It is not merge-ready. Four blocking issues stand: `npm test` is red on two suites (verified, not inferred); the modal's new effect dependency silently destroys in-progress user drafts; a malformed persisted citation permanently takes out the entire conversation pane; and the web-research setting skips the pending-persistence guard that PR #83 added to this exact file for exactly this failure. Three of those four were flagged independently by two or three reviewers, which is the strongest signal this panel produces.
+
+The through-line worth sitting with is Sensei's first lesson: almost every serious finding is a third sibling that quietly differs from the two beside it. Fix the four blockers, thread `RunWorkshopToolSidePass`, accumulate citations across turns, and revisit the scope and disclosure on what is — despite its "preference" ergonomics — a network capability. Then this ships well.
+
+---
+
+*Reviewed by: Marcus 🏛️ · Blake 🔥 · Sam 🔍 · Parker 📖 · Cal 🧪 · Stan 🗂️ · Tim ⚡ · Patricia 🛡️ · Oliver 🌙 · Bria 🎯 · Sensei 🎓*

--- a/docs/pr-reviews/pr-93-workshop-web-research-review.md
+++ b/docs/pr-reviews/pr-93-workshop-web-research-review.md
@@ -13,28 +13,39 @@ findings are addressed so this file stays a living record. Legend: **Open** = ac
 
 | # | Sev | Finding | Reviewers | Consensus | Status |
 |---|-----|---------|-----------|-----------|--------|
-| 1 | 🔴 Blocking | `npm test` is red — modal suite fails to compile, `MessageHandler` test throws `getWebResearch is not a function` | Cal, Bria | 🎯🎯 | **Open** |
-| 2 | 🔴 Blocking | `[open, webResearch]` dep array wipes half-typed Conversation Settings drafts on every session-state push | Blake, Tim, Bria | 🎯🎯 | **Open** |
-| 3 | 🔴 Blocking | `assertCitation` accepts any string as a URL; `new URL()` in render then takes out the whole thread pane | Sam, Patricia, Blake | 🎯🎯 | **Open** |
-| 4 | 🔴 Blocking | `webResearch` skips the pending-persistence guard PR #83 added — failed write silently reverts | Marcus, Stan | 🎯 | **Open** |
-| 5 | 🟠 High | `citations: last.citations` drops every source found before the final turn of a multi-turn run | Blake | — | **Open** |
-| 6 | 🟠 High | `RunWorkshopToolSidePass` host tool-synthesis turn never receives `webResearch` | Bria | — | **Open** |
-| 7 | 🟠 High | No session-level cap on web-search spend or latency; attached to every persona turn | Tim | — | **Open** |
-| 8 | 🟠 High | `scope: "application"` on a network capability — no per-workspace opt-out, syncs across machines | Patricia | — | **Open** |
-| 9 | 🟠 High | Disclosure names latency and provider charges, never the second data recipient | Patricia | — | **Open** |
-| 10 | 🟠 High | First-wins citation merge silently discards a richer duplicate's title | Sam | — | **Open** |
-| 11 | 🟠 High | Pill numbers can disagree with the model's own inline `[n]` markers | Sam | — | **Open** |
-| 12 | 🟠 High | `WorkshopConversationSettingsService` web-research logic untested — and the existing mock would mask a backwards wiring | Cal | — | **Open** |
-| 13 | 🟠 High | The default-off case — the whole point of the feature — is never asserted | Cal | — | **Open** |
-| 14 | 🟠 High | Citation parse failures are indistinguishable from "the model cited nothing" | Oliver | — | **Open** |
-| 15 | 🟠 High | `createAnalysisResult` reaches 8 positional params; 3 call sites pad slot 7 with a literal `undefined` | Parker | — | **Open** |
-| 16 | 🟡 Standard | `readWebResearchSetting` drops the rejection-logging convention its writer-profile sibling adopted | Stan, Oliver | 🎯 | **Open** |
-| 17 | 🟡 Standard | Nothing logs that a turn attached the web-search tool; a research-only toggle logs nothing at all | Oliver | — | **Open** |
-| 18 | 🟡 Standard | Dedicated-service pattern not extended — web research is a bare private field on the coordinator | Marcus | — | **Open** |
-| 19 | 🟡 Standard | `changed: result.changed \|\| webResearchChanged` spelled out 3×, plus a rename that never diverges | Parker | — | **Open** |
-| 20 | 🟡 Standard | One feature, four names — Advanced / Research / `webResearch` / "live web research" | Parker | — | **Open** |
-| 21 | 🟢 Nit | `UrlCitation` forks the `TokenUsage` precedent for where cross-cutting provider types live | Marcus | — | **Open** |
-| 22 | 🟢 Nit | New `coerce`/`equal` pair ships without the doc comments both siblings carry; lone optional param | Stan | — | **Open** |
+| 1 | 🔴 Blocking | `npm test` is red — modal suite fails to compile, `MessageHandler` test throws `getWebResearch is not a function` | Cal, Bria | 🎯🎯 | **Addressed** |
+| 2 | 🔴 Blocking | `[open, webResearch]` dep array wipes half-typed Conversation Settings drafts on every session-state push | Blake, Tim, Bria | 🎯🎯 | **Addressed** |
+| 3 | 🔴 Blocking | `assertCitation` accepts any string as a URL; `new URL()` in render then takes out the whole thread pane | Sam, Patricia, Blake | 🎯🎯 | **Addressed** |
+| 4 | 🔴 Blocking | `webResearch` skips the pending-persistence guard PR #83 added — failed write silently reverts | Marcus, Stan | 🎯 | **Addressed** |
+| 5 | 🟠 High | `citations: last.citations` drops every source found before the final turn of a multi-turn run | Blake | — | **Addressed** |
+| 6 | 🟠 High | `RunWorkshopToolSidePass` host tool-synthesis turn never receives `webResearch` | Bria | — | **Addressed** |
+| 7 | 🟠 High | No session-level cap on web-search spend or latency; attached to every persona turn | Tim | — | **Deferred** |
+| 8 | 🟠 High | `scope: "application"` on a network capability — no per-workspace opt-out, syncs across machines | Patricia | — | **Addressed** |
+| 9 | 🟠 High | Disclosure names latency and provider charges, never the second data recipient | Patricia | — | **Addressed** |
+| 10 | 🟠 High | First-wins citation merge silently discards a richer duplicate's title | Sam | — | **Addressed** |
+| 11 | 🟠 High | Pill numbers can disagree with the model's own inline `[n]` markers | Sam | — | **Deferred** |
+| 12 | 🟠 High | `WorkshopConversationSettingsService` web-research logic untested — and the existing mock would mask a backwards wiring | Cal | — | **Addressed** |
+| 13 | 🟠 High | The default-off case — the whole point of the feature — is never asserted | Cal | — | **Addressed** |
+| 14 | 🟠 High | Citation parse failures are indistinguishable from "the model cited nothing" | Oliver | — | **Addressed** |
+| 15 | 🟠 High | `createAnalysisResult` reaches 8 positional params; 3 call sites pad slot 7 with a literal `undefined` | Parker | — | **Addressed** |
+| 16 | 🟡 Standard | `readWebResearchSetting` drops the rejection-logging convention its writer-profile sibling adopted | Stan, Oliver | 🎯 | **Addressed** |
+| 17 | 🟡 Standard | Nothing logs that a turn attached the web-search tool; a research-only toggle logs nothing at all | Oliver | — | **Addressed** |
+| 18 | 🟡 Standard | Dedicated-service pattern not extended — web research is a bare private field on the coordinator | Marcus | — | **Deferred** |
+| 19 | 🟡 Standard | `changed: result.changed \|\| webResearchChanged` spelled out 3×, plus a rename that never diverges | Parker | — | **Addressed** |
+| 20 | 🟡 Standard | One feature, four names — Advanced / Research / `webResearch` / "live web research" | Parker | — | **N/A** |
+| 21 | 🟢 Nit | `UrlCitation` forks the `TokenUsage` precedent for where cross-cutting provider types live | Marcus | — | **Addressed** |
+| 22 | 🟢 Nit | New `coerce`/`equal` pair ships without the doc comments both siblings carry; lone optional param | Stan | — | **Addressed** |
+
+---
+
+## Resolution notes — 2026-07-27
+
+- Findings **1–6**, **8–10**, and **12–17** now have direct regression coverage. Citation URLs are validated at provider ingestion and persisted-state restoration; the renderer also has a safe fallback.
+- Finding **7** is deferred to `.todo/tech-debt/2026-07-27-workshop-web-research-budget-and-citation-contract.md`: OpenRouter's current response does not provide an authoritative server-tool invocation count, so a session cap needs an explicit product/accounting contract rather than a misleading arbitrary limit.
+- Finding **11** is deferred in the same tracked item. The UI intentionally retains the user-requested independently numbered, clickable source pills; it does not claim an unprovable mapping to model-authored inline markers.
+- Finding **18** is deferred with that expansion path: the current single enablement toggle has the coordinator's guarded persistence contract, while any budget/control expansion must extract a dedicated web-research settings service.
+- Finding **20** is **N/A**: **Advanced** is the user-directed tab location, while **live web research** is the capability label and `webResearch` remains the precise internal setting name.
+- Findings **21–22** move `UrlCitation` into the cross-cutting messages barrel and align the web-research coercion API with sibling documentation/default-parameter conventions.
 
 ---
 

--- a/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/MessageHandler.test.ts
@@ -167,7 +167,8 @@ function createTestAssembly(): TestAssembly {
       applyFromWebview: jest.fn().mockResolvedValue({ changed: false, deferred: false }),
       syncFromSettings: jest.fn().mockResolvedValue({ changed: false, deferred: false }),
       flushDeferredSettingsSync: jest.fn().mockResolvedValue({ changed: false, deferred: false }),
-      getWriterProfile: jest.fn().mockReturnValue(DEFAULT_WORKSHOP_WRITER_PROFILE)
+      getWriterProfile: jest.fn().mockReturnValue(DEFAULT_WORKSHOP_WRITER_PROFILE),
+      getWebResearch: jest.fn().mockReturnValue({ enabled: false })
     },
     workshopSessionTimeService: new WorkshopSessionTimeService({
       now: () => new Date('2026-07-23T14:00:00.000Z'),
@@ -455,7 +456,8 @@ describe('MessageHandler assembly', () => {
 
   it.each([
     'proseMinion.workshop.conversationBehavior',
-    'proseMinion.workshop.writerProfile'
+    'proseMinion.workshop.writerProfile',
+    'proseMinion.workshop.webResearch'
   ])('pulls external Workshop setting %s into the live room', async (changedKey) => {
     const assembly = createTestAssembly();
     const handler = createHandler(assembly, jest.fn().mockResolvedValue(undefined));

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -232,7 +232,8 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
         roomDelivery,
         capabilityFactory,
         log,
-        writerProfileService
+        writerProfileService,
+        () => false
       ),
       capabilityFactory,
       postMessage,

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopToolSidePass.integration.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopToolSidePass.integration.test.ts
@@ -90,7 +90,8 @@ describe('Workshop tool side-pass — handler to agent engine', () => {
         roomDelivery,
         capabilityFactory,
         output,
-        writerProfileService
+        writerProfileService,
+        () => true
       ),
       capabilityFactory,
       postMessage,
@@ -176,6 +177,10 @@ describe('Workshop tool side-pass — handler to agent engine', () => {
       'tool_report',
       'persona_synthesis'
     ]);
+    expect(engine.runInitial.mock.calls[1]![0].options?.tools).toEqual([{
+      type: 'openrouter:web_search',
+      parameters: { engine: 'auto', max_uses: 2, max_total_results: 10 }
+    }]);
     expect(session.getSnapshot().turns.at(-1)?.behavior).toMatchObject({
       interactionMode: 'balanced',
       expressionLevel: 'full'

--- a/packages/core/src/__tests__/application/services/AgentRunEngine.test.ts
+++ b/packages/core/src/__tests__/application/services/AgentRunEngine.test.ts
@@ -143,6 +143,32 @@ describe('AgentRunEngine', () => {
     });
   });
 
+  it('retains citations gathered before a capability round produces the final response', async () => {
+    const guides = capability();
+    guides.fulfill.mockResolvedValueOnce({
+      evidence: 'Evidence', deliveredItems: ['dialogue.md'], artifacts: []
+    });
+    client.createChatCompletion
+      .mockResolvedValueOnce({
+        content: GUIDE_REQUEST,
+        citations: [{ url: 'https://one.example', title: 'First source' }]
+      })
+      .mockResolvedValueOnce({
+        content: 'Final response.',
+        citations: [{ url: 'https://two.example', title: 'Second source' }]
+      });
+
+    const result = await engine.runInitial({
+      toolName: 'dialogue', systemMessage: 'System', userMessage: 'Analyze.',
+      policy: { ...AGENT_RUN_POLICIES.assistant, retention: 'retain' }, capability: guides
+    });
+
+    expect(result.citations).toEqual([
+      { url: 'https://one.example', title: 'First source' },
+      { url: 'https://two.example', title: 'Second source' }
+    ]);
+  });
+
   it('buffers an exact XML request, then progressively streams the final answer', async () => {
     const guides = capability();
     client.createStreamingChatCompletion

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopConversationSettingsService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopConversationSettingsService.test.ts
@@ -5,8 +5,10 @@ import type { AssistantToolService } from '@services/analysis/AssistantToolServi
 import type { LogSink, SettingsStore } from '@/platform';
 import {
   DEFAULT_WORKSHOP_WRITER_PROFILE,
+  DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS,
   type WorkshopConversationBehavior,
-  type WorkshopWriterProfile
+  type WorkshopWriterProfile,
+  type WorkshopWebResearchSettings
 } from '@messages';
 
 const balanced: WorkshopConversationBehavior = {
@@ -32,6 +34,7 @@ describe('WorkshopConversationSettingsService', () => {
   let session: WorkshopSessionService;
   let configured: WorkshopConversationBehavior;
   let configuredProfile: WorkshopWriterProfile;
+  let configuredWebResearch: WorkshopWebResearchSettings;
   let settings: jest.Mocked<SettingsStore>;
   let assistant: jest.Mocked<AssistantToolService>;
   let log: jest.Mocked<LogSink>;
@@ -41,10 +44,13 @@ describe('WorkshopConversationSettingsService', () => {
     session = new WorkshopSessionService(() => 1, balanced);
     configured = analysis;
     configuredProfile = { ...DEFAULT_WORKSHOP_WRITER_PROFILE };
+    configuredWebResearch = { ...DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS };
     settings = {
-      get: jest.fn((_section: string, key: string) =>
-        key === 'workshop.writerProfile' ? configuredProfile : configured
-      ),
+      get: jest.fn((_section: string, key: string) => {
+        if (key === 'workshop.writerProfile') return configuredProfile;
+        if (key === 'workshop.webResearch') return configuredWebResearch;
+        return configured;
+      }),
       update: jest.fn().mockResolvedValue(undefined)
     } as unknown as jest.Mocked<SettingsStore>;
     assistant = {
@@ -170,6 +176,53 @@ describe('WorkshopConversationSettingsService', () => {
     });
 
     expect(service.getWriterProfile()).toEqual(profile);
+  });
+
+  describe('web research', () => {
+    it('defaults off and persists an explicit enabled choice', async () => {
+      expect(service.getWebResearch()).toEqual(DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS);
+
+      await expect(
+        service.applyFromWebview(balanced, DEFAULT_WORKSHOP_WRITER_PROFILE, { enabled: true })
+      ).resolves.toEqual({ changed: true, deferred: false });
+
+      expect(settings.update).toHaveBeenCalledWith(
+        'proseMinion',
+        'workshop.webResearch',
+        { enabled: true }
+      );
+      expect(service.getWebResearch()).toEqual({ enabled: true });
+      expect(log.appendLine).toHaveBeenCalledWith(
+        expect.stringContaining('webResearchEnabled=true')
+      );
+    });
+
+    it('retains an applied research choice after its settings write fails', async () => {
+      configured = balanced;
+      settings.update.mockImplementation(async (_section, key) => {
+        if (key === 'workshop.webResearch') throw new Error('research is read-only');
+      });
+
+      await expect(
+        service.applyFromWebview(balanced, DEFAULT_WORKSHOP_WRITER_PROFILE, { enabled: true })
+      ).resolves.toEqual({
+        changed: true,
+        deferred: false,
+        persistenceErrors: { webResearch: 'research is read-only' }
+      });
+      await expect(service.syncFromSettings()).resolves.toEqual({ changed: false, deferred: false });
+
+      expect(service.getWebResearch()).toEqual({ enabled: true });
+    });
+
+    it('reports an external research-only setting change', async () => {
+      configured = balanced;
+      configuredWebResearch = { enabled: true };
+
+      await expect(service.syncFromSettings()).resolves.toEqual({ changed: true, deferred: false });
+
+      expect(service.getWebResearch()).toEqual({ enabled: true });
+    });
   });
 
   it('does not let a successful behavior echo revert a profile whose persistence failed', async () => {

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
@@ -202,6 +202,15 @@ describe('WorkshopSessionService committed persistence', () => {
       message: 'actionableFindings must be array'
     },
     {
+      label: 'a persisted citation has an unsafe URL',
+      mutate: (value: unknown) => {
+        const report = (value as { turns: Array<{ citations?: Array<{ url: string }> }> }).turns
+          .find((turn) => turn.citations !== undefined)!;
+        report.citations![0].url = 'file:///private/draft';
+      },
+      message: 'citations[0].url must be a complete HTTP(S) URL'
+    },
+    {
       label: 'a participant union contains an invalid liveness value',
       mutate: (value: unknown) => {
         (value as { participants: { personaGuests: Array<{ liveness: unknown }> } })

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopSessionPersistence.test.ts
@@ -35,7 +35,12 @@ const buildCompleteState = (): WorkshopSessionStateV1 => {
   });
   session.recordSessionMarker('start', 'Session started at 10:00 AM.');
   session.beginPersonaMessage('host-open', 'Begin.');
-  session.completeRun('host-open', 'I am here.', undefined, false, 'host-runtime-before-save');
+  session.completeRun('host-open', 'I am here.', undefined, false, 'host-runtime-before-save', [], [{
+    url: 'https://www.anthropic.com/news/claude-opus-5',
+    title: 'Introducing Claude Opus 5',
+    startIndex: 0,
+    endIndex: 4
+  }]);
 
   session.replaceExcerpt({
     text: 'The second cup breaks.',
@@ -120,6 +125,12 @@ describe('WorkshopSessionService committed persistence', () => {
     expect(state.excerpt!.text).toBe('The second cup breaks.');
     expect(state.turns[0].content).not.toBe('Mutated parsed turn.');
     expect(state.writerSources.host[0].label).not.toBe('Mutated parsed source.');
+    expect(parsed.turns.find((turn) => turn.citations !== undefined)?.citations).toEqual([{
+      url: 'https://www.anthropic.com/news/claude-opus-5',
+      title: 'Introducing Claude Opus 5',
+      startIndex: 0,
+      endIndex: 4
+    }]);
   });
 
   it('round-trips guest-origin next steps with their persona provenance', () => {

--- a/packages/core/src/__tests__/infrastructure/api/providers/OpenRouterClient.test.ts
+++ b/packages/core/src/__tests__/infrastructure/api/providers/OpenRouterClient.test.ts
@@ -187,4 +187,27 @@ describe('OpenRouterClient model hot-swap', () => {
       global.fetch = originalFetch;
     }
   });
+
+  it('accumulates citations reported across streaming frames', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue(streamingResponse(
+      { choices: [{ delta: { annotations: [{ type: 'url_citation', url_citation: { url: 'https://one.example', title: 'One' } }] } }] },
+      { choices: [{ delta: { annotations: [{ type: 'url_citation', url_citation: { url: 'https://two.example', title: 'Two' } }] }, finish_reason: 'stop' }] },
+      '[DONE]'
+    )) as unknown as typeof fetch;
+    try {
+      const chunks = [];
+      for await (const chunk of new OpenRouterClient('key').createStreamingChatCompletion([{ role: 'user', content: 'Hello' }])) {
+        chunks.push(chunk);
+      }
+      expect(chunks.at(-1)).toMatchObject({
+        citations: [
+          { url: 'https://one.example', title: 'One' },
+          { url: 'https://two.example', title: 'Two' }
+        ]
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/core/src/__tests__/infrastructure/api/providers/OpenRouterClient.test.ts
+++ b/packages/core/src/__tests__/infrastructure/api/providers/OpenRouterClient.test.ts
@@ -98,6 +98,28 @@ describe('OpenRouterClient model hot-swap', () => {
     }
   });
 
+  it('sends an explicitly enabled web-search server tool unchanged', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        id: 'response-1', choices: [{ message: { role: 'assistant', content: 'Hi' }, finish_reason: 'stop' }]
+      })
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      await new OpenRouterClient('key', 'model/requested').createChatCompletion(
+        [{ role: 'user', content: 'Hello' }],
+        { tools: [{ type: 'openrouter:web_search', parameters: { engine: 'auto', max_uses: 2, max_total_results: 10 } }] }
+      );
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body as string).tools).toEqual([
+        { type: 'openrouter:web_search', parameters: { engine: 'auto', max_uses: 2, max_total_results: 10 } }
+      ]);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
   it('emits streaming terminal usage and metadata exactly once when they arrive after finish reason', async () => {
     const originalFetch = global.fetch;
     const fetchMock = jest.fn().mockResolvedValue(streamingResponse(

--- a/packages/core/src/__tests__/infrastructure/api/providers/OpenRouterClient.test.ts
+++ b/packages/core/src/__tests__/infrastructure/api/providers/OpenRouterClient.test.ts
@@ -148,6 +148,41 @@ describe('OpenRouterClient model hot-swap', () => {
     }
   });
 
+  it('drops malformed citation URLs with a diagnostic while retaining valid sources', async () => {
+    const originalFetch = global.fetch;
+    const output = { appendLine: jest.fn(), show: jest.fn(), clear: jest.fn() };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        id: 'response-1',
+        choices: [{
+          message: {
+            role: 'assistant', content: 'Grounded answer.',
+            annotations: [
+              { type: 'url_citation', url_citation: { url: 'https://', title: 'Broken' } },
+              { type: 'url_citation', url_citation: { url: 'file:///private/draft', title: 'Unsafe' } },
+              { type: 'url_citation', url_citation: { url: 'https://www.anthropic.com/news/example', title: 'Primary source' } }
+            ]
+          },
+          finish_reason: 'stop'
+        }]
+      })
+    }) as unknown as typeof fetch;
+    try {
+      const result = await new OpenRouterClient('key', undefined, output).createChatCompletion(
+        [{ role: 'user', content: 'Hello' }]
+      );
+      expect(result.citations).toEqual([
+        { url: 'https://www.anthropic.com/news/example', title: 'Primary source', startIndex: undefined, endIndex: undefined }
+      ]);
+      expect(output.appendLine).toHaveBeenCalledWith(
+        expect.stringContaining('Dropped 2/3 unparseable citation annotation(s)')
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
   it('emits streaming terminal usage and metadata exactly once when they arrive after finish reason', async () => {
     const originalFetch = global.fetch;
     const fetchMock = jest.fn().mockResolvedValue(streamingResponse(
@@ -205,6 +240,26 @@ describe('OpenRouterClient model hot-swap', () => {
           { url: 'https://one.example', title: 'One' },
           { url: 'https://two.example', title: 'Two' }
         ]
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('backfills a duplicate citation title from a later streaming annotation', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue(streamingResponse(
+      { choices: [{ delta: { annotations: [{ type: 'url_citation', url_citation: { url: 'https://one.example' } }] } }] },
+      { choices: [{ delta: { annotations: [{ type: 'url_citation', url_citation: { url: 'https://one.example', title: 'One' } }] }, finish_reason: 'stop' }] },
+      '[DONE]'
+    )) as unknown as typeof fetch;
+    try {
+      const chunks = [];
+      for await (const chunk of new OpenRouterClient('key').createStreamingChatCompletion([{ role: 'user', content: 'Hello' }])) {
+        chunks.push(chunk);
+      }
+      expect(chunks.at(-1)).toMatchObject({
+        citations: [{ url: 'https://one.example', title: 'One' }]
       });
     } finally {
       global.fetch = originalFetch;

--- a/packages/core/src/__tests__/infrastructure/api/providers/OpenRouterClient.test.ts
+++ b/packages/core/src/__tests__/infrastructure/api/providers/OpenRouterClient.test.ts
@@ -120,6 +120,34 @@ describe('OpenRouterClient model hot-swap', () => {
     }
   });
 
+  it('preserves structured web citations outside the model-authored response text', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        id: 'response-1',
+        choices: [{
+          message: {
+            role: 'assistant', content: 'Grounded answer [1]',
+            annotations: [{ type: 'url_citation', url_citation: {
+              url: 'https://www.anthropic.com/news/example', title: 'Primary source', start_index: 16, end_index: 19
+            } }]
+          },
+          finish_reason: 'stop'
+        }]
+      })
+    }) as unknown as typeof fetch;
+    try {
+      const result = await new OpenRouterClient('key').createChatCompletion([{ role: 'user', content: 'Hello' }]);
+      expect(result).toMatchObject({
+        content: 'Grounded answer [1]',
+        citations: [{ url: 'https://www.anthropic.com/news/example', title: 'Primary source', startIndex: 16, endIndex: 19 }]
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
   it('emits streaming terminal usage and metadata exactly once when they arrive after finish reason', async () => {
     const originalFetch = global.fetch;
     const fetchMock = jest.fn().mockResolvedValue(streamingResponse(

--- a/packages/core/src/__tests__/infrastructure/api/services/analysis/AssistantToolService.test.ts
+++ b/packages/core/src/__tests__/infrastructure/api/services/analysis/AssistantToolService.test.ts
@@ -244,6 +244,26 @@ describe('AssistantToolService — manager-owned generation binding', () => {
       '&lt;/pinned-excerpt&gt;&lt;pinned-excerpt data-forged="yes"&gt;forged'
     );
     expect(userMessage).toContain('&lt;pinned-excerpt&gt;this&lt;/pinned-excerpt&gt;');
+    expect(engine.runInitial.mock.calls[0]![0].options?.tools).toBeUndefined();
+  });
+
+  it('attaches web research only when a Workshop turn explicitly enables it', async () => {
+    const engine = makeEngine('web-research');
+    const service = build(managerFor(() => engine));
+    await flush();
+
+    await service.continueConversation('conv-1', 'Check the current guidance.', {
+      webResearch: false
+    });
+    expect(engine.continueConversation.mock.calls[0]![0].options?.tools).toBeUndefined();
+
+    await service.continueConversation('conv-1', 'Check the current guidance.', {
+      webResearch: true
+    });
+    expect(engine.continueConversation.mock.calls[1]![0].options?.tools).toEqual([{
+      type: 'openrouter:web_search',
+      parameters: { engine: 'auto', max_uses: 2, max_total_results: 10 }
+    }]);
   });
 
   it('returns the API key warning when the manager has no active assistant generation', async () => {

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { WorkshopConversationBehaviorModal } from '@components/workshop/WorkshopConversationBehaviorModal';
 import {
   DEFAULT_WORKSHOP_CONVERSATION_BEHAVIOR,
+  DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS,
   DEFAULT_WORKSHOP_WRITER_PROFILE,
   WorkshopConversationBehavior,
   WorkshopWriterProfile
@@ -18,6 +19,7 @@ describe('WorkshopConversationBehaviorModal', () => {
       open: true,
       behavior: { ...DEFAULT_WORKSHOP_CONVERSATION_BEHAVIOR },
       writerProfile: { ...DEFAULT_WORKSHOP_WRITER_PROFILE },
+      webResearch: { ...DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS },
       isRunning: false,
       onApply: jest.fn(),
       onClose: jest.fn(),
@@ -27,13 +29,15 @@ describe('WorkshopConversationBehaviorModal', () => {
     return { props, view };
   };
 
-  it('renders accessible Behavior and About you tabs with the approved scope', () => {
+  it('renders accessible Behavior, About you, and Advanced tabs with the approved scope', () => {
     renderModal();
 
     expect(screen.getByRole('heading', { name: 'Conversation settings' })).not.toBeNull();
     expect(screen.getByRole('tab', { name: 'Behavior' }).getAttribute('aria-selected')).toBe('true');
     expect(screen.getByRole('tab', { name: 'About you' }).getAttribute('aria-controls'))
       .toBe('pm-ws-profile-panel');
+    expect(screen.getByRole('tab', { name: 'Advanced' }).getAttribute('aria-controls'))
+      .toBe('pm-ws-advanced-panel');
     expect(screen.getByRole('tabpanel').getAttribute('aria-labelledby')).toBe('pm-ws-behavior-tab');
     expect(screen.getByText('Response style')).not.toBeNull();
     expect(screen.getByText('Relational depth')).not.toBeNull();
@@ -49,6 +53,14 @@ describe('WorkshopConversationBehaviorModal', () => {
     expect(profileTab.getAttribute('aria-selected')).toBe('true');
     expect(document.activeElement).toBe(profileTab);
     expect(screen.getByRole('tabpanel').getAttribute('aria-labelledby')).toBe('pm-ws-profile-tab');
+
+    fireEvent.keyDown(profileTab, { key: 'ArrowRight' });
+    const advancedTab = screen.getByRole('tab', { name: 'Advanced' });
+    expect(advancedTab.getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(advancedTab);
+
+    fireEvent.keyDown(advancedTab, { key: 'ArrowRight' });
+    expect(behaviorTab.getAttribute('aria-selected')).toBe('true');
   });
 
   it('edits profile fields locally and submits both complete drafts together', () => {
@@ -66,7 +78,8 @@ describe('WorkshopConversationBehaviorModal', () => {
 
     expect(props.onApply).toHaveBeenCalledWith(
       expect.objectContaining({ interactionMode: 'analysis' }),
-      { enabled: true, preferredAddress: 'Okey', bio: 'I write fiction.' }
+      { enabled: true, preferredAddress: 'Okey', bio: 'I write fiction.' },
+      DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS
     );
     expect(screen.getByText('Conversation settings are updating…')).not.toBeNull();
   });
@@ -86,7 +99,8 @@ describe('WorkshopConversationBehaviorModal', () => {
 
     expect(props.onApply).toHaveBeenCalledWith(
       DEFAULT_WORKSHOP_CONVERSATION_BEHAVIOR,
-      DEFAULT_WORKSHOP_WRITER_PROFILE
+      DEFAULT_WORKSHOP_WRITER_PROFILE,
+      DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS
     );
   });
 
@@ -148,6 +162,36 @@ describe('WorkshopConversationBehaviorModal', () => {
     });
 
     expect(screen.getByText(`4 / 80`)).not.toBeNull();
+  });
+
+  it('keeps drafts intact when an unrelated session-state push re-allocates web research', () => {
+    const { props, view } = renderModal();
+    fireEvent.click(screen.getByRole('tab', { name: 'About you' }));
+    fireEvent.change(screen.getByRole('textbox', { name: /How should the room address you/ }), {
+      target: { value: 'Half-typed' }
+    });
+
+    view.rerender(
+      <WorkshopConversationBehaviorModal {...props} webResearch={{ enabled: false }} />
+    );
+
+    expect(screen.getByRole('tab', { name: 'About you' }).getAttribute('aria-selected')).toBe('true');
+    expect((screen.getByRole('textbox', {
+      name: /How should the room address you/
+    }) as HTMLInputElement).value).toBe('Half-typed');
+  });
+
+  it('submits the Advanced research draft with the other conversation settings', () => {
+    const { props } = renderModal();
+    fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    fireEvent.click(screen.getByRole('switch', { name: 'Allow live web research' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Apply to next turn' }));
+
+    expect(props.onApply).toHaveBeenCalledWith(
+      DEFAULT_WORKSHOP_CONVERSATION_BEHAVIOR,
+      DEFAULT_WORKSHOP_WRITER_PROFILE,
+      { enabled: true }
+    );
   });
 
   it('locks Apply during a response while leaving inspection and drafts available', () => {

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopNoticeModal.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopNoticeModal.test.tsx
@@ -39,7 +39,7 @@ describe('WorkshopNoticeModal', () => {
     expect(next.disabled).toBe(true);
   });
 
-  it('explains host choice, model guidance, controller scope, and persona-run tools', () => {
+  it('explains host choice, model guidance, conversation settings, and persona-run tools', () => {
     renderModal();
 
     fireEvent.click(screen.getByRole('button', { name: 'Notice 3' }));
@@ -50,6 +50,8 @@ describe('WorkshopNoticeModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Notice 4' }));
     expect(screen.getByText(/Conversation Controller/)).toBeTruthy();
+    expect(screen.getByText(/About you/)).toBeTruthy();
+    expect(screen.getByText(/clickable citation pill/)).toBeTruthy();
     expect(screen.getByText(/do not apply to direct instrument threads/)).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Notice 5' }));

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopTurnBubble.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopTurnBubble.test.tsx
@@ -63,6 +63,39 @@ Third version.`);
 });
 
 describe('WorkshopTurnBubble variation cards', () => {
+  it('renders each web citation as an independently clickable context-style pill', () => {
+    render(
+      <WorkshopTurnBubble
+        turn={{
+          ...assistantTurn('Research findings.'),
+          citations: [
+            { url: 'https://www.anthropic.com/news/claude-opus-5', title: 'Introducing Claude Opus 5' },
+            { url: 'https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5', title: 'What\'s new in Claude Opus 5' },
+            { url: 'https://example.com/system-card.pdf' }
+          ]
+        }}
+        quickActionToolId={null}
+        onQuickAction={jest.fn()}
+        onTalkDirectly={jest.fn()}
+        onCopy={jest.fn()}
+        onSave={jest.fn()}
+      />
+    );
+
+    const citations = screen.getAllByRole('link');
+    expect(citations).toHaveLength(3);
+    expect(citations.map((citation) => citation.textContent)).toEqual([
+      '1Introducing Claude Opus 5',
+      "2What's new in Claude Opus 5",
+      '3example.com'
+    ]);
+    expect(citations[0].classList.contains('pm-ws-ctx-pill')).toBe(true);
+    expect(citations[0].classList.contains('pm-ws-turn-citation-pill')).toBe(true);
+    expect(citations[1].getAttribute('href')).toBe(
+      'https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5'
+    );
+  });
+
   it('renders the direct-run divider with the pinned revision', () => {
     render(
       <WorkshopTurnBubble

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/useWorkshop.test.ts
@@ -75,6 +75,7 @@ const sessionState = (session: Partial<WorkshopSessionSnapshot>): WorkshopSessio
         ...session
       },
       writerProfile: { ...DEFAULT_WORKSHOP_WRITER_PROFILE },
+      webResearch: { enabled: false },
       persistence: { available: true, degradedConversationKeys: [] }
     },
     timestamp: 0
@@ -441,6 +442,7 @@ describe('useWorkshop', () => {
       .toEqual({
         behavior: selected,
         writerProfile: DEFAULT_WORKSHOP_WRITER_PROFILE
+        ,webResearch: { enabled: false }
       });
     expect(result.current.conversationBehavior).toEqual(
       DEFAULT_WORKSHOP_CONVERSATION_BEHAVIOR

--- a/packages/core/src/application/handlers/MessageHandler.ts
+++ b/packages/core/src/application/handlers/MessageHandler.ts
@@ -22,7 +22,8 @@ import {
   TokenUsageTotals,
   WorkshopSessionStateMessage,
   WORKSHOP_CONVERSATION_BEHAVIOR_SETTING,
-  WORKSHOP_WRITER_PROFILE_SETTING
+  WORKSHOP_WRITER_PROFILE_SETTING,
+  WORKSHOP_WEB_RESEARCH_SETTING
 } from '@messages';
 import {
   CoreServices,
@@ -598,7 +599,9 @@ export class MessageHandler {
       WORKSHOP_CONVERSATION_BEHAVIOR_SETTING.key;
     const workshopWriterProfileKey = `${WORKSHOP_WRITER_PROFILE_SETTING.section}.` +
       WORKSHOP_WRITER_PROFILE_SETTING.key;
-    if (affects(workshopBehaviorKey) || affects(workshopWriterProfileKey)) {
+    const workshopWebResearchKey = `${WORKSHOP_WEB_RESEARCH_SETTING.section}.` +
+      WORKSHOP_WEB_RESEARCH_SETTING.key;
+    if (affects(workshopBehaviorKey) || affects(workshopWriterProfileKey) || affects(workshopWebResearchKey)) {
       void this.workshopHandler.syncConversationSettingsFromSettings();
     }
 

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -483,7 +483,8 @@ export class WorkshopHandler {
     try {
       const result = await this.conversationSettingsService.applyFromWebview(
         message.payload?.behavior,
-        message.payload?.writerProfile
+        message.payload?.writerProfile,
+        message.payload?.webResearch
       );
       if (result.persistenceErrors) {
         const persistenceDetails = [
@@ -492,6 +493,9 @@ export class WorkshopHandler {
             : undefined,
           result.persistenceErrors.writerProfile
             ? `writer profile: ${result.persistenceErrors.writerProfile}`
+            : undefined,
+          result.persistenceErrors.webResearch
+            ? `web research: ${result.persistenceErrors.webResearch}`
             : undefined
         ].filter(Boolean).join('; ');
         this.outputChannel.appendLine(
@@ -694,7 +698,8 @@ export class WorkshopHandler {
         }, {
           signal: controller.signal,
           onToken: (token: string) => this.sendStreamChunk(requestId, token),
-          capability: guestCapability
+          capability: guestCapability,
+          webResearch: this.conversationSettingsService.getWebResearch().enabled
         });
         const assistantTurn = completeWorkshopRun({
           session: this.session,
@@ -1074,7 +1079,8 @@ export class WorkshopHandler {
         ? await this.assistantToolService.continueConversation(conversationId, modelMessage, {
             signal: controller.signal,
             onToken: (token: string) => this.sendStreamChunk(requestId, token),
-            capability: participantCapability
+            capability: participantCapability,
+            webResearch: this.conversationSettingsService.getWebResearch().enabled
           })
         : await this.assistantToolService.startWorkshopPersonaConversation({
             personaId,
@@ -1093,7 +1099,8 @@ export class WorkshopHandler {
           }, {
             signal: controller.signal,
             onToken: (token: string) => this.sendStreamChunk(requestId, token),
-            capability: participantCapability!
+            capability: participantCapability!,
+            webResearch: this.conversationSettingsService.getWebResearch().enabled
           });
 
       const assistantTurn = completeWorkshopRun({
@@ -2707,6 +2714,7 @@ export class WorkshopHandler {
       payload: {
         session,
         writerProfile: this.conversationSettingsService.getWriterProfile(),
+        webResearch: this.conversationSettingsService.getWebResearch(),
         persistence: {
           available: availability.available,
           unavailableReason: availability.available ? undefined : availability.reason,

--- a/packages/core/src/application/services/workshop/RunWorkshopToolSidePass.ts
+++ b/packages/core/src/application/services/workshop/RunWorkshopToolSidePass.ts
@@ -69,7 +69,8 @@ export class RunWorkshopToolSidePass {
     private readonly roomDelivery: WorkshopRoomDeliveryService,
     private readonly capabilityFactory: WorkshopPersonaCapabilityFactory,
     private readonly outputChannel: LogSink,
-    private readonly writerProfileService: WorkshopWriterProfileService
+    private readonly writerProfileService: WorkshopWriterProfileService,
+    private readonly webResearchEnabled: () => boolean
   ) {}
 
   async run(
@@ -228,7 +229,8 @@ export class RunWorkshopToolSidePass {
         ? await this.assistantToolService.continueConversation(hostConversationId, hostMessage, {
             signal: controller.signal,
             onToken: (token: string) => events.streamChunk(synthesisRequestId, token),
-            capability: hostCapability
+            capability: hostCapability,
+            webResearch: this.webResearchEnabled()
           })
         : await this.assistantToolService.startWorkshopPersonaConversation({
             personaId,
@@ -245,7 +247,8 @@ export class RunWorkshopToolSidePass {
           }, {
             signal: controller.signal,
             onToken: (token: string) => events.streamChunk(synthesisRequestId, token),
-            capability: hostCapability
+            capability: hostCapability,
+            webResearch: this.webResearchEnabled()
           });
       const synthesisTurn = completeWorkshopRun({
         session: this.session,

--- a/packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts
@@ -9,14 +9,19 @@ import {
   workshopWriterProfilePromptsEqual,
   workshopWriterProfilesEqual,
   WORKSHOP_CONVERSATION_BEHAVIOR_SETTING,
+  WORKSHOP_WEB_RESEARCH_SETTING,
   WorkshopConversationBehavior,
   WorkshopPersonaId,
-  WorkshopWriterProfile
+  WorkshopWriterProfile,
+  WorkshopWebResearchSettings,
+  coerceWorkshopWebResearchSettings,
+  workshopWebResearchSettingsEqual
 } from '@messages';
 
 export interface WorkshopConversationSettingsPersistenceErrors {
   behavior?: string;
   writerProfile?: string;
+  webResearch?: string;
 }
 
 export interface WorkshopConversationSettingsUpdate {
@@ -51,6 +56,7 @@ export class WorkshopConversationSettingsService {
   private externalSyncPending = false;
   private pendingBehaviorPersistence?: PendingPersistence<WorkshopConversationBehavior>;
   private pendingProfilePersistence?: PendingPersistence<WorkshopWriterProfile>;
+  private webResearch: WorkshopWebResearchSettings;
 
   constructor(
     private readonly session: WorkshopSessionService,
@@ -58,15 +64,19 @@ export class WorkshopConversationSettingsService {
     private readonly settings: SettingsStore,
     private readonly outputChannel: LogSink,
     private readonly writerProfileService: WorkshopWriterProfileService
-  ) {}
+  ) {
+    this.webResearch = this.readWebResearchSetting();
+  }
 
   /** Apply and persist the modal's complete Behavior + About You submission. */
   applyFromWebview(
     rawBehavior: unknown,
-    rawWriterProfile: unknown
+    rawWriterProfile: unknown,
+    rawWebResearch?: unknown
   ): Promise<WorkshopConversationSettingsUpdate> {
     const nextBehavior = coerceWorkshopConversationBehavior(rawBehavior);
     const nextProfile = coerceWorkshopWriterProfile(rawWriterProfile);
+    const nextWebResearch = coerceWorkshopWebResearchSettings(rawWebResearch);
     return this.serialize(async () => {
       this.assertBetweenRuns();
       const result = await this.apply(nextBehavior, nextProfile);
@@ -79,8 +89,11 @@ export class WorkshopConversationSettingsService {
       const persistProfile = result.profileChanged
         || (pendingProfile !== undefined
           && workshopWriterProfilesEqual(pendingProfile.appliedValue, nextProfile));
-      if (!persistBehavior && !persistProfile) {
-        return this.publicResult(result);
+      const webResearchChanged = !workshopWebResearchSettingsEqual(this.webResearch, nextWebResearch);
+      const persistWebResearch = webResearchChanged;
+      this.webResearch = nextWebResearch;
+      if (!persistBehavior && !persistProfile && !persistWebResearch) {
+        return this.publicResult({ ...result, changed: result.changed || webResearchChanged });
       }
 
       const persistenceErrors: WorkshopConversationSettingsPersistenceErrors = {};
@@ -112,10 +125,21 @@ export class WorkshopConversationSettingsService {
           };
         }
       }
+      if (persistWebResearch) {
+        try {
+          await this.settings.update(
+            WORKSHOP_WEB_RESEARCH_SETTING.section,
+            WORKSHOP_WEB_RESEARCH_SETTING.key,
+            nextWebResearch
+          );
+        } catch (error) {
+          persistenceErrors.webResearch = this.errorMessage(error);
+        }
+      }
       return this.publicResult(
         Object.keys(persistenceErrors).length > 0
-          ? { ...result, persistenceErrors }
-          : result
+          ? { ...result, changed: result.changed || webResearchChanged, persistenceErrors }
+          : { ...result, changed: result.changed || webResearchChanged }
       );
     });
   }
@@ -134,12 +158,17 @@ export class WorkshopConversationSettingsService {
         );
         return { changed: false, deferred: true };
       }
+      const previousWebResearch = this.webResearch;
       const result = await this.apply(
         this.resolveBehaviorSetting(this.readBehaviorSetting()),
         this.resolveProfileSetting(this.writerProfileService.readSetting())
       );
+      this.webResearch = this.readWebResearchSetting();
       this.externalSyncPending = false;
-      return this.publicResult(result);
+      return this.publicResult({
+        ...result,
+        changed: result.changed || !workshopWebResearchSettingsEqual(previousWebResearch, this.webResearch)
+      });
     });
   }
 
@@ -152,12 +181,17 @@ export class WorkshopConversationSettingsService {
       if (this.hasActiveRun()) {
         return { changed: false, deferred: true };
       }
+      const previousWebResearch = this.webResearch;
       const result = await this.apply(
         this.resolveBehaviorSetting(this.readBehaviorSetting()),
         this.resolveProfileSetting(this.writerProfileService.readSetting())
       );
+      this.webResearch = this.readWebResearchSetting();
       this.externalSyncPending = false;
-      return this.publicResult(result);
+      return this.publicResult({
+        ...result,
+        changed: result.changed || !workshopWebResearchSettingsEqual(previousWebResearch, this.webResearch)
+      });
     });
   }
 
@@ -204,6 +238,17 @@ export class WorkshopConversationSettingsService {
 
   getWriterProfile(): WorkshopWriterProfile {
     return this.writerProfileService.getProfile();
+  }
+
+  getWebResearch(): WorkshopWebResearchSettings {
+    return { ...this.webResearch };
+  }
+
+  private readWebResearchSetting(): WorkshopWebResearchSettings {
+    return coerceWorkshopWebResearchSettings(this.settings.get<unknown>(
+      WORKSHOP_WEB_RESEARCH_SETTING.section,
+      WORKSHOP_WEB_RESEARCH_SETTING.key
+    ));
   }
 
   private replacementTargets(): Array<{

--- a/packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopConversationSettingsService.ts
@@ -15,6 +15,7 @@ import {
   WorkshopWriterProfile,
   WorkshopWebResearchSettings,
   coerceWorkshopWebResearchSettings,
+  isValidWorkshopWebResearchSettings,
   workshopWebResearchSettingsEqual
 } from '@messages';
 
@@ -56,6 +57,7 @@ export class WorkshopConversationSettingsService {
   private externalSyncPending = false;
   private pendingBehaviorPersistence?: PendingPersistence<WorkshopConversationBehavior>;
   private pendingProfilePersistence?: PendingPersistence<WorkshopWriterProfile>;
+  private pendingWebResearchPersistence?: PendingPersistence<WorkshopWebResearchSettings>;
   private webResearch: WorkshopWebResearchSettings;
 
   constructor(
@@ -68,11 +70,11 @@ export class WorkshopConversationSettingsService {
     this.webResearch = this.readWebResearchSetting();
   }
 
-  /** Apply and persist the modal's complete Behavior + About You submission. */
+  /** Apply and persist the modal's complete Behavior, About You, and Advanced submission. */
   applyFromWebview(
     rawBehavior: unknown,
     rawWriterProfile: unknown,
-    rawWebResearch?: unknown
+    rawWebResearch: unknown = undefined
   ): Promise<WorkshopConversationSettingsUpdate> {
     const nextBehavior = coerceWorkshopConversationBehavior(rawBehavior);
     const nextProfile = coerceWorkshopWriterProfile(rawWriterProfile);
@@ -83,6 +85,7 @@ export class WorkshopConversationSettingsService {
       this.externalSyncPending = false;
       const pendingBehavior = this.pendingBehaviorPersistence;
       const pendingProfile = this.pendingProfilePersistence;
+      const pendingWebResearch = this.pendingWebResearchPersistence;
       const persistBehavior = result.behaviorChanged
         || (pendingBehavior !== undefined
           && workshopConversationBehaviorsEqual(pendingBehavior.appliedValue, nextBehavior));
@@ -90,10 +93,13 @@ export class WorkshopConversationSettingsService {
         || (pendingProfile !== undefined
           && workshopWriterProfilesEqual(pendingProfile.appliedValue, nextProfile));
       const webResearchChanged = !workshopWebResearchSettingsEqual(this.webResearch, nextWebResearch);
-      const persistWebResearch = webResearchChanged;
+      const persistWebResearch = webResearchChanged
+        || (pendingWebResearch !== undefined
+          && workshopWebResearchSettingsEqual(pendingWebResearch.appliedValue, nextWebResearch));
       this.webResearch = nextWebResearch;
+      const changed = result.changed || webResearchChanged;
       if (!persistBehavior && !persistProfile && !persistWebResearch) {
-        return this.publicResult({ ...result, changed: result.changed || webResearchChanged });
+        return this.publicResult({ ...result, changed });
       }
 
       const persistenceErrors: WorkshopConversationSettingsPersistenceErrors = {};
@@ -132,14 +138,20 @@ export class WorkshopConversationSettingsService {
             WORKSHOP_WEB_RESEARCH_SETTING.key,
             nextWebResearch
           );
+          this.pendingWebResearchPersistence = undefined;
         } catch (error) {
           persistenceErrors.webResearch = this.errorMessage(error);
+          this.pendingWebResearchPersistence = {
+            storedValue: this.readWebResearchSetting(),
+            appliedValue: { ...nextWebResearch }
+          };
         }
       }
+      if (changed) this.logSettingsApplied(nextBehavior, nextProfile, nextWebResearch);
       return this.publicResult(
         Object.keys(persistenceErrors).length > 0
-          ? { ...result, changed: result.changed || webResearchChanged, persistenceErrors }
-          : { ...result, changed: result.changed || webResearchChanged }
+          ? { ...result, changed, persistenceErrors }
+          : { ...result, changed }
       );
     });
   }
@@ -163,11 +175,17 @@ export class WorkshopConversationSettingsService {
         this.resolveBehaviorSetting(this.readBehaviorSetting()),
         this.resolveProfileSetting(this.writerProfileService.readSetting())
       );
-      this.webResearch = this.readWebResearchSetting();
+      this.webResearch = this.resolveWebResearchSetting(this.readWebResearchSetting());
       this.externalSyncPending = false;
+      const changed = result.changed || !workshopWebResearchSettingsEqual(previousWebResearch, this.webResearch);
+      if (changed) this.logSettingsApplied(
+        this.session.getConversationBehavior(),
+        this.writerProfileService.getProfile(),
+        this.webResearch
+      );
       return this.publicResult({
         ...result,
-        changed: result.changed || !workshopWebResearchSettingsEqual(previousWebResearch, this.webResearch)
+        changed
       });
     });
   }
@@ -186,11 +204,17 @@ export class WorkshopConversationSettingsService {
         this.resolveBehaviorSetting(this.readBehaviorSetting()),
         this.resolveProfileSetting(this.writerProfileService.readSetting())
       );
-      this.webResearch = this.readWebResearchSetting();
+      this.webResearch = this.resolveWebResearchSetting(this.readWebResearchSetting());
       this.externalSyncPending = false;
+      const changed = result.changed || !workshopWebResearchSettingsEqual(previousWebResearch, this.webResearch);
+      if (changed) this.logSettingsApplied(
+        this.session.getConversationBehavior(),
+        this.writerProfileService.getProfile(),
+        this.webResearch
+      );
       return this.publicResult({
         ...result,
-        changed: result.changed || !workshopWebResearchSettingsEqual(previousWebResearch, this.webResearch)
+        changed
       });
     });
   }
@@ -227,12 +251,6 @@ export class WorkshopConversationSettingsService {
 
     this.session.setConversationBehavior(nextBehavior);
     this.writerProfileService.commit(nextProfile);
-    this.outputChannel.appendLine(
-      `[WorkshopConversationSettingsService] Conversation settings committed ` +
-      `(mode=${nextBehavior.interactionMode}, expression=${nextBehavior.expressionLevel}, ` +
-      `relationalDepth=${nextBehavior.relationalDepth}, carry=${nextBehavior.carryCuesThroughSession}, ` +
-      `profileEnabled=${nextProfile.enabled}, profileHasContent=${nextProfile.preferredAddress.length > 0 || nextProfile.bio.length > 0})`
-    );
     return { changed: true, deferred: false, behaviorChanged, profileChanged };
   }
 
@@ -245,10 +263,16 @@ export class WorkshopConversationSettingsService {
   }
 
   private readWebResearchSetting(): WorkshopWebResearchSettings {
-    return coerceWorkshopWebResearchSettings(this.settings.get<unknown>(
+    const raw = this.settings.get<unknown>(
       WORKSHOP_WEB_RESEARCH_SETTING.section,
       WORKSHOP_WEB_RESEARCH_SETTING.key
-    ));
+    );
+    if (raw !== undefined && !isValidWorkshopWebResearchSettings(raw)) {
+      this.outputChannel.appendLine(
+        '[WorkshopConversationSettingsService] Rejected invalid web research setting; using the disabled default'
+      );
+    }
+    return coerceWorkshopWebResearchSettings(raw);
   }
 
   private replacementTargets(): Array<{
@@ -311,6 +335,32 @@ export class WorkshopConversationSettingsService {
     }
     this.pendingProfilePersistence = undefined;
     return storedValue;
+  }
+
+  private resolveWebResearchSetting(
+    storedValue: WorkshopWebResearchSettings
+  ): WorkshopWebResearchSettings {
+    const pending = this.pendingWebResearchPersistence;
+    if (!pending) return storedValue;
+    if (workshopWebResearchSettingsEqual(storedValue, pending.storedValue)) {
+      return { ...pending.appliedValue };
+    }
+    this.pendingWebResearchPersistence = undefined;
+    return storedValue;
+  }
+
+  private logSettingsApplied(
+    behavior: WorkshopConversationBehavior,
+    profile: WorkshopWriterProfile,
+    webResearch: WorkshopWebResearchSettings
+  ): void {
+    this.outputChannel.appendLine(
+      `[WorkshopConversationSettingsService] Conversation settings applied ` +
+      `(mode=${behavior.interactionMode}, expression=${behavior.expressionLevel}, ` +
+      `relationalDepth=${behavior.relationalDepth}, carry=${behavior.carryCuesThroughSession}, ` +
+      `profileEnabled=${profile.enabled}, profileHasContent=${profile.preferredAddress.length > 0 || profile.bio.length > 0}, ` +
+      `webResearchEnabled=${webResearch.enabled})`
+    );
   }
 
   private assertBetweenRuns(): void {

--- a/packages/core/src/application/services/workshop/WorkshopRunCompletion.ts
+++ b/packages/core/src/application/services/workshop/WorkshopRunCompletion.ts
@@ -128,7 +128,8 @@ export function completeWorkshopRun(input: WorkshopRunCompletionInput): Workshop
     result.usage,
     truncated,
     result.conversationId,
-    actionableFindings.findings
+    actionableFindings.findings,
+    result.citations
   );
   if (!turn) {
     if (input.createsRetainedConversation && result.conversationId) {

--- a/packages/core/src/application/services/workshop/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionService.ts
@@ -39,6 +39,7 @@ import {
   WorkshopTurnKind
 } from '@messages';
 import { isContextPathGroup, TokenUsage } from '@shared/types';
+import type { UrlCitation } from '@shared/types/citations';
 import {
   WorkshopCapabilityArtifactDetails,
   WorkshopAnalysisInputProvenance,
@@ -1479,7 +1480,8 @@ export class WorkshopSessionService {
     usage?: TokenUsage,
     truncated?: boolean,
     conversationId?: string,
-    actionableFindings: WorkshopActionableFinding[] = []
+    actionableFindings: WorkshopActionableFinding[] = [],
+    citations?: UrlCitation[]
   ): WorkshopTurn | undefined {
     if (this.activeRun?.requestId !== requestId) {
       return undefined;
@@ -1513,6 +1515,7 @@ export class WorkshopSessionService {
       content,
       timestamp: this.now(),
       usage: usage ? { ...usage } : undefined,
+      citations: citations?.map((citation) => ({ ...citation })),
       truncated: truncated || undefined,
       excerptVersion: active.excerptVersion,
       actionableFindings: (isHost || isGuest) && actionableFindings.length > 0
@@ -2286,6 +2289,7 @@ function cloneTurn(turn: WorkshopTurn): WorkshopTurn {
         }
       : undefined,
     usage: turn.usage ? { ...turn.usage } : undefined,
+    citations: turn.citations?.map((citation) => ({ ...citation })),
     capability: turn.capability ? cloneCapabilityDetails(turn.capability) : undefined,
     analysisInputs: turn.analysisInputs
       ? cloneAnalysisInputs(turn.analysisInputs)

--- a/packages/core/src/application/services/workshop/WorkshopSessionService.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionService.ts
@@ -39,7 +39,7 @@ import {
   WorkshopTurnKind
 } from '@messages';
 import { isContextPathGroup, TokenUsage } from '@shared/types';
-import type { UrlCitation } from '@shared/types/citations';
+import type { UrlCitation } from '@messages';
 import {
   WorkshopCapabilityArtifactDetails,
   WorkshopAnalysisInputProvenance,

--- a/packages/core/src/application/services/workshop/WorkshopSessionStateV1Shape.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionStateV1Shape.ts
@@ -315,6 +315,7 @@ function assertTurn(value: unknown, path: string): void {
       'actionableFindings',
       'messageAttachments',
       'usage',
+      'citations',
       'truncated',
       'behavior',
       'behaviorTransition'
@@ -383,6 +384,9 @@ function assertTurn(value: unknown, path: string): void {
   if (turn.usage !== undefined) {
     assertTokenUsage(turn.usage, `${path}.usage`);
   }
+  if (turn.citations !== undefined) {
+    arrayOf(turn.citations, `${path}.citations`, assertCitation);
+  }
   optionalBooleanAt(turn.truncated, `${path}.truncated`);
   if (turn.behavior !== undefined) {
     assertBehavior(turn.behavior, `${path}.behavior`);
@@ -390,6 +394,14 @@ function assertTurn(value: unknown, path: string): void {
   if (turn.behaviorTransition !== undefined) {
     assertBehaviorTransition(turn.behaviorTransition, `${path}.behaviorTransition`);
   }
+}
+
+function assertCitation(value: unknown, path: string): void {
+  const citation = exactObject(value, path, ['url'], ['title', 'startIndex', 'endIndex']);
+  stringAt(citation.url, `${path}.url`);
+  optionalStringAt(citation.title, `${path}.title`);
+  optionalNumberAt(citation.startIndex, `${path}.startIndex`);
+  optionalNumberAt(citation.endIndex, `${path}.endIndex`);
 }
 
 function assertAnalysisInputProvenance(value: unknown, path: string): void {

--- a/packages/core/src/application/services/workshop/WorkshopSessionStateV1Shape.ts
+++ b/packages/core/src/application/services/workshop/WorkshopSessionStateV1Shape.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  isHttpUrl,
   isWorkshopInteractionMode,
   isWorkshopPersonaExpressionLevel,
   isWorkshopRelationalDepth,
@@ -399,6 +400,9 @@ function assertTurn(value: unknown, path: string): void {
 function assertCitation(value: unknown, path: string): void {
   const citation = exactObject(value, path, ['url'], ['title', 'startIndex', 'endIndex']);
   stringAt(citation.url, `${path}.url`);
+  if (!isHttpUrl(citation.url)) {
+    throw new Error(`${path}.url must be a complete HTTP(S) URL`);
+  }
   optionalStringAt(citation.title, `${path}.title`);
   optionalNumberAt(citation.startIndex, `${path}.startIndex`);
   optionalNumberAt(citation.endIndex, `${path}.endIndex`);

--- a/packages/core/src/domain/models/AnalysisResult.ts
+++ b/packages/core/src/domain/models/AnalysisResult.ts
@@ -3,6 +3,8 @@
  * Represents the output from prose analysis tools ( Prose Excerpt Assistant )
  */
 
+import type { UrlCitation } from '@shared/types/citations';
+
 export interface AnalysisResult {
   readonly toolName: string;
   readonly content: string;
@@ -14,6 +16,7 @@ export interface AnalysisResult {
   readonly finishReason?: string;
   /** Retained conversation id, when the run asked for continuation (Workshop multi-turn). */
   readonly conversationId?: string;
+  readonly citations?: UrlCitation[];
 }
 
 export interface MetricsResult {
@@ -23,7 +26,7 @@ export interface MetricsResult {
 }
 
 export class AnalysisResultFactory {
-  static createAnalysisResult(toolName: string, content: string, usedGuides?: string[], usage?: TokenUsage, finishReason?: string, conversationId?: string, requestedResources?: string[]): AnalysisResult {
+  static createAnalysisResult(toolName: string, content: string, usedGuides?: string[], usage?: TokenUsage, finishReason?: string, conversationId?: string, requestedResources?: string[], citations?: UrlCitation[]): AnalysisResult {
     return {
       toolName,
       content,
@@ -32,7 +35,8 @@ export class AnalysisResultFactory {
       requestedResources,
       usage,
       finishReason,
-      conversationId
+      conversationId,
+      citations
     };
   }
 

--- a/packages/core/src/domain/models/AnalysisResult.ts
+++ b/packages/core/src/domain/models/AnalysisResult.ts
@@ -3,7 +3,7 @@
  * Represents the output from prose analysis tools ( Prose Excerpt Assistant )
  */
 
-import type { UrlCitation } from '@shared/types/citations';
+import type { UrlCitation } from '@messages';
 
 export interface AnalysisResult {
   readonly toolName: string;
@@ -25,18 +25,26 @@ export interface MetricsResult {
   readonly timestamp: Date;
 }
 
+export interface AnalysisResultOptions {
+  usedGuides?: string[];
+  requestedResources?: string[];
+  usage?: TokenUsage;
+  finishReason?: string;
+  conversationId?: string;
+  citations?: UrlCitation[];
+}
+
 export class AnalysisResultFactory {
-  static createAnalysisResult(toolName: string, content: string, usedGuides?: string[], usage?: TokenUsage, finishReason?: string, conversationId?: string, requestedResources?: string[], citations?: UrlCitation[]): AnalysisResult {
+  static createAnalysisResult(
+    toolName: string,
+    content: string,
+    options: AnalysisResultOptions = {}
+  ): AnalysisResult {
     return {
       toolName,
       content,
       timestamp: new Date(),
-      usedGuides,
-      requestedResources,
-      usage,
-      finishReason,
-      conversationId,
-      citations
+      ...options
     };
   }
 

--- a/packages/core/src/infrastructure/api/orchestration/AgentRunContracts.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AgentRunContracts.ts
@@ -1,5 +1,6 @@
 import { ContextPathGroup, TokenUsage } from '@shared/types';
 import type { OpenRouterWebSearchTool } from '@providers/OpenRouterClient';
+import type { UrlCitation } from '@shared/types/citations';
 
 /** The caller-selected capability surface available to one agent turn. */
 export type CapabilityCatalog =
@@ -154,4 +155,5 @@ export interface ExecutionResult {
   readonly finishReason?: string;
   readonly cancelled?: boolean;
   readonly conversationId?: string;
+  readonly citations?: UrlCitation[];
 }

--- a/packages/core/src/infrastructure/api/orchestration/AgentRunContracts.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AgentRunContracts.ts
@@ -1,6 +1,6 @@
 import { ContextPathGroup, TokenUsage } from '@shared/types';
 import type { OpenRouterWebSearchTool } from '@providers/OpenRouterClient';
-import type { UrlCitation } from '@shared/types/citations';
+import type { UrlCitation } from '@messages';
 
 /** The caller-selected capability surface available to one agent turn. */
 export type CapabilityCatalog =

--- a/packages/core/src/infrastructure/api/orchestration/AgentRunContracts.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AgentRunContracts.ts
@@ -1,4 +1,5 @@
 import { ContextPathGroup, TokenUsage } from '@shared/types';
+import type { OpenRouterWebSearchTool } from '@providers/OpenRouterClient';
 
 /** The caller-selected capability surface available to one agent turn. */
 export type CapabilityCatalog =
@@ -121,6 +122,8 @@ export interface AgentRunOptions {
   readonly signal?: AbortSignal;
   readonly timeoutMs?: number;
   readonly onToken?: StreamingTokenCallback;
+  /** Provider server tools explicitly granted to this one inference request. */
+  readonly tools?: OpenRouterWebSearchTool[];
 }
 
 export interface InitialRunRequest {

--- a/packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts
@@ -803,13 +803,16 @@ export class AgentRunEngine {
     additions: UrlCitation[] | undefined
   ): UrlCitation[] | undefined {
     if (!additions?.length) return current;
+    // `merged` is a shallow copy, so its entries are still shared with `current`
+    // and `additions`. Copy on insert and replace on backfill so a caller holding
+    // either array never observes a citation changing under it.
     const merged = [...(current ?? [])];
     for (const citation of additions) {
-      const existing = merged.find((entry) => entry.url === citation.url);
-      if (!existing) {
+      const index = merged.findIndex((entry) => entry.url === citation.url);
+      if (index < 0) {
         merged.push({ ...citation });
-      } else if (!existing.title?.trim() && citation.title?.trim()) {
-        existing.title = citation.title;
+      } else if (!merged[index].title?.trim() && citation.title?.trim()) {
+        merged[index] = { ...merged[index], title: citation.title };
       }
     }
     return merged.length > 0 ? merged : undefined;

--- a/packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts
@@ -1,5 +1,6 @@
 import { LogSink, SettingsStore } from '@/platform';
 import { OpenRouterClient, OpenRouterMessage } from '@providers/OpenRouterClient';
+import type { UrlCitation } from '@shared/types/citations';
 import {
   ConversationArchiveEntryV1,
   ConversationExportTarget,
@@ -49,6 +50,7 @@ interface TurnResult {
   readonly exactRequest?: unknown;
   /** A protocol-shaped response failed structural or allow-list validation. */
   readonly invalidRequest?: AgentCapabilityRejection;
+  readonly citations?: UrlCitation[];
 }
 
 const TOOL_CALL_OPEN = '<prose-minion-tool-call';
@@ -457,6 +459,7 @@ export class AgentRunEngine {
         artifacts,
         usage: totalUsage,
         finishReason: last.finishReason,
+        citations: last.citations,
         cancelled
       };
     } finally {
@@ -612,6 +615,7 @@ export class AgentRunEngine {
           finishReason: response.finishReason,
           usage: response.usage,
           observation: response.observation,
+          citations: response.citations,
           cancelled: this.isAborted(options.signal),
           exactRequest: inspection?.kind === 'request' ? inspection.request : undefined,
           invalidRequest: inspection?.kind === 'invalid' ? inspection : undefined
@@ -628,6 +632,7 @@ export class AgentRunEngine {
     let usage: TokenUsage | undefined;
     let finishReason: string | undefined;
     let observation: InferenceRequestObservation | undefined;
+    let citations: UrlCitation[] | undefined;
     let cancelled = false;
     let classification: 'undecided' | 'text' | 'candidate' = 'undecided';
     const visibilityGuard = capability ? new ToolCallStreamVisibilityGuard() : undefined;
@@ -643,6 +648,7 @@ export class AgentRunEngine {
           usage = chunk.usage ?? usage;
           finishReason = chunk.finishReason ?? finishReason;
           observation = chunk.observation ?? observation;
+          citations = chunk.citations ?? citations;
           continue;
         }
         if (!chunk.token) continue;
@@ -707,6 +713,7 @@ export class AgentRunEngine {
       finishReason,
       usage,
       observation,
+      citations,
       cancelled,
       exactRequest,
       invalidRequest

--- a/packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts
@@ -1,6 +1,6 @@
 import { LogSink, SettingsStore } from '@/platform';
 import { OpenRouterClient, OpenRouterMessage } from '@providers/OpenRouterClient';
-import type { UrlCitation } from '@shared/types/citations';
+import type { UrlCitation } from '@messages';
 import {
   ConversationArchiveEntryV1,
   ConversationExportTarget,
@@ -274,6 +274,7 @@ export class AgentRunEngine {
     const requestedResources: string[] = [];
     const collectedSources: ContextSourceEntry[] = [];
     let totalUsage: TokenUsage | undefined;
+    let runCitations: UrlCitation[] | undefined;
     let latestObservation: InferenceRequestObservation | undefined;
     let peakPromptTokens = 0;
     let correctionTurns = 0;
@@ -296,6 +297,7 @@ export class AgentRunEngine {
       const next = await this.executeTurn(currentMessages(), runOptions, capability);
       recordObservation(next.observation);
       totalUsage = this.addUsage(totalUsage, next.usage);
+      runCitations = this.mergeUrlCitations(runCitations, next.citations);
       return next;
     };
 
@@ -328,6 +330,7 @@ export class AgentRunEngine {
       let last = await this.executeTurn(currentMessages(), runOptions, capability);
       recordObservation(last.observation);
       totalUsage = this.addUsage(totalUsage, last.usage);
+      runCitations = this.mergeUrlCitations(runCitations, last.citations);
       last = await recoverInvalidRequest(last);
       let rounds = 0;
 
@@ -459,7 +462,7 @@ export class AgentRunEngine {
         artifacts,
         usage: totalUsage,
         finishReason: last.finishReason,
-        citations: last.citations,
+        citations: runCitations,
         cancelled
       };
     } finally {
@@ -793,6 +796,23 @@ export class AgentRunEngine {
         ? (total.costUsd ?? 0) + (usage.costUsd ?? 0)
         : undefined
     };
+  }
+
+  private mergeUrlCitations(
+    current: UrlCitation[] | undefined,
+    additions: UrlCitation[] | undefined
+  ): UrlCitation[] | undefined {
+    if (!additions?.length) return current;
+    const merged = [...(current ?? [])];
+    for (const citation of additions) {
+      const existing = merged.find((entry) => entry.url === citation.url);
+      if (!existing) {
+        merged.push({ ...citation });
+      } else if (!existing.title?.trim() && citation.title?.trim()) {
+        existing.title = citation.title;
+      }
+    }
+    return merged.length > 0 ? merged : undefined;
   }
 
   private emitUsage(usage?: TokenUsage): void {

--- a/packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts
+++ b/packages/core/src/infrastructure/api/orchestration/AgentRunEngine.ts
@@ -601,7 +601,8 @@ export class AgentRunEngine {
         const response = await this.openRouterClient.createChatCompletion(messages, {
           temperature: options.temperature,
           maxTokens: options.maxTokens,
-          signal: options.signal
+          signal: options.signal,
+          tools: options.tools
         });
         this.emitUsage(response.usage);
         const inspection = capability?.inspectRequest(response.content);
@@ -635,7 +636,8 @@ export class AgentRunEngine {
       for await (const chunk of this.openRouterClient.createStreamingChatCompletion(messages, {
         temperature: options.temperature,
         maxTokens: options.maxTokens,
-        signal: options.signal
+        signal: options.signal,
+        tools: options.tools
       })) {
         if (chunk.done) {
           usage = chunk.usage ?? usage;

--- a/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
+++ b/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
@@ -25,6 +25,15 @@ export interface OpenRouterRequest {
   usage?: { include: boolean };
 }
 
+export interface OpenRouterWebSearchTool {
+  type: 'openrouter:web_search';
+  parameters: {
+    engine: 'auto';
+    max_uses: number;
+    max_total_results: number;
+  };
+}
+
 export interface OpenRouterResponse {
   id: string;
   model: string;
@@ -95,6 +104,7 @@ export class OpenRouterClient {
       temperature?: number;
       maxTokens?: number;
       signal?: AbortSignal;
+      tools?: OpenRouterWebSearchTool[];
     }
   ): Promise<{
     content: string;
@@ -120,7 +130,8 @@ export class OpenRouterClient {
         messages,
         temperature: options?.temperature ?? 0.7,
         max_tokens: requestedMaxOutputTokens,
-        usage: { include: true }
+        usage: { include: true },
+        ...(options?.tools ? { tools: options.tools } : {})
       })
     });
 
@@ -162,6 +173,7 @@ export class OpenRouterClient {
       temperature?: number;
       maxTokens?: number;
       signal?: AbortSignal;
+      tools?: OpenRouterWebSearchTool[];
     }
   ): AsyncGenerator<{
     token: string;
@@ -188,7 +200,8 @@ export class OpenRouterClient {
         stream: true,
         temperature: options?.temperature ?? 0.7,
         max_tokens: requestedMaxOutputTokens,
-        stream_options: { include_usage: true }
+        stream_options: { include_usage: true },
+        ...(options?.tools ? { tools: options.tools } : {})
       })
     });
 

--- a/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
+++ b/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
@@ -281,7 +281,7 @@ export class OpenRouterClient {
             const chunkCitations = this.toUrlCitations(
               delta?.annotations ?? parsed.choices?.[0]?.message?.annotations
             );
-            if (chunkCitations?.length) citations = chunkCitations;
+            if (chunkCitations?.length) citations = this.mergeUrlCitations(citations, chunkCitations);
 
             if (token) {
               yield { token, done: false };
@@ -341,7 +341,20 @@ export class OpenRouterClient {
         endIndex: typeof value.end_index === 'number' ? value.end_index : undefined
       }];
     });
-    return citations.length > 0 ? citations : undefined;
+    return this.mergeUrlCitations(undefined, citations);
+  }
+
+  private mergeUrlCitations(
+    current: UrlCitation[] | undefined,
+    additions: UrlCitation[]
+  ): UrlCitation[] | undefined {
+    const merged = [...(current ?? [])];
+    for (const citation of additions) {
+      if (!merged.some((existing) => existing.url === citation.url)) {
+        merged.push(citation);
+      }
+    }
+    return merged.length > 0 ? merged : undefined;
   }
 
   private toObservation(

--- a/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
+++ b/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
@@ -372,13 +372,16 @@ export class OpenRouterClient {
     current: UrlCitation[] | undefined,
     additions: UrlCitation[]
   ): UrlCitation[] | undefined {
+    // `merged` is a shallow copy, so its entries are still shared with `current`
+    // and `additions`. Copy on insert and replace on backfill so a caller holding
+    // either array never observes a citation changing under it.
     const merged = [...(current ?? [])];
     for (const citation of additions) {
-      const existing = merged.find((entry) => entry.url === citation.url);
-      if (!existing) {
-        merged.push(citation);
-      } else if (!existing.title?.trim() && citation.title?.trim()) {
-        existing.title = citation.title;
+      const index = merged.findIndex((entry) => entry.url === citation.url);
+      if (index < 0) {
+        merged.push({ ...citation });
+      } else if (!merged[index].title?.trim() && citation.title?.trim()) {
+        merged[index] = { ...merged[index], title: citation.title };
       }
     }
     return merged.length > 0 ? merged : undefined;

--- a/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
+++ b/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
@@ -9,6 +9,7 @@ import {
   InferenceRequestObservation,
   TokenUsage
 } from '@shared/types';
+import type { UrlCitation } from '@shared/types/citations';
 
 const FALLBACK_OUTPUT_RESERVE_TOKENS = 10000;
 
@@ -41,6 +42,7 @@ export interface OpenRouterResponse {
     message: {
       role: string;
       content: string;
+      annotations?: unknown;
     };
     finish_reason: string;
   }>;
@@ -112,6 +114,7 @@ export class OpenRouterClient {
     usage?: TokenUsage;
     observation?: InferenceRequestObservation;
     id?: string;
+    citations?: UrlCitation[];
   }> {
     const requestedModel = this.model;
     const requestedMaxOutputTokens = options?.maxTokens ?? FALLBACK_OUTPUT_RESERVE_TOKENS;
@@ -152,6 +155,7 @@ export class OpenRouterClient {
       content: data.choices[0].message.content,
       finishReason: data.choices[0]?.finish_reason,
       usage,
+      citations: this.toUrlCitations(data.choices[0].message.annotations),
       observation: usage ? this.toObservation(
         data.model || requestedModel,
         requestedMaxOutputTokens,
@@ -181,6 +185,7 @@ export class OpenRouterClient {
     usage?: TokenUsage;
     finishReason?: string;
     observation?: InferenceRequestObservation;
+    citations?: UrlCitation[];
   }> {
     const requestedModel = this.model;
     const requestedMaxOutputTokens = options?.maxTokens ?? FALLBACK_OUTPUT_RESERVE_TOKENS;
@@ -224,6 +229,7 @@ export class OpenRouterClient {
       let responseModel = requestedModel;
       let routerMetadata: unknown;
       let terminalEmitted = false;
+      let citations: UrlCitation[] | undefined;
       const terminal = () => ({
         token: '',
         done: true,
@@ -235,7 +241,8 @@ export class OpenRouterClient {
           usage,
           finishReason,
           routerMetadata
-        ) : undefined
+        ) : undefined,
+        citations
       });
       while (true) {
         const { done, value } = await reader.read();
@@ -271,6 +278,10 @@ export class OpenRouterClient {
             if (chunkUsage) usage = chunkUsage;
             if (typeof parsed.model === 'string' && parsed.model) responseModel = parsed.model;
             if (parsed.openrouter_metadata !== undefined) routerMetadata = parsed.openrouter_metadata;
+            const chunkCitations = this.toUrlCitations(
+              delta?.annotations ?? parsed.choices?.[0]?.message?.annotations
+            );
+            if (chunkCitations?.length) citations = chunkCitations;
 
             if (token) {
               yield { token, done: false };
@@ -313,6 +324,24 @@ export class OpenRouterClient {
       totalTokens: Number(raw.total_tokens) || 0,
       costUsd: Number.isFinite(costNum) ? costNum : undefined
     };
+  }
+
+  private toUrlCitations(raw: unknown): UrlCitation[] | undefined {
+    if (!Array.isArray(raw)) return undefined;
+    const citations = raw.flatMap((annotation): UrlCitation[] => {
+      if (typeof annotation !== 'object' || annotation === null) return [];
+      const source = (annotation as { url_citation?: unknown }).url_citation;
+      if (typeof source !== 'object' || source === null) return [];
+      const value = source as Record<string, unknown>;
+      if (typeof value.url !== 'string' || !/^https?:\/\//.test(value.url)) return [];
+      return [{
+        url: value.url,
+        title: typeof value.title === 'string' ? value.title : undefined,
+        startIndex: typeof value.start_index === 'number' ? value.start_index : undefined,
+        endIndex: typeof value.end_index === 'number' ? value.end_index : undefined
+      }];
+    });
+    return citations.length > 0 ? citations : undefined;
   }
 
   private toObservation(

--- a/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
+++ b/packages/core/src/infrastructure/api/providers/OpenRouterClient.ts
@@ -9,7 +9,7 @@ import {
   InferenceRequestObservation,
   TokenUsage
 } from '@shared/types';
-import type { UrlCitation } from '@shared/types/citations';
+import { isHttpUrl, type UrlCitation } from '@messages';
 
 const FALLBACK_OUTPUT_RESERVE_TOKENS = 10000;
 
@@ -328,12 +328,24 @@ export class OpenRouterClient {
 
   private toUrlCitations(raw: unknown): UrlCitation[] | undefined {
     if (!Array.isArray(raw)) return undefined;
+    const rejectedTypes: string[] = [];
     const citations = raw.flatMap((annotation): UrlCitation[] => {
-      if (typeof annotation !== 'object' || annotation === null) return [];
+      if (typeof annotation !== 'object' || annotation === null) {
+        rejectedTypes.push(typeof annotation);
+        return [];
+      }
       const source = (annotation as { url_citation?: unknown }).url_citation;
-      if (typeof source !== 'object' || source === null) return [];
+      if (typeof source !== 'object' || source === null) {
+        rejectedTypes.push(typeof (annotation as { type?: unknown }).type === 'string'
+          ? (annotation as { type: string }).type
+          : 'unknown');
+        return [];
+      }
       const value = source as Record<string, unknown>;
-      if (typeof value.url !== 'string' || !/^https?:\/\//.test(value.url)) return [];
+      if (!isHttpUrl(value.url)) {
+        rejectedTypes.push('url_citation:invalid-url');
+        return [];
+      }
       return [{
         url: value.url,
         title: typeof value.title === 'string' ? value.title : undefined,
@@ -341,7 +353,19 @@ export class OpenRouterClient {
         endIndex: typeof value.end_index === 'number' ? value.end_index : undefined
       }];
     });
-    return this.mergeUrlCitations(undefined, citations);
+    if (rejectedTypes.length > 0) {
+      this.outputChannel?.appendLine(
+        `[OpenRouterClient] Dropped ${rejectedTypes.length}/${raw.length} unparseable citation annotation(s): ` +
+        [...new Set(rejectedTypes)].join(', ')
+      );
+    }
+    const merged = this.mergeUrlCitations(undefined, citations);
+    if (merged?.length) {
+      this.outputChannel?.appendLine(
+        `[OpenRouterClient] Parsed ${merged.length} web citation(s) from ${raw.length} annotation(s)`
+      );
+    }
+    return merged;
   }
 
   private mergeUrlCitations(
@@ -350,8 +374,11 @@ export class OpenRouterClient {
   ): UrlCitation[] | undefined {
     const merged = [...(current ?? [])];
     for (const citation of additions) {
-      if (!merged.some((existing) => existing.url === citation.url)) {
+      const existing = merged.find((entry) => entry.url === citation.url);
+      if (!existing) {
         merged.push(citation);
+      } else if (!existing.title?.trim() && citation.title?.trim()) {
+        existing.title = citation.title;
       }
     }
     return merged.length > 0 ? merged : undefined;

--- a/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
+++ b/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
@@ -358,11 +358,13 @@ export class AssistantToolService {
       return AnalysisResultFactory.createAnalysisResult(
         'dialogue_analysis',
         executionResult.content,
-        executionResult.usedGuides,
-        executionResult.usage,
-        executionResult.finishReason,
-        executionResult.conversationId,
-        executionResult.requestedResources
+        {
+          usedGuides: executionResult.usedGuides,
+          usage: executionResult.usage,
+          finishReason: executionResult.finishReason,
+          conversationId: executionResult.conversationId,
+          requestedResources: executionResult.requestedResources
+        }
       );
     } catch (error) {
       // AbortError is now caught in the orchestrator, so this is only for other errors
@@ -430,11 +432,13 @@ export class AssistantToolService {
       return AnalysisResultFactory.createAnalysisResult(
         `writing_tools_${focus}`,
         executionResult.content,
-        executionResult.usedGuides,
-        executionResult.usage,
-        executionResult.finishReason,
-        executionResult.conversationId,
-        executionResult.requestedResources
+        {
+          usedGuides: executionResult.usedGuides,
+          usage: executionResult.usage,
+          finishReason: executionResult.finishReason,
+          conversationId: executionResult.conversationId,
+          requestedResources: executionResult.requestedResources
+        }
       );
     } catch (error) {
       // AbortError is now caught in the orchestrator, so this is only for other errors
@@ -499,11 +503,13 @@ export class AssistantToolService {
       return AnalysisResultFactory.createAnalysisResult(
         'prose_analysis',
         executionResult.content,
-        executionResult.usedGuides,
-        executionResult.usage,
-        executionResult.finishReason,
-        executionResult.conversationId,
-        executionResult.requestedResources
+        {
+          usedGuides: executionResult.usedGuides,
+          usage: executionResult.usage,
+          finishReason: executionResult.finishReason,
+          conversationId: executionResult.conversationId,
+          requestedResources: executionResult.requestedResources
+        }
       );
     } catch (error) {
       // AbortError is now caught in the orchestrator, so this is only for other errors
@@ -567,12 +573,13 @@ export class AssistantToolService {
     return AnalysisResultFactory.createAnalysisResult(
       'workshop_persona',
       executionResult.content,
-      executionResult.usedGuides,
-      executionResult.usage,
-      executionResult.finishReason,
-      executionResult.conversationId,
-      undefined,
-      executionResult.citations
+      {
+        usedGuides: executionResult.usedGuides,
+        usage: executionResult.usage,
+        finishReason: executionResult.finishReason,
+        conversationId: executionResult.conversationId,
+        citations: executionResult.citations
+      }
     );
   }
 
@@ -629,12 +636,13 @@ export class AssistantToolService {
     return AnalysisResultFactory.createAnalysisResult(
       'workshop_guest',
       executionResult.content,
-      executionResult.usedGuides,
-      executionResult.usage,
-      executionResult.finishReason,
-      executionResult.conversationId,
-      undefined,
-      executionResult.citations
+      {
+        usedGuides: executionResult.usedGuides,
+        usage: executionResult.usage,
+        finishReason: executionResult.finishReason,
+        conversationId: executionResult.conversationId,
+        citations: executionResult.citations
+      }
     );
   }
 
@@ -685,20 +693,25 @@ export class AssistantToolService {
     return AnalysisResultFactory.createAnalysisResult(
       'workshop_follow_up',
       executionResult.content,
-      executionResult.usedGuides,
-      executionResult.usage,
-      executionResult.finishReason,
-      executionResult.conversationId,
-      undefined,
-      executionResult.citations
+      {
+        usedGuides: executionResult.usedGuides,
+        usage: executionResult.usage,
+        finishReason: executionResult.finishReason,
+        conversationId: executionResult.conversationId,
+        citations: executionResult.citations
+      }
     );
   }
 
   private workshopWebSearchTools(enabled: boolean | undefined): OpenRouterWebSearchTool[] | undefined {
-    return enabled ? [{
+    if (!enabled) return undefined;
+    this.outputChannel?.appendLine(
+      '[AssistantToolService] Attaching OpenRouter web research tool (max uses=2, max results=10)'
+    );
+    return [{
       type: 'openrouter:web_search',
       parameters: { engine: 'auto', max_uses: 2, max_total_results: 10 }
-    }] : undefined;
+    }];
   }
 
   /**

--- a/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
+++ b/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
@@ -570,7 +570,9 @@ export class AssistantToolService {
       executionResult.usedGuides,
       executionResult.usage,
       executionResult.finishReason,
-      executionResult.conversationId
+      executionResult.conversationId,
+      undefined,
+      executionResult.citations
     );
   }
 
@@ -630,7 +632,9 @@ export class AssistantToolService {
       executionResult.usedGuides,
       executionResult.usage,
       executionResult.finishReason,
-      executionResult.conversationId
+      executionResult.conversationId,
+      undefined,
+      executionResult.citations
     );
   }
 
@@ -684,7 +688,9 @@ export class AssistantToolService {
       executionResult.usedGuides,
       executionResult.usage,
       executionResult.finishReason,
-      executionResult.conversationId
+      executionResult.conversationId,
+      undefined,
+      executionResult.citations
     );
   }
 

--- a/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
+++ b/packages/core/src/infrastructure/api/services/analysis/AssistantToolService.ts
@@ -65,6 +65,7 @@ import {
 } from '@/utils/workshopPromptFrames';
 import { PROMPT_BUDGETS } from '@shared/constants/promptBudgets';
 import { buildWorkshopWriterProfileFrame } from '@/utils/workshopWriterProfile';
+import type { OpenRouterWebSearchTool } from '@providers/OpenRouterClient';
 
 /**
  * Options for streaming analysis operations
@@ -89,6 +90,8 @@ export interface AnalysisStreamingOptions {
    * Meaningful only with retainConversation; sidebar runs never set it.
    */
   workshopSource?: WorkshopConfiguredResourceRef;
+  /** Opt-in, per-turn server-side web search for Workshop persona conversations. */
+  webResearch?: boolean;
 }
 
 export interface WorkshopHostStreamingOptions extends AnalysisStreamingOptions {
@@ -556,7 +559,8 @@ export class AssistantToolService {
         temperature: options.temperature,
         maxTokens: options.maxTokens,
         signal: streamingOptions?.signal,
-        onToken: streamingOptions?.onToken
+        onToken: streamingOptions?.onToken,
+        tools: this.workshopWebSearchTools(streamingOptions?.webResearch)
       }
     });
 
@@ -615,7 +619,8 @@ export class AssistantToolService {
         temperature: options.temperature,
         maxTokens: options.maxTokens,
         signal: streamingOptions.signal,
-        onToken: streamingOptions.onToken
+        onToken: streamingOptions.onToken,
+        tools: this.workshopWebSearchTools(streamingOptions.webResearch)
       }
     });
 
@@ -668,7 +673,8 @@ export class AssistantToolService {
         temperature: options.temperature,
         maxTokens: options.maxTokens,
         signal: streamingOptions?.signal,
-        onToken: streamingOptions?.onToken
+        onToken: streamingOptions?.onToken,
+        tools: this.workshopWebSearchTools(streamingOptions?.webResearch)
       }
     });
 
@@ -680,6 +686,13 @@ export class AssistantToolService {
       executionResult.finishReason,
       executionResult.conversationId
     );
+  }
+
+  private workshopWebSearchTools(enabled: boolean | undefined): OpenRouterWebSearchTool[] | undefined {
+    return enabled ? [{
+      type: 'openrouter:web_search',
+      parameters: { engine: 'auto', max_uses: 2, max_total_results: 10 }
+    }] : undefined;
   }
 
   /**

--- a/packages/core/src/infrastructure/api/services/dictionary/DictionaryService.ts
+++ b/packages/core/src/infrastructure/api/services/dictionary/DictionaryService.ts
@@ -177,9 +177,7 @@ export class DictionaryService {
       return AnalysisResultFactory.createAnalysisResult(
         'dictionary_lookup',
         executionResult.content,
-        undefined,
-        executionResult.usage,
-        executionResult.finishReason
+        { usage: executionResult.usage, finishReason: executionResult.finishReason }
       );
     } catch (error) {
       return AnalysisResultFactory.createAnalysisResult(
@@ -230,9 +228,7 @@ export class DictionaryService {
       return AnalysisResultFactory.createAnalysisResult(
         'dictionary_lookup',
         executionResult.content,
-        undefined,
-        executionResult.usage,
-        executionResult.finishReason
+        { usage: executionResult.usage, finishReason: executionResult.finishReason }
       );
     } catch (error) {
       // AbortError is now caught in the orchestrator, so this is only for other errors

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -1398,6 +1398,7 @@ export const WorkshopApp: React.FC = () => {
         open={behaviorModalOpen}
         behavior={workshop.conversationBehavior}
         writerProfile={workshop.writerProfile}
+        webResearch={workshop.webResearch}
         isRunning={roomMutationLocked}
         errorMessage={workshop.errorMessage}
         onApply={workshop.setConversationSettings}

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx
@@ -99,7 +99,7 @@ interface WorkshopConversationBehaviorModalProps {
   onClose: () => void;
 }
 
-type SettingsTab = 'behavior' | 'profile';
+type SettingsTab = 'behavior' | 'profile' | 'advanced';
 
 export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBehaviorModalProps> = ({
   open,
@@ -119,6 +119,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
   const [confirmClear, setConfirmClear] = React.useState(false);
   const behaviorTabRef = React.useRef<HTMLButtonElement>(null);
   const profileTabRef = React.useRef<HTMLButtonElement>(null);
+  const advancedTabRef = React.useRef<HTMLButtonElement>(null);
 
   React.useEffect(() => {
     if (open) {
@@ -163,15 +164,17 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
     setConfirmClear(false);
   };
   const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    const next = event.key === 'ArrowLeft' || event.key === 'Home'
-      ? 'behavior'
-      : event.key === 'ArrowRight' || event.key === 'End'
-        ? 'profile'
-        : undefined;
+    const tabs: SettingsTab[] = ['behavior', 'profile', 'advanced'];
+    const currentIndex = tabs.indexOf(tab);
+    const next = event.key === 'Home' ? 'behavior'
+      : event.key === 'End' ? 'advanced'
+        : event.key === 'ArrowLeft' ? tabs[(currentIndex + tabs.length - 1) % tabs.length]
+          : event.key === 'ArrowRight' ? tabs[(currentIndex + 1) % tabs.length]
+            : undefined;
     if (!next) return;
     event.preventDefault();
     switchTab(next);
-    (next === 'behavior' ? behaviorTabRef : profileTabRef).current?.focus();
+    (next === 'behavior' ? behaviorTabRef : next === 'profile' ? profileTabRef : advancedTabRef).current?.focus();
   };
   const apply = () => {
     if (applyLocked) return;
@@ -238,6 +241,19 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
           onKeyDown={handleTabKeyDown}
         >
           About you
+        </button>
+        <button
+          ref={advancedTabRef}
+          type="button"
+          role="tab"
+          id="pm-ws-advanced-tab"
+          aria-selected={tab === 'advanced'}
+          aria-controls="pm-ws-advanced-panel"
+          tabIndex={tab === 'advanced' ? 0 : -1}
+          onClick={() => switchTab('advanced')}
+          onKeyDown={handleTabKeyDown}
+        >
+          Advanced
         </button>
       </div>
 
@@ -325,27 +341,13 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
             />
           </div>
         </div>
-      ) : (
+      ) : tab === 'profile' ? (
         <div
           className="pm-ws-behavior-body pm-ws-profile-body"
           role="tabpanel"
           id="pm-ws-profile-panel"
           aria-labelledby="pm-ws-profile-tab"
         >
-          <div className="pm-ws-profile-share-row">
-            <div>
-              <div className="pm-ws-behavior-row-name">Allow live web research</div>
-              <div className="pm-ws-behavior-row-desc">
-                Persona conversations may search current web information when it helps. This can add latency and provider charges; Grok can also search X when supported.
-              </div>
-            </div>
-            <Switch
-              checked={webResearchDraft.enabled}
-              disabled={editingLocked}
-              label="Allow live web research"
-              onClick={() => setWebResearchDraft((current) => ({ enabled: !current.enabled }))}
-            />
-          </div>
           <div className="pm-ws-profile-share-row">
             <div>
               <div className="pm-ws-behavior-row-name">
@@ -451,6 +453,28 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
                 Clear profile…
               </button>
             )}
+          </div>
+        </div>
+      ) : (
+        <div
+          className="pm-ws-behavior-body pm-ws-profile-body"
+          role="tabpanel"
+          id="pm-ws-advanced-panel"
+          aria-labelledby="pm-ws-advanced-tab"
+        >
+          <div className="pm-ws-profile-share-row">
+            <div>
+              <div className="pm-ws-behavior-row-name">Allow live web research</div>
+              <div className="pm-ws-behavior-row-desc">
+                Persona conversations may search current web information when it helps. This can add latency and provider charges; Grok can also search X when supported.
+              </div>
+            </div>
+            <Switch
+              checked={webResearchDraft.enabled}
+              disabled={editingLocked}
+              label="Allow live web research"
+              onClick={() => setWebResearchDraft((current) => ({ enabled: !current.enabled }))}
+            />
           </div>
         </div>
       )}

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx
@@ -130,7 +130,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
       setPending(null);
       setConfirmClear(false);
     }
-  }, [open, webResearch]);
+  }, [open]);
 
   React.useEffect(() => {
     if (!pending) return;
@@ -466,7 +466,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
             <div>
               <div className="pm-ws-behavior-row-name">Allow live web research</div>
               <div className="pm-ws-behavior-row-desc">
-                Persona conversations may search current web information when it helps. This can add latency and provider charges; Grok can also search X when supported.
+                Persona conversations may search current web information when it helps. Search queries can draw on the active room, excerpt, attachments, and shared profile, then run through OpenRouter and its search providers. Enable it only for material you are comfortable sharing. It can add latency and provider charges; Grok can also search X when supported.
               </div>
             </div>
             <Switch
@@ -496,7 +496,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
           </span>
         ) : (
           <span className="pm-ws-behavior-foot-note">
-            Applies the Behavior, About You, and Research drafts together. Research takes effect on your next message.
+            Applies the Behavior, About You, and Advanced drafts together. Live web research takes effect on your next message.
           </span>
         )}
         <button className="pm-ws-action-btn" type="button" onClick={onClose}>Cancel</button>

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopConversationBehaviorModal.tsx
@@ -13,7 +13,9 @@ import {
   WorkshopInteractionMode,
   WorkshopPersonaExpressionLevel,
   WorkshopRelationalDepth,
-  WorkshopWriterProfile
+  WorkshopWriterProfile,
+  WorkshopWebResearchSettings,
+  workshopWebResearchSettingsEqual
 } from '@messages';
 
 const MODE_CARDS: ReadonlyArray<{
@@ -83,15 +85,17 @@ interface PendingApply {
   submittedProfile: WorkshopWriterProfile;
   baselineBehavior: WorkshopConversationBehavior;
   baselineProfile: WorkshopWriterProfile;
+  submittedWebResearch: WorkshopWebResearchSettings;
 }
 
 interface WorkshopConversationBehaviorModalProps {
   open: boolean;
   behavior: WorkshopConversationBehavior;
   writerProfile: WorkshopWriterProfile;
+  webResearch: WorkshopWebResearchSettings;
   isRunning: boolean;
   errorMessage?: string;
-  onApply: (behavior: WorkshopConversationBehavior, writerProfile: WorkshopWriterProfile) => void;
+  onApply: (behavior: WorkshopConversationBehavior, writerProfile: WorkshopWriterProfile, webResearch: WorkshopWebResearchSettings) => void;
   onClose: () => void;
 }
 
@@ -101,6 +105,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
   open,
   behavior,
   writerProfile,
+  webResearch,
   isRunning,
   errorMessage,
   onApply,
@@ -109,6 +114,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
   const [tab, setTab] = React.useState<SettingsTab>('behavior');
   const [behaviorDraft, setBehaviorDraft] = React.useState({ ...behavior });
   const [profileDraft, setProfileDraft] = React.useState({ ...writerProfile });
+  const [webResearchDraft, setWebResearchDraft] = React.useState({ ...webResearch });
   const [pending, setPending] = React.useState<PendingApply | null>(null);
   const [confirmClear, setConfirmClear] = React.useState(false);
   const behaviorTabRef = React.useRef<HTMLButtonElement>(null);
@@ -119,10 +125,11 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
       setTab('behavior');
       setBehaviorDraft({ ...behavior });
       setProfileDraft({ ...writerProfile });
+      setWebResearchDraft({ ...webResearch });
       setPending(null);
       setConfirmClear(false);
     }
-  }, [open]);
+  }, [open, webResearch]);
 
   React.useEffect(() => {
     if (!pending) return;
@@ -133,6 +140,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
     if (
       workshopConversationBehaviorsEqual(behavior, pending.submittedBehavior)
       && workshopWriterProfilesEqual(writerProfile, pending.submittedProfile)
+      && workshopWebResearchSettingsEqual(webResearch, pending.submittedWebResearch)
     ) {
       setPending(null);
       onClose();
@@ -142,7 +150,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
     ) {
       setPending(null);
     }
-  }, [behavior, onClose, open, pending, writerProfile]);
+  }, [behavior, onClose, open, pending, webResearch, writerProfile]);
 
   React.useEffect(() => {
     if (pending && errorMessage) setPending(null);
@@ -173,12 +181,13 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
       preferredAddress: profileDraft.preferredAddress.trim(),
       bio: profileDraft.bio.trim()
     };
-    onApply(submittedBehavior, submittedProfile);
+    onApply(submittedBehavior, submittedProfile, webResearchDraft);
     setPending({
       submittedBehavior,
       submittedProfile,
       baselineBehavior: { ...behavior },
-      baselineProfile: { ...writerProfile }
+      baselineProfile: { ...writerProfile },
+      submittedWebResearch: { ...webResearchDraft }
     });
   };
   const clearProfile = () => {
@@ -198,7 +207,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
         <div>
           <div className="pm-ws-eyebrow">Workshop · Room settings</div>
           <h2 id="pm-ws-settings-title">Conversation settings</h2>
-          <p>Choose how Workshop personas respond and what you explicitly share with them. Tools are unchanged.</p>
+          <p>Choose how Workshop personas respond, what you explicitly share, and whether they may research the live web. Tools are unchanged.</p>
         </div>
         <WorkshopModalShell.CloseButton />
       </div>
@@ -325,6 +334,20 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
         >
           <div className="pm-ws-profile-share-row">
             <div>
+              <div className="pm-ws-behavior-row-name">Allow live web research</div>
+              <div className="pm-ws-behavior-row-desc">
+                Persona conversations may search current web information when it helps. This can add latency and provider charges; Grok can also search X when supported.
+              </div>
+            </div>
+            <Switch
+              checked={webResearchDraft.enabled}
+              disabled={editingLocked}
+              label="Allow live web research"
+              onClick={() => setWebResearchDraft((current) => ({ enabled: !current.enabled }))}
+            />
+          </div>
+          <div className="pm-ws-profile-share-row">
+            <div>
               <div className="pm-ws-behavior-row-name">
                 Share this profile with Workshop personas
               </div>
@@ -449,7 +472,7 @@ export const WorkshopConversationBehaviorModal: React.FC<WorkshopConversationBeh
           </span>
         ) : (
           <span className="pm-ws-behavior-foot-note">
-            Applies the Behavior and About You drafts together to the active room.
+            Applies the Behavior, About You, and Research drafts together. Research takes effect on your next message.
           </span>
         )}
         <button className="pm-ws-action-btn" type="button" onClick={onClose}>Cancel</button>

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopNoticeModal.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopNoticeModal.tsx
@@ -66,10 +66,13 @@ const PAGES: readonly NoticePage[] = [
     body: (
       <>
         Find the diamond-shaped <b>Conversation Controller</b> chip in the composer controls.
-        It sets how host and guest personas respond: <b>mode</b> (how opinionated),{' '}
+        The <b>Behavior</b> tab sets how host and guest personas respond: <b>mode</b> (how opinionated),{' '}
         <b>expression</b> (how much they say), and <b>depth</b> (how far they read into things).
-        These settings are per-session, stay visible, and never change silently. They do not
-        apply to direct instrument threads.
+        Those choices are per-session, stay visible, and never change silently. The <b>About
+        you</b> tab lets you choose how the room addresses you and share a short writer profile
+        as background context. In <b>Advanced</b>, you can let personas research the live web
+        when it helps; their replies show each source as a clickable citation pill. These
+        conversation controls do not apply to direct instrument threads.
       </>
     )
   },

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopNoticeModal.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopNoticeModal.tsx
@@ -71,7 +71,9 @@ const PAGES: readonly NoticePage[] = [
         Those choices are per-session, stay visible, and never change silently. The <b>About
         you</b> tab lets you choose how the room addresses you and share a short writer profile
         as background context. In <b>Advanced</b>, you can let personas research the live web
-        when it helps; their replies show each source as a clickable citation pill. These
+        when it helps; search queries may use active room context and run through OpenRouter and
+        search providers, so enable it only for material you are comfortable sharing. Their
+        replies show each source as a clickable citation pill. These
         conversation controls do not apply to direct instrument threads.
       </>
     )

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
@@ -47,6 +47,11 @@ interface ParsedVariations {
 const VARIATION_HEADING = /^#{2,4}\s*Variation\s+(\d+)(?:\s*[-:]\s*(.+))?\s*$/gim;
 export const WORKSHOP_TURN_ID_ATTRIBUTE = 'data-turn-id';
 
+const citationLabel = (citation: { url: string; title?: string }): string => {
+  const title = citation.title?.trim();
+  return title && !/^\d+$/.test(title) ? title : new URL(citation.url).hostname;
+};
+
 export const parseVariations = (content: string): ParsedVariations | null => {
   const matches = [...content.matchAll(VARIATION_HEADING)];
   if (matches.length < 2) {
@@ -421,7 +426,7 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
               {citations.map((citation, index) => (
                 <li key={citation.url}>
                   <a href={citation.url} target="_blank" rel="noreferrer">
-                    [{index + 1}] {citation.title || new URL(citation.url).hostname}
+                    [{index + 1}] {citationLabel(citation)}
                   </a>
                 </li>
               ))}

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
@@ -422,15 +422,23 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
         {citations.length > 0 && (
           <div className="pm-ws-turn-citations" aria-label="Web sources">
             <div className="pm-ws-eyebrow">Web sources</div>
-            <ol>
+            <div className="pm-ws-turn-citation-pills">
               {citations.map((citation, index) => (
-                <li key={citation.url}>
-                  <a href={citation.url} target="_blank" rel="noreferrer">
-                    [{index + 1}] {citationLabel(citation)}
-                  </a>
-                </li>
+                <a
+                  key={citation.url}
+                  className="pm-ws-ctx-pill pm-ws-turn-citation-pill"
+                  href={citation.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={citation.url}
+                  aria-label={`Open web source ${index + 1}: ${citationLabel(citation)}`}
+                >
+                  <Icon name="link" size={12} />
+                  <span className="pm-ws-turn-citation-number">{index + 1}</span>
+                  <span className="pm-ws-ctx-pill-label">{citationLabel(citation)}</span>
+                </a>
               ))}
-            </ol>
+            </div>
           </div>
         )}
         <div className="pm-ws-turn-actions">

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
@@ -165,6 +165,14 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
         : turn.toolLabel ?? 'Analysis'} · ${turn.capability.requestSummary} · requested by ${workshopPersonaLabel(turn.capability.requestedByPersonaId)}`
     : undefined;
   const capabilityMetadata = capabilityMetadataRows(turn);
+  const citations = React.useMemo(() => {
+    const seen = new Set<string>();
+    return (turn.citations ?? []).filter((citation) => {
+      if (seen.has(citation.url)) return false;
+      seen.add(citation.url);
+      return true;
+    });
+  }, [turn.citations]);
   const turnIdentity = { [WORKSHOP_TURN_ID_ATTRIBUTE]: turn.id };
   const isPrivateInstrumentTurn =
     turn.artifact === 'direct_tool_message' || turn.artifact === 'direct_tool_response';
@@ -404,6 +412,20 @@ export const WorkshopTurnBubble: React.FC<WorkshopTurnBubbleProps> = React.memo(
                 </div>
               );
             })}
+          </div>
+        )}
+        {citations.length > 0 && (
+          <div className="pm-ws-turn-citations" aria-label="Web sources">
+            <div className="pm-ws-eyebrow">Web sources</div>
+            <ol>
+              {citations.map((citation, index) => (
+                <li key={citation.url}>
+                  <a href={citation.url} target="_blank" rel="noreferrer">
+                    [{index + 1}] {citation.title || new URL(citation.url).hostname}
+                  </a>
+                </li>
+              ))}
+            </ol>
           </div>
         )}
         <div className="pm-ws-turn-actions">

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopTurnBubble.tsx
@@ -49,7 +49,12 @@ export const WORKSHOP_TURN_ID_ATTRIBUTE = 'data-turn-id';
 
 const citationLabel = (citation: { url: string; title?: string }): string => {
   const title = citation.title?.trim();
-  return title && !/^\d+$/.test(title) ? title : new URL(citation.url).hostname;
+  if (title && !/^\d+$/.test(title)) return title;
+  try {
+    return new URL(citation.url).hostname || citation.url;
+  } catch {
+    return citation.url;
+  }
 };
 
 export const parseVariations = (content: string): ParsedVariations | null => {

--- a/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/useWorkshop.ts
@@ -29,6 +29,7 @@ import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 import {
   DEFAULT_WORKSHOP_CONVERSATION_BEHAVIOR,
   DEFAULT_WORKSHOP_WRITER_PROFILE,
+  DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS,
   ErrorMessage,
   StatusMessage,
   StreamChunkMessage,
@@ -64,8 +65,10 @@ import {
   WorkshopTurn,
   WorkshopTurnMessage,
   WorkshopWriterProfile,
+  WorkshopWebResearchSettings,
   coerceWorkshopConversationBehavior,
-  coerceWorkshopWriterProfile
+  coerceWorkshopWriterProfile,
+  coerceWorkshopWebResearchSettings
 } from '@messages';
 import { LabeledContextBudgetSnapshot } from '@messages';
 
@@ -147,6 +150,7 @@ export interface WorkshopState {
   conversationBehavior: WorkshopConversationBehavior;
   /** Global profile mirrored beside, never inside, the host session snapshot. */
   writerProfile: WorkshopWriterProfile;
+  webResearch: WorkshopWebResearchSettings;
   /** Public metadata for the latest retained sidecar per tool. */
   toolSidecars: WorkshopToolSidecarSnapshot[];
   /** Explicitly invited persona guests, including disposed history markers. */
@@ -227,7 +231,8 @@ export interface WorkshopActions {
   setChatTarget: (target: WorkshopChatTarget) => void;
   setConversationSettings: (
     behavior: WorkshopConversationBehavior,
-    writerProfile: WorkshopWriterProfile
+    writerProfile: WorkshopWriterProfile,
+    webResearch?: WorkshopWebResearchSettings
   ) => void;
   todoAction: (action: WorkshopTodoAction) => void;
   cancelRun: () => void;
@@ -302,6 +307,8 @@ export const useWorkshop = (): UseWorkshopReturn => {
     React.useState<WorkshopConversationBehavior>({ ...DEFAULT_WORKSHOP_CONVERSATION_BEHAVIOR });
   const [writerProfile, setWriterProfile] =
     React.useState<WorkshopWriterProfile>({ ...DEFAULT_WORKSHOP_WRITER_PROFILE });
+  const [webResearch, setWebResearch] =
+    React.useState<WorkshopWebResearchSettings>({ ...DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS });
   const [toolSidecars, setToolSidecars] = React.useState<WorkshopToolSidecarSnapshot[]>([]);
   const [personaGuests, setPersonaGuests] = React.useState<WorkshopPersonaGuestSnapshot[]>([]);
   const [contextBudget, setContextBudget] = React.useState<LabeledContextBudgetSnapshot | undefined>();
@@ -553,11 +560,12 @@ export const useWorkshop = (): UseWorkshopReturn => {
   // the system-message replacement batch the old mode stays visible. The new
   // object arrives with the next WORKSHOP_SESSION_STATE.
   const setConversationSettings = React.useCallback(
-    (behavior: WorkshopConversationBehavior, profile: WorkshopWriterProfile) => {
+    (behavior: WorkshopConversationBehavior, profile: WorkshopWriterProfile, research = DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS) => {
       setErrorMessage('');
       post(MessageType.WORKSHOP_SET_CONVERSATION_SETTINGS, {
         behavior,
-        writerProfile: profile
+        writerProfile: profile,
+        webResearch: research
       });
     },
     [post]
@@ -700,6 +708,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
       // degrades to the COMPLETE approved default, never a per-field blend.
       setConversationBehaviorState(coerceWorkshopConversationBehavior(session.conversationBehavior));
       setWriterProfile(coerceWorkshopWriterProfile(message.payload.writerProfile));
+      setWebResearch(coerceWorkshopWebResearchSettings(message.payload.webResearch));
       setToolSidecars(session.participants.toolSidecars);
       setPersonaGuests(session.participants.personaGuests);
       setContextBudget(session.contextBudget);
@@ -920,6 +929,7 @@ export const useWorkshop = (): UseWorkshopReturn => {
     chatTarget,
     conversationBehavior,
     writerProfile,
+    webResearch,
     toolSidecars,
     personaGuests,
     contextBudget,

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -5034,18 +5034,29 @@
 
 [data-pm-surface="workshop"] .pm-ws-turn-citations {
   margin: 14px 0 2px;
-  padding: 10px 12px;
-  border: 1px solid var(--pm-border);
-  border-radius: var(--pm-r-button);
-  background: var(--pm-panel);
 }
-[data-pm-surface="workshop"] .pm-ws-turn-citations ol {
+[data-pm-surface="workshop"] .pm-ws-turn-citation-pills {
+  display: grid;
+  justify-items: start;
+  gap: 6px;
   margin: 6px 0 0;
-  padding-left: 20px;
 }
-[data-pm-surface="workshop"] .pm-ws-turn-citations li + li {
-  margin-top: 6px;
+[data-pm-surface="workshop"] .pm-ws-turn-citation-pill {
+  cursor: pointer;
+  text-decoration: none;
 }
-[data-pm-surface="workshop"] .pm-ws-turn-citations a {
-  color: var(--pm-accent);
+[data-pm-surface="workshop"] .pm-ws-turn-citation-number {
+  font-family: var(--pm-mono);
+  font-size: 10px;
+  color: var(--pm-muted);
+  white-space: nowrap;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-citation-pill:hover {
+  color: var(--pm-text);
+  border-color: var(--pm-accent-hi);
+  background: color-mix(in srgb, var(--pm-accent-hi) 10%, var(--pm-surface-2));
+}
+[data-pm-surface="workshop"] .pm-ws-turn-citation-pill:focus-visible {
+  outline: 2px solid var(--pm-accent-hi);
+  outline-offset: 2px;
 }

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -5031,3 +5031,18 @@
 [data-pm-surface="workshop"] .pm-ws-notice-dismiss:hover {
   filter: brightness(1.07);
 }
+
+[data-pm-surface="workshop"] .pm-ws-turn-citations {
+  margin: 14px 0 2px;
+  padding: 10px 12px;
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-r-button);
+  background: var(--pm-panel);
+}
+[data-pm-surface="workshop"] .pm-ws-turn-citations ol {
+  margin: 6px 0 0;
+  padding-left: 20px;
+}
+[data-pm-surface="workshop"] .pm-ws-turn-citations a {
+  color: var(--pm-accent);
+}

--- a/packages/core/src/presentation/webview/workshop.css
+++ b/packages/core/src/presentation/webview/workshop.css
@@ -5043,6 +5043,9 @@
   margin: 6px 0 0;
   padding-left: 20px;
 }
+[data-pm-surface="workshop"] .pm-ws-turn-citations li + li {
+  margin-top: 6px;
+}
 [data-pm-surface="workshop"] .pm-ws-turn-citations a {
   color: var(--pm-accent);
 }

--- a/packages/core/src/shared/types/citations.ts
+++ b/packages/core/src/shared/types/citations.ts
@@ -1,7 +1,0 @@
-/** Provider-normalized, display-safe source citation for a grounded response. */
-export interface UrlCitation {
-  url: string;
-  title?: string;
-  startIndex?: number;
-  endIndex?: number;
-}

--- a/packages/core/src/shared/types/citations.ts
+++ b/packages/core/src/shared/types/citations.ts
@@ -1,0 +1,7 @@
+/** Provider-normalized, display-safe source citation for a grounded response. */
+export interface UrlCitation {
+  url: string;
+  title?: string;
+  startIndex?: number;
+  endIndex?: number;
+}

--- a/packages/core/src/shared/types/index.ts
+++ b/packages/core/src/shared/types/index.ts
@@ -3,3 +3,4 @@ export * from './context';
 export * from './sources';
 export * from './surface';
 export * from './workshopCapabilities';
+export * from './citations';

--- a/packages/core/src/shared/types/index.ts
+++ b/packages/core/src/shared/types/index.ts
@@ -3,4 +3,3 @@ export * from './context';
 export * from './sources';
 export * from './surface';
 export * from './workshopCapabilities';
-export * from './citations';

--- a/packages/core/src/shared/types/messages/citations.ts
+++ b/packages/core/src/shared/types/messages/citations.ts
@@ -1,0 +1,18 @@
+/** Provider-normalized, display-safe source citation for a grounded response. */
+export interface UrlCitation {
+  url: string;
+  title?: string;
+  startIndex?: number;
+  endIndex?: number;
+}
+
+/** Accept only complete HTTP(S) URLs before a citation reaches persistence or UI. */
+export const isHttpUrl = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false;
+  try {
+    const url = new URL(value);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.hostname.length > 0;
+  } catch {
+    return false;
+  }
+};

--- a/packages/core/src/shared/types/messages/index.ts
+++ b/packages/core/src/shared/types/messages/index.ts
@@ -10,6 +10,7 @@ export * from './base';
 export * from './error';
 export * from './status';
 export * from './tokenUsage';
+export * from './citations';
 export * from './inferenceContext';
 export * from './accountBalance';
 export * from './warnings';

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -15,6 +15,7 @@
 import { MessageEnvelope, MessageType } from './base';
 import { WritingToolsFocus } from './analysis';
 import { TokenUsage } from '../index';
+import { UrlCitation } from '../citations';
 import type { LabeledContextBudgetSnapshot } from './inferenceContext';
 import type {
   WorkshopAnalysisInputProvenance,
@@ -761,6 +762,8 @@ export interface WorkshopTurn {
   timestamp: number;
   /** Usage for assistant turns, when the provider reported it. */
   usage?: TokenUsage;
+  /** Provider-returned web sources; model-authored [n] markers remain ordinary text. */
+  citations?: UrlCitation[];
   /** True when the response stopped at the max-token limit (assistant turns). */
   truncated?: boolean;
   /**

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -15,7 +15,7 @@
 import { MessageEnvelope, MessageType } from './base';
 import { WritingToolsFocus } from './analysis';
 import { TokenUsage } from '../index';
-import { UrlCitation } from '../citations';
+import { UrlCitation } from './citations';
 import type { LabeledContextBudgetSnapshot } from './inferenceContext';
 import type {
   WorkshopAnalysisInputProvenance,
@@ -171,13 +171,20 @@ export const WORKSHOP_WEB_RESEARCH_SETTING = Object.freeze({
   key: 'workshop.webResearch'
 });
 
-export function coerceWorkshopWebResearchSettings(raw: unknown): WorkshopWebResearchSettings {
+/** Fail closed: only the complete one-field setting shape may enable research. */
+export function isValidWorkshopWebResearchSettings(raw: unknown): raw is WorkshopWebResearchSettings {
   return typeof raw === 'object' && raw !== null && !Array.isArray(raw)
-    && Object.keys(raw).length === 1 && typeof (raw as { enabled?: unknown }).enabled === 'boolean'
+    && Object.keys(raw).length === 1 && typeof (raw as { enabled?: unknown }).enabled === 'boolean';
+}
+
+/** Coerce untrusted settings to the default-off live-web capability. */
+export function coerceWorkshopWebResearchSettings(raw: unknown): WorkshopWebResearchSettings {
+  return isValidWorkshopWebResearchSettings(raw)
     ? { enabled: (raw as { enabled: boolean }).enabled }
     : { ...DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS };
 }
 
+/** Compare the value rather than allocation identity for settings synchronization. */
 export function workshopWebResearchSettingsEqual(
   left: WorkshopWebResearchSettings,
   right: WorkshopWebResearchSettings

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -157,6 +157,33 @@ export const WORKSHOP_WRITER_PROFILE_SETTING = Object.freeze({
   key: 'workshop.writerProfile'
 });
 
+/** Optional live-web capability for persona conversations; deterministic tools stay offline. */
+export interface WorkshopWebResearchSettings {
+  enabled: boolean;
+}
+
+export const DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS: Readonly<WorkshopWebResearchSettings> =
+  Object.freeze({ enabled: false });
+
+export const WORKSHOP_WEB_RESEARCH_SETTING = Object.freeze({
+  section: 'proseMinion',
+  key: 'workshop.webResearch'
+});
+
+export function coerceWorkshopWebResearchSettings(raw: unknown): WorkshopWebResearchSettings {
+  return typeof raw === 'object' && raw !== null && !Array.isArray(raw)
+    && Object.keys(raw).length === 1 && typeof (raw as { enabled?: unknown }).enabled === 'boolean'
+    ? { enabled: (raw as { enabled: boolean }).enabled }
+    : { ...DEFAULT_WORKSHOP_WEB_RESEARCH_SETTINGS };
+}
+
+export function workshopWebResearchSettingsEqual(
+  left: WorkshopWebResearchSettings,
+  right: WorkshopWebResearchSettings
+): boolean {
+  return left.enabled === right.enabled;
+}
+
 export function isValidWorkshopWriterProfile(raw: unknown): raw is WorkshopWriterProfile {
   if (typeof raw !== 'object' || raw === null) {
     return false;
@@ -908,6 +935,7 @@ export interface WorkshopSetChatTargetMessage extends MessageEnvelope<WorkshopCh
 export interface WorkshopSetConversationSettingsPayload {
   behavior: WorkshopConversationBehavior;
   writerProfile: WorkshopWriterProfile;
+  webResearch: WorkshopWebResearchSettings;
 }
 
 export interface WorkshopSetConversationSettingsMessage
@@ -1286,6 +1314,8 @@ export interface WorkshopSessionStatePayload {
   session: WorkshopSessionSnapshot;
   /** Global writer setting, deliberately outside the serializable session aggregate. */
   writerProfile: WorkshopWriterProfile;
+  /** Global web-research preference; deliberately outside the session aggregate. */
+  webResearch: WorkshopWebResearchSettings;
   persistence: {
     available: boolean;
     unavailableReason?: 'no-workspace' | 'multi-root';


### PR DESCRIPTION
## Summary

Adds a default-off Room Settings toggle for live web research in Workshop persona conversations.

- Persists the application-scoped `proseMinion.workshop.webResearch` setting and syncs VS Code Settings edits.
- Threads the enabled state through Workshop host and guest turns to OpenRouter as the bounded `openrouter:web_search` server tool (`auto`, two uses, ten total results).
- Keeps deterministic Workshop tools and unrelated Prose Minion surfaces offline.

## Validation

- `npm run lint` (0 errors; existing warnings)
- `npm run typecheck`
- Targeted Workshop/OpenRouter Jest tests (60 tests)
- `npm run build` (includes bundle verification)