### PR TITLE
refactor(workshop): centralize shared route and contract ownership

### DIFF
--- a/.todo/epics/epic-workshop-architecture-refactor-2026-08-03/sprints/02-shared-route-contract-ownership.md
+++ b/.todo/epics/epic-workshop-architecture-refactor-2026-08-03/sprints/02-shared-route-contract-ownership.md
@@ -1,10 +1,12 @@
 # Sprint 02: Shared Route and Contract Ownership
 
-**Status:** Planned
+**Status:** Complete — implemented and verified on 2026-08-03
 
 **Branch:** `sprint/workshop-architecture-refactor-02-shared-ownership` -> `epic/workshop-architecture-refactor`
 
 **Depends on:** Sprint 01
+
+**Evidence:** [Sprint 02 architecture change runway](../../../../docs/architecture/2026-08-03-workshop-sprint-02-shared-ownership-runway.md)
 
 ## Goal
 
@@ -14,20 +16,133 @@ while keeping all feature semantics in named slices.
 ## Scope
 
 - Add `WorkshopStandingDirectiveHandler` as the sole generic apply/remove route
-  owner.
+  owner, at `application/handlers/domain/workshop/`.
+- Add `useWorkshopStandingDirectives` as the generic presentation owner of
+  `remove`, action-result correlation, and the removal acknowledgement copy.
+  Ownership applies to both sides of the message boundary (D1, mirroring
+  Sprint 01's widget-host decision).
 - Split feature preparation/rendering operations from the generic serialized
-  standing transaction kernel.
-- Add exact request/action correlation and feature identity.
-- Rename Gesture-specific generate/menu/commit messages honestly.
-- Retain exact discriminated unions at shared family boundaries.
-- Add a compile-time/minimal fixture proving a second standing family does not
-  edit Lexical files or collide in `MessageRouter`.
+  standing transaction kernel via `WorkshopStandingDirectiveOperations`, a closed
+  registry mirroring `WorkshopWidgetConfigOperations`. The kernel's serialization,
+  between-run guard, frame-replacement ordering, and atomic commit do not change.
+- Lift the generic standing directive service out of the Lexical arm of
+  `WorkshopWidgetRuntime` (`MessageHandler.ts`, `WorkshopHandler.ts`).
+- Add exact request/action correlation and feature identity: an echoed request
+  token on commit, apply-standing, and remove-standing plus their shared action
+  result (D3), consumed with an exact `token && widgetId` filter.
+- Rename Gesture-specific generate/progress/menu messages honestly.
+  `WORKSHOP_COMMIT_WIDGET` stays generic — it is the family's one-shot rail, not
+  a Gesture concept (D2) — and is made exact by payload union instead.
+- Retain exact discriminated unions at shared family boundaries. Convert the four
+  payloads that pair `widgetId: WorkshopWidgetId` with a Gesture-only body into
+  exact contracts keyed by the literal Gesture widget identity; keep generic
+  family rails union-ready.
+- Make every generic-to-feature dispatch in the standing slice a `never`-guarded
+  switch or registry object, including the frames renderer and the standing rail
+  formatter.
+- Install fitness witnesses #2 (generic standing ownership), #4 (closed dispatch),
+  #8 (exact draft/message pairings), and #9 (action-result correlation).
+- Add a minimal test-only second standing family fixture (a `proseController`
+  operations stub driven apply -> commit -> remove) proving the family adds no
+  Lexical edits and no `MessageRouter` collision. This is a refactor fixture, not
+  shipped feature behavior; the feature freeze still applies.
+
+## Accepted decisions
+
+| ID | Decision | Accepted |
+|---|---|---|
+| **D1** | The presentation side of the standing boundary gets a generic owner in this sprint: `useWorkshopStandingDirectives`. | Yes — Okey, 2026-08-03 |
+| **D2** | `WORKSHOP_COMMIT_WIDGET` stays family-generic; only its payload is narrowed. Scope line reads "generate/progress/menu". | Yes — Okey, 2026-08-03 |
+| **D3** | The correlation token spans all three action-bearing requests, not standing alone. | Option (a) — Okey, 2026-08-03 |
+| **D4** | `WorkshopStandingDirectiveFrames.ts` is retained; its renderer entry moves into `WorkshopStandingDirectiveOperations` and `Frames` becomes a thin caller. Recorded as an ADR §7 documented deviation from the semantic-runway destination map, because `Frames` has five production call sites outside the directive slice. | Option (b) — Okey, 2026-08-03 |
+| **D5** | Newly discovered pre-existing false generics may be added to the migration exception ledger when documented with an owning phase. The "may only shrink" rule is amended to "may only shrink for a phase once that phase's exceptions are recorded." | Option (a) — Okey, 2026-08-03 |
+
+## Locked constraints
+
+- The standing transaction kernel is not rewritten: serialization,
+  `assertBetweenRuns`, prompt-frame replacement before session commit, and
+  `commitStandingDirectiveMutation` atomicity are preserved exactly.
+- No persisted shape changes. `WorkshopStandingDirectiveSnapshot` and the
+  standing family union already carry `'prose-controller'`; the live
+  `WorkshopWidgetConfigSnapshot` union deliberately does not. The second-family
+  proof therefore uses a structural test fake instead of shipping a future
+  Prose Controller config shape.
+- `extension.ts` is not edited; the directive service is already constructed
+  generically as a top-level `CoreServices` member.
+- No feature default travels into generic code. A generic handler must not
+  answer "which widget failed?" with `'lexical-gravity'`, and generic modules
+  must not carry a feature's writer-facing copy.
+- Route-owner ledger entries are updated in the same commit as the move they
+  describe, and reviewed as a claim rather than a fixup.
+
+## Implementation slices
+
+| # | Purpose | Depends on |
+|---|---|---|
+| 0 | Record D4's deviation and the D5 exception entries; amend the ledger rule wording | — |
+| 1 | `WorkshopStandingDirectiveOperations` closed registry; `Frames`, `Presentation`, and the rail formatter delegate to it; fitness #4 | 0 |
+| 2 | `WorkshopStandingDirectiveHandler`; Lexical handler sheds both routes and both bodies; kernel request union de-narrowed; `WorkshopWidgetRuntime` reshaped; route + exception ledgers updated; fitness #2 | 1 |
+| 3 | Message renames, four payload unions, correlation token, `useWorkshopStandingDirectives`, dispatcher loses Lexical copy; fitness #8 and #9 | 2 |
+| 4 | Second standing family fixture | 1-3 |
+| 5 | Close-out: P2 exceptions empty; deviations recorded | 1-4 |
+
+## Implementation outcome
+
+- `WorkshopStandingDirectiveHandler` is now the sole apply/remove route owner.
+  `WorkshopLexicalGravityHandler` owns only its catalog, preview, build, and save
+  workflow.
+- `WorkshopStandingDirectiveOperations` is the closed family registry. Lexical
+  semantics live in `LexicalGravityStandingDirectiveOperations`; the generic
+  transaction kernel, frame helpers, presentation helpers, and rail delegate to
+  the registry without carrying Lexical writer-facing copy.
+- `WorkshopWidgetRuntime.standingDirectives` is a sibling of the Gesture and
+  Lexical feature bundles. The extension composition root did not change.
+- Gesture generate/progress/menu/cancel contracts now say Gesture Playground.
+  `WORKSHOP_COMMIT_WIDGET` remains the generic one-shot rail and has an exact
+  Gesture payload arm.
+- Commit, apply, and remove mint and echo request tokens. The three presentation
+  owners accept results only when action, widget identity, and token all match.
+- The test-only Prose Controller operations seam completes apply → aggregate
+  commit → remove without adding production persistence or routes.
+- Fitness witnesses #2, #4, #8, and #9 now cover route/presentation ownership,
+  closed registry exhaustiveness, invalid contract pairings, and stale result
+  rejection. Phase-2 migration exceptions are empty; the two accepted Phase-6
+  exceptions remain.
+
+### Verification
+
+- `npm run typecheck`
+- `npm run lint` — zero errors; repository baseline warnings remain
+- `npm run build` — production extension/webview bundles and bundle sentinel pass
+- `npm test -- --runInBand` — 168 suites, 1,810 tests, 1 snapshot passed
+
+## Deferred, with reasons
+
+- Moving Lexical Gravity's weight/reach field grammar out of
+  `shared/constants/workshopWidgets.ts` and its prompt copy/validation out of
+  `utils/workshopWidgetRecommendation.ts`. Both are pre-existing false generics
+  discovered during this sprint's runway; both are recorded as P6 exceptions
+  under D5 rather than folded into a phase that already owns contract change.
+- Folding `WorkshopStandingDirectiveFrames` away entirely (D4).
+- Any further `WorkshopApp` decomposition, including where the removal toast
+  finally lives if it should move to the shell (Sprint 03).
 
 ## Completion criteria
 
-- [ ] Generic standing routes are not registered by feature handlers.
-- [ ] `WorkshopStandingDirectiveService` contains no Lexical-only request type or
-      literals outside approved closed dispatch.
-- [ ] Invalid widget/draft pairings are hard to represent.
-- [ ] Cross-feature/stale acknowledgements cannot settle another feature.
-- [ ] The P2 migration exceptions are empty.
+- [x] Generic standing routes are not registered by feature handlers.
+- [x] The generic standing rail and its remove path do not depend on a feature
+      hook, and no generic module carries a feature's writer-facing copy.
+- [x] `WorkshopStandingDirectiveService` contains no Lexical-only request type or
+      literals outside approved closed dispatch, including its error strings.
+- [x] Invalid widget/draft pairings are hard to represent: the generate, progress,
+      menu-result, and commit payloads carry exact `widgetId` discrimination,
+      proven by a type-level fixture.
+- [x] Cross-feature/stale acknowledgements cannot settle another feature: every
+      action-result consumer filters on both the echoed request token and exact
+      feature identity.
+- [x] Every generic-to-feature dispatch in the standing slice fails to compile
+      when a family is added without an entry.
+- [x] A second standing family adds no `lexicalGravity/**` diff lines and no
+      route collision.
+- [x] Fitness witnesses #2, #4, #8, and #9 are installed and failing-on-drift.
+- [x] The P2 migration exceptions are empty.

--- a/docs/adr/2026-08-03-workshop-feature-family-and-module-boundaries.md
+++ b/docs/adr/2026-08-03-workshop-feature-family-and-module-boundaries.md
@@ -134,6 +134,18 @@ An implementation may deviate when current code proves a more cohesive owner,
 but Phase 7 must record the reason. Accidental placement and empty symmetry are
 not acceptable deviations.
 
+Two Phase-2 clarifications are accepted:
+
+- `WorkshopStandingDirectiveFrames` remains as a thin public caller over the
+  closed standing-operations registry. It has five production call sites
+  outside the directive mutation slice, so deleting it would widen a route and
+  contract ownership phase without improving the variation boundary.
+- The executable migration-exception inventory may add a newly discovered
+  pre-existing violation only when the same change records its owning cleanup
+  phase and evidence marker. Once a phase's inventory is recorded, that phase's
+  entries may only shrink. This keeps the ledger honest without allowing new
+  violations to masquerade as discovery.
+
 ### 8. Extraction follows responsibility, not a numeric line limit
 
 No arbitrary maximum line count defines completion. A broad file is complete

--- a/docs/architecture/2026-08-03-workshop-sprint-02-shared-ownership-runway.md
+++ b/docs/architecture/2026-08-03-workshop-sprint-02-shared-ownership-runway.md
@@ -1,0 +1,569 @@
+# Architecture Change Runway — Sprint 02: Shared Route and Contract Ownership
+
+**Subject:** [`.todo/epics/epic-workshop-architecture-refactor-2026-08-03/sprints/02-shared-route-contract-ownership.md`](../../.todo/epics/epic-workshop-architecture-refactor-2026-08-03/sprints/02-shared-route-contract-ownership.md)
+
+**Branch:** `sprint/workshop-architecture-refactor-02-shared-ownership` → `epic/workshop-architecture-refactor` (Sprint 00 = PR #101, Sprint 01 = PR #102, both merged; branch point `0f35294`)
+
+**Altitude:** One sprint. The epic arc, the ADR, and the Phase-0 witness design are settled in the [epic runway](2026-08-03-workshop-refactor-epic-runway.md), the [semantic runway](2026-08-03-workshop-module-semantic-runway.md), and the [Sprint 01 runway](2026-08-03-workshop-sprint-01-feature-slice-runway.md) and are not re-derived here. This runway asks only: *what does P2 actually re-own, and where does "family-generic" stop being true?*
+
+Repository-specific vocabulary is defined in the [Reader Terms Appendix](#band-5--reader-terms-appendix).
+
+**Audience / task:** Decision owner (Okey) opening the P2 gate; implementer sequencing the moves.
+
+**Date:** 2026-08-03 · **Status:** `IMPLEMENTED` — D1–D5 accepted by Okey and completed on 2026-08-03 · **Implementation gate:** **CLEARED**
+
+---
+
+## Band 0 — Change Card (30 seconds)
+
+### Thesis
+
+Because the family's standing apply/remove routes are registered by Lexical Gravity's handler and its transaction kernel narrows its request type to `family: 'lexical-gravity'`, change **route ownership, generic/feature dispatch, message naming, and action correlation** so that generic seams carry family mechanics and named slices carry feature semantics, while preserving **the session aggregate boundary, the serialized between-run standing transaction, persisted widget-config and directive shapes, and every rendered prompt frame**, so that **a second standing family (Prose Controller) is added by extending closed registries rather than by editing Lexical Gravity.**
+
+### Architecture moves
+
+| # | Move | Before | After | Confidence |
+|---|---|---|---|---|
+| 1 | Generic standing route owner | `WorkshopLexicalGravityHandler.ts:84-91` registers `APPLY`/`REMOVE_STANDING_WIDGET` | `handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts` [+] | STRONG |
+| 2 | Closed dispatch for standing operations | `WorkshopStandingDirectiveApplyRequest.family: 'lexical-gravity'` (`…Service.ts:16`); renderer is an `if`/`throw` (`…Frames.ts:22-30`) | `WorkshopStandingDirectiveOperations.ts` [+] — validate/render/summarize by family, mirroring `WORKSHOP_WIDGET_CONFIG_OPERATIONS` | MODERATE — see D4/F5 |
+| 3 | Correlation + feature identity on the action result | `WorkshopWidgetActionResultPayload` has no request token; `useLexicalGravity:126` filters on `action` alone | Echoed request token + exact widget/family identity | MODERATE — see D3/F2 |
+| 4 | Honest Gesture message names | `WORKSHOP_WIDGET_GENERATE` / `_GENERATION_PROGRESS` / `_MENU_RESULT` / `_COMMIT_WIDGET` / `CANCEL_WIDGET_GENERATE_REQUEST` | Rename the four Gesture-only generate/progress/menu/cancel contracts; keep commit family-generic because it is a rail mechanic (D2/F3) | MODERATE |
+| 5 | Exact draft/message pairings | 4 payloads pair `widgetId: WorkshopWidgetId` (13 members) with a Gesture-only body | Discriminated unions keyed on `widgetId` | STRONG |
+
+### Scope and highest risks
+
+| Affected boundary | Why affected | Highest failure mode | Risk |
+|---|---|---|---|
+| Standing IPC route ownership | The two family routes change file | A generic handler that still defaults to `'lexical-gravity'` — a false generic reintroduced inside the fix (**F8**) | MODERATE |
+| Webview standing ownership | `WorkshopStandingDirectiveRail` (generic) calls `lexicalGravity.remove`; the generic dispatcher hardcodes Lexical toast copy | Handler side becomes honest, presentation side stays a feature lie (**F1**) | **HIGH** |
+| Action-result correlation | One message type, three consumers, no request token | A second standing family's result settles Lexical Gravity's modal (**F2**) | **HIGH** |
+| Wire contract (message names + exact payloads) | 4 message renames + 4 literal-identity payload contracts + 1 new correlation field | Frontend/backend drift; paused feature branches rebase | MODERATE |
+| Widget runtime composition | `WorkshopWidgetRuntime.lexicalGravity.directives` nests the generic service inside the feature bundle (`MessageHandler.ts:321-324`) | The route move compiles locally but leaves generic runtime ownership nested under Lexical unless both wiring files move together (**F6**) | MODERATE |
+| Session / persistence | — | **None.** The standing ledger/snapshot/family union include `'prose-controller'`; the live widget-config union intentionally remains Gesture + Lexical only | LOW |
+| Composition root | `extension.ts` already constructs the directive service as a top-level `CoreServices` entry | None — no `extension.ts` edit required | LOW |
+
+### Human decisions — all accepted 2026-08-03
+
+| ID | Decision | Accepted outcome | Rationale | Lands in |
+|---|---|---|---|---|
+| **D1** | Does the **presentation** side of the standing boundary get a generic owner in P2? | **Yes** — add `useWorkshopStandingDirectives` owning `remove`, generic action-result correlation, and the removal acknowledgement copy | Sprint 01's own D1 ruled that ownership applies to *both sides* of a message boundary, and `boundaries.test.ts:289-300` already witnesses that rule for widget config. Deferring re-opens a question this epic answered. | slice 3 |
+| **D2** | Is `WORKSHOP_COMMIT_WIDGET` Gesture-specific or the family's one-shot rail mechanic? | **Family rail** — keep the message generic; narrow its current payload to an exact Gesture arm and keep the alias union-ready | `workshopWidgets.ts` declares six `rail: 'oneshot'` widgets and derives the thread-artifact `kind` from the id. Renaming commit Gesture-specific creates a false *specific* on the family's most reusable rail. | slice 3 |
+| **D3** | Correlation token scope | **(a)** — all three action-bearing requests (commit, apply-standing, remove-standing) | Fitness #9 is family-generic, and GP's commit has the same defect. One contract change beats two. | slice 3 |
+| **D4** | Does `WorkshopStandingDirectiveFrames` fold into `WorkshopStandingDirectiveOperations`? | **(b)** — keep both; record an ADR §7 documented deviation | `Frames` has five production call sites outside the directive slice; folding is a wider edit than this sprint's review boundary. The renderer entry lives in Operations; `Frames` becomes a thin caller. | slice 1 |
+| **D5** | May newly discovered *pre-existing* false generics be added to the exception ledger? | **(a)** — yes, when documented with an owning phase; the "may only shrink" rule is amended to "may only shrink for a phase once that phase's exceptions are recorded" | Sprint 01 raised this as F8 and it recurs here (**F7**). A rule that forbids recording what you find rewards not looking. F7's two modules become P6 exceptions. | slice 0 |
+
+### Gate
+
+**State:** `CLEARED` · **Blockers:** none. D1–D5 landed; **F2** is closed by echoed request tokens plus exact action/widget/token filters and fitness witness #9.
+
+### Implementation close-out
+
+The implementation preserved the serialized standing transaction and changed
+its ownership seams around it:
+
+- `WorkshopStandingDirectiveHandler` now owns both generic standing routes.
+  `WorkshopLexicalGravityHandler` shed those registrations and bodies.
+- `WorkshopStandingDirectiveOperations` is the compile-time-complete family
+  registry. Lexical validation, rendering, summary formatting, conflict copy,
+  and diagnostic description live in the named Lexical operations slice;
+  `Frames`, `Presentation`, the transaction service, and the rail are thin
+  generic callers.
+- The generic directive service moved out of the Lexical runtime bundle without
+  changing `extension.ts` or the `CoreServices` composition contract.
+- Gesture-only generate, progress, menu-result, and cancel message names now say
+  Gesture Playground. Commit stays generic, with an exact Gesture payload arm.
+- Commit/apply/remove requests mint tokens and every backend outcome—including
+  mutation-gate rejection—echoes the token and exact widget identity. Gesture,
+  Lexical, and standing presentation owners ignore stale or cross-feature
+  acknowledgements.
+- `useWorkshopStandingDirectives` owns remove, correlation, and catalog-derived
+  acknowledgement copy. The fan-out dispatcher now contains no feature copy.
+- The Prose Controller reproduction is intentionally structural and test-only.
+  Contrary to an assumption in the pre-implementation analysis,
+  `WorkshopWidgetConfigSnapshot` does **not** yet contain a Prose Controller arm;
+  adding one would violate this sprint's no-persistence-change and feature-freeze
+  constraints. The fixture drives the shared service through apply → aggregate
+  commit → remove with injected operations and a fake config boundary.
+
+No production behavior, persisted checkpoint shape, settings, secrets, or
+extension composition-root wiring changed. The Phase-2 exception inventory is
+empty; the two evidence-backed Phase-6 exceptions remain assigned to Phase 6.
+
+Verification at close-out: `npm run typecheck` passed all three TypeScript
+projects; `npm run lint` completed with zero errors (existing repository
+warnings remain); `npm run build` produced both production bundles and passed
+the bundle sentinel; and `npm test -- --runInBand` passed 168 suites / 1,810
+tests / 1 snapshot.
+
+---
+
+## Band 1 — Architecture Delta Map (~2 minutes)
+
+### 1.1 Affected subtree — before
+
+*`wc -l` at branch point `0f35294`. The two commits after `c2321c3` touch only prompt-budget/model-sync files, so the inspected ownership slice is unchanged.*
+
+```text
+packages/core/src/
+├── application/
+│   ├── handlers/MessageHandler.ts                    :320-324 ⚠ directives nested under lexicalGravity
+│   └── handlers/domain/
+│       ├── WorkshopHandler.ts                        2,976  composes 4 widget/session handlers
+│       └── workshop/widgets/
+│           ├── WorkshopWidgetHostHandler.ts             50  ✅ P1's generic seat — the mold P2 copies
+│           ├── gesturePlayground/…Handler.ts                  4 Gesture routes
+│           └── lexicalGravity/…Handler.ts             347  ⚠ 4 LG routes + 2 FAMILY routes (:84-91)
+├── application/services/workshop/
+│   ├── directives/
+│   │   ├── WorkshopStandingDirectiveService.ts       123  ⚠ ApplyRequest.family: 'lexical-gravity' (:16)
+│   │   ├── WorkshopStandingDirectiveLedger.ts        133  ✅ fully family-generic
+│   │   ├── WorkshopStandingDirectiveFrames.ts         64  ⚠ if/throw, not closed dispatch (:22-30)
+│   │   └── WorkshopStandingDirectivePresentation.ts   70  ✅ closed registry WITH assertNever
+│   └── widgets/WorkshopWidgetConfigOperations.ts     108  ✅ the exemplar P2's Operations mirrors
+├── presentation/webview/
+│   ├── components/workshop/WorkshopStandingDirectiveRail.tsx  60  ⚠ "generic" but imports LG formatter
+│   │                                                              and `default: return ''` (:25)
+│   └── hooks/domain/workshop/
+│       ├── dispatchWorkshopWidgetActionResult.ts      37  ⚠ hardcodes "Lexical Gravity removed."
+│       └── widgets/useLexicalGravity.ts              159  ⚠ owns apply/remove + action-result filter
+├── shared/types/messages/workshop.ts               1,982  ⚠ 4 loose widgetId/draft pairings
+├── shared/constants/workshopWidgets.ts                     ⚠ LG weight/reach grammar (unlisted — F7)
+└── utils/workshopWidgetRecommendation.ts             532  ⚠ LG prompt copy + validation (unlisted — F7)
+```
+
+### 1.2 Target subtree
+
+Legend: `[+]` add · `[~]` modify · `[>]` move/rename · `[=]` unchanged boundary
+
+```text
+packages/core/src/
+├── application/handlers/
+│   ├── MessageHandler.ts                            [~] widgetRuntime.directives lifted to top level (F6)
+│   └── domain/
+│       ├── WorkshopHandler.ts                       [~] constructs + registers the new handler
+│       └── workshop/
+│           ├── WorkshopStandingDirectiveHandler.ts  [+] sole APPLY/REMOVE owner, correlation, dispatch
+│           └── widgets/
+│               ├── WorkshopWidgetHostHandler.ts     [=]
+│               ├── gesturePlayground/…Handler.ts    [~] message renames only
+│               └── lexicalGravity/…Handler.ts       [~] −2 routes, −handleApply, −handleRemove (≈347→≈250–280)
+├── application/services/workshop/directives/
+│   ├── WorkshopStandingDirectiveService.ts          [~] family-agnostic ApplyRequest; no LG literals
+│   ├── WorkshopStandingDirectiveOperations.ts       [+] closed registry: validateDraft/renderFrame/summarize
+│   ├── WorkshopStandingDirectiveFrames.ts           [~] delegates rendering to Operations (D4)
+│   ├── WorkshopStandingDirectivePresentation.ts     [~] summary arm re-homed into Operations (D4)
+│   └── WorkshopStandingDirectiveLedger.ts           [=]
+├── presentation/webview/
+│   ├── components/workshop/WorkshopStandingDirectiveRail.tsx  [~] exhaustive dispatch, no silent default
+│   └── hooks/domain/workshop/
+│       ├── useWorkshopStandingDirectives.ts         [+] D1 — remove + generic correlation + toast copy
+│       ├── dispatchWorkshopWidgetActionResult.ts    [~] loses the Lexical-only toast literal
+│       └── widgets/useLexicalGravity.ts             [~] −remove, −generic action filter (≈159→≈130)
+└── shared/types/messages/workshop.ts                [~] Gesture renames + 4 exact unions + correlation token
+```
+
+**The shape of the change in one line:** P1 made the two features *look* alike; P2 makes the seam between them *behave* generically — every place that says "lexical-gravity" inside a family-named module either becomes a registry entry or moves into the Lexical slice.
+
+### 1.3 Responsibility ledger — what changes hands
+
+| Module | Before | After | Ownership delta | Pattern / smell |
+|---|---|---|---|---|
+| `WorkshopStandingDirectiveHandler` [+] | — | `APPLY`/`REMOVE_STANDING_WIDGET`, correlation, closed dispatch by family, standing logging | Gains the family's IPC seat | *Feature-agnostic route owner*, mirroring `WorkshopWidgetHostHandler` |
+| `WorkshopLexicalGravityHandler` | LG catalog/preview/build/save **+ 2 family routes + apply/remove bodies** | LG catalog/preview/build/save | **Loses** both family routes and ~70 lines of standing transaction glue | *False generic* removed — the epic's central correction |
+| `WorkshopStandingDirectiveService` | Serialized kernel **narrowed to `family: 'lexical-gravity'`** (`:16`, `:48-57`) | Serialized between-run kernel: guard, frame replacement, atomic commit | Loses request narrowing and the LG "already active" copy | Kernel + *closed registry* seam |
+| `WorkshopStandingDirectiveOperations` [+] | — | Per-family `validateDraft` / `renderFrame` / `summarize` | Gains the only generic→feature dispatch point for standing | `Closed Registry`, mold = `WORKSHOP_WIDGET_CONFIG_OPERATIONS` |
+| `useLexicalGravity` | LG catalog/preview/build/save **+ apply + remove + action-result filter** | LG catalog/preview/build/save + apply (feature draft) | Loses `remove(family)` and the generic result filter (D1) | Presentation mirror of the handler correction |
+| `useWorkshopStandingDirectives` [+] (D1) | — | `remove`, family-generic correlation, removal acknowledgement copy | Gains the presentation half of the family seat | Thin generic host hook, mirroring `useWorkshopWidgetHost` |
+| `WorkshopStandingDirectiveRail` | Generic rail that imports Lexical's formatter and silently blanks unknown families | Generic rail over an exhaustive family formatter registry | Loses the silent `default` | Removes a *leaky abstraction* |
+| `WorkshopHandler` | — | — | **No responsibility change** — one added collaborator + wiring | Composition owner, untouched |
+
+### 1.4 Structural view — where "generic" currently stops being true
+
+**Question:** for a *second* standing family, which modules must be edited?
+**Scope:** standing apply/remove only. **Legend:** solid = deliberate target collaboration; dashed = current coupling that crosses the intended generic/feature boundary.
+
+```mermaid
+flowchart TB
+    subgraph today["TODAY — a second family edits Lexical Gravity"]
+      A1[APPLY_STANDING_WIDGET] -.->|registered by| LG1[WorkshopLexicalGravityHandler]
+      LG1 -.->|widgetId !== 'lexical-gravity' → throw :250| LG1
+      LG1 --> SVC1[StandingDirectiveService\nfamily: 'lexical-gravity' :16]
+      SVC1 -.-> FR1[Frames\nif family === lexical-gravity → else throw]
+      RAIL1[StandingDirectiveRail\ngeneric component] -.->|onRemove| HOOK1[useLexicalGravity.remove]
+    end
+    subgraph target["TARGET — a second family adds registry entries"]
+      A2[APPLY_STANDING_WIDGET] -->|registered by| SDH[WorkshopStandingDirectiveHandler]
+      SDH --> OPS[StandingDirectiveOperations\nclosed registry by family]
+      OPS --> LGOPS[lexicalGravity entry]
+      OPS --> PCOPS[proseController entry]
+      SDH --> SVC2[StandingDirectiveService\nfamily-agnostic kernel]
+      RAIL2[StandingDirectiveRail] -->|onRemove| HOOK2[useWorkshopStandingDirectives]
+    end
+```
+
+**Reading it:** the three dashed arrows on the left drove the ownership correction. The original sprint named the handler and service edges but missed the rail's remove path through the Lexical hook; D1 adds that third edge to the accepted plan (**F1**).
+
+### 1.5 Representative runtime flow — apply, with the correlation gap
+
+```mermaid
+sequenceDiagram
+    participant Modal as Lexical modal
+    participant Hook as useLexicalGravity
+    participant H as Standing handler (LG today → generic after)
+    participant Ops as Operations (closed registry)
+    participant Svc as StandingDirectiveService
+    participant Sess as WorkshopSessionService
+    Modal->>Hook: apply(draft, widgetConfigId?)
+    Hook->>H: APPLY_STANDING_WIDGET  ❌ no request token
+    H->>Ops: validateDraft(family, draft)
+    H->>Svc: apply({family, draft, widgetConfigId})
+    Svc->>Svc: serialize() + assertBetweenRuns()
+    Svc->>Sess: prepareWidgetConfig* + prepareStandingDirectiveUpsert
+    Svc->>Sess: commitStandingDirectiveMutation (atomic)
+    H-->>Hook: WIDGET_ACTION_RESULT {action:'apply-standing'}
+    Note over Hook: filters on action ONLY (:126)<br/>no widgetId, no token
+```
+
+**Notable:** the kernel between `serialize()` and `commitStandingDirectiveMutation` is already family-agnostic and already atomic — P2 must not touch it. The defect is entirely at the two ends: who registers the route, and how the acknowledgement is correlated back.
+
+### 1.6 Blast-radius summary
+
+| Dimension | Direct | Indirect | Main failure | Witness | Risk |
+|---|---|---|---|---|---|
+| Structure | 1 new handler, 1 new service module, 1 new hook; 2 routes change file | `WorkshopHandler` wiring; `MessageHandler` runtime shape (F6) | Compile error | `tsc` + jest | LOW |
+| Runtime | Standing apply/remove change owner; correlation added | LG modal settle path, removal toast | Silent mis-settle across families (**F2**) | **none today** | **HIGH** |
+| Contract (wire) | 4 renames, 4 exact payload contracts, 1 correlation field | ≤5 production files per cluster (measured) | Frontend/backend drift | `tsc` across projects | MODERATE |
+| Data / persistence | **None** — `WorkshopStandingDirectiveSnapshot` and the family union carry `'prose-controller'`; `WorkshopWidgetConfigSnapshot` remains the two-live-feature union | — | — | aggregate + ledger-bypass guards plus structural second-family fixture | LOW |
+| Operations / security | Standing log ownership moves; no configuration, permission, secret, or trust boundary changes | Output loses useful feature detail if Operations cannot describe the applied config | A successful move leaves weaker manual diagnostics | Handler log assertions; Output Channel remains a manual signal with no alerting consumer | LOW–MODERATE |
+| Route ownership | 2 registrations move to a generic owner | — | Ledger edited to match a wrong move | route-owner ledger (must update in the same commit) | MODERATE |
+| Verification | 4 witnesses to install or complete (#2, #4, #8, #9); 7 test files touch standing | `WorkshopLexicalGravityHandler.test.ts` (279) splits | Vacuous green | slice-0 characterization | MODERATE |
+| Coordination | Paused Conversation Widgets branches rebase across renamed messages | 02B-B, 03, 04 | Merge pain later | epic-level, accepted | MODERATE |
+| Evolution | **The point.** Reproduction test measured at end of P2 | — | — | second-family fixture | **HIGH — intended** |
+
+**Confidence:** structural, contract, route, and persistence conclusions are STRONG because direct code anchors and live witnesses agree. Runtime, verification, and evolution conclusions are MODERATE until the correlation and second-family fixtures exist.
+
+---
+
+## Band 2 — Reviewer Packet (~10 minutes)
+
+### 2.1 The real job of this sprint
+
+P2 is the first phase that changes *behavior contracts*, not just placement. Its discipline is the inverse of P1's: P1 was forbidden to decide anything; P2 exists to decide. The three decisions it actually owns are (1) where the family's seat is on **both** sides of the message boundary, (2) what "exact" means for a widget message's payload, and (3) how an acknowledgement finds the request that produced it. Everything else in the scope list is mechanical once those are settled.
+
+Its success metric is not the checkbox list. It is: **after P2, adding Prose Controller's standing arm touches zero lines under `lexicalGravity/**`.**
+
+### 2.2 Declared vs observed
+
+| Topic | [Declared] | [Observed] | [Inferred] / decision state |
+|---|---|---|---|
+| "Generic standing routes are not registered by feature handlers" | Completion criterion 1 | `WorkshopLexicalGravityHandler.ts:84-91` registers both | Straightforward; the route-owner ledger already pins the expected new owner path |
+| "`WorkshopStandingDirectiveService` contains no Lexical-only request type" | Completion criterion 2 | `:16` (`family: 'lexical-gravity'`), `:48-57` (narrowing + LG copy), `:51-56` (LG-worded errors) | The *errors* are also LG copy — "Lexical Gravity can edit only its currently active configuration." Generic kernels should not write a feature's writer-facing text (ADR §3) |
+| "Invalid widget/draft pairings are hard to represent" | Completion criterion 3 | 4 payloads pair a 13-member `WorkshopWidgetId` with a Gesture-only body (`workshop.ts:1769`, `:1796`, `:1814`, `:1941`) | [Inferred] the fix is per-payload literal identity, with shared family rails represented as exact-arm aliases. The original criterion named neither the payloads nor the technique; the accepted sprint plan now names both (**F4**). |
+| "Cross-feature/stale acknowledgements cannot settle another feature" | Completion criterion 4 | `useLexicalGravity.ts:126` filters on `action` only; `WorkshopWidgetActionResultPayload` has no token | [Inferred] exact correlation requires both an echoed request token and feature identity. **Resolved by D3** and now explicit in the sprint scope. |
+| "Generic standing and **widget-host** contracts live under generic owners" | Sprint scope line 11 | Widget host landed in P1 on **both** sides (handler + hook + witness) | [Inferred] standing should match. **Resolved by D1**: P2 adds the presentation owner as well as the handler. |
+| "The P2 migration exceptions are empty" | Completion criterion 5 | Ledger holds exactly 2 P2 entries (`boundaries.test.ts:151-162`) | Both are removable by the named moves. But two *unlisted* pre-existing violations exist (**F7**) |
+| Fitness witnesses #2, #4, #8, #9 install here | Epic phase table | None exist yet | The original sprint compressed four witnesses into one fixture bullet; the accepted sprint plan now names each witness and its invariant. |
+
+### 2.3 Contracts and invariants
+
+| Contract / invariant | Current owner | Target owner | Change? | Failure if broken | Witness |
+|---|---|---|---|---|---|
+| `WORKSHOP_APPLY_STANDING_WIDGET` / `…REMOVE…` | `WorkshopLexicalGravityHandler` | `WorkshopStandingDirectiveHandler` | ownership | LG apply/remove dead | route-owner ledger (update in the same commit) |
+| One registration per message type | `MessageRouter.register` throws (`MessageRouter.ts:31-35`) | unchanged | no | duplicate route | runtime throw + ledger |
+| Standing mutation is serialized and between-runs only | `…Service.serialize()` + `assertBetweenRuns()` (`:112-122`) | unchanged | **no — must not change** | Concurrent apply corrupts prompt/session agreement | `WorkshopStandingDirectiveService.test.ts` |
+| Prompt frames replaced *before* session commit | `…Service.ts:75-85`, `:102-107` | unchanged | **no** | Provider history and session history disagree | same suite |
+| `commitStandingDirectiveMutation` atomicity | `WorkshopSessionService.ts:1097-1146` | unchanged | no | Directive without config, or marker without turn | session suite |
+| Persisted `WorkshopStandingDirectiveSnapshot` / `WorkshopWidgetConfigSnapshot` | `workshop.ts:837-905` | unchanged | **no** | Checkpoint incompatibility | codec/normalization suites |
+| `WorkshopWidgetActionResultPayload` | `workshop.ts:1966-1978` | **+ correlation token, exact identity** (D3) | **yes — wire** | Stale/cross-family settle | **none today** (**F2**) |
+| Gesture generate/menu/progress payloads | `workshop.ts:1768-1830` | Gesture-named + exact unions | **yes — wire** | Frontend/backend drift | `tsc` |
+| `WORKSHOP_COMMIT_WIDGET` | Wire contract in `workshop.ts:1940-1949`; route in `WorkshopGesturePlaygroundHandler` | Same feature route owner; generic message name retained and payload becomes an exact, union-ready Gesture arm (D2) | payload only | Renaming would close the one-shot rail to 5 declared future widgets; leaving the current loose payload would permit invalid pairs | catalog + fitness #8 |
+| `packages/core` free of `vscode`; handlers never touch ledgers | `boundaries.test.ts:200`, `:302-309` | unchanged | no | boundary regression | live witnesses |
+
+**D2 boundary note:** retaining a family-generic commit message does **not** make Gesture's preparation workflow generic. `WorkshopGesturePlaygroundHandler` remains the current commit route owner; only the rail contract name and its exact payload union are shared. A second one-shot workflow can justify a generic route owner later if its preparation contract truly matches. This preserves the semantic runway's feature-owned generation/preparation boundary rather than building a universal widget handler early.
+
+### 2.4 Negative space
+
+| Generic owner | May know | Must not know | Next-feature edit surface | Verdict |
+|---|---|---|---|---|
+| `WorkshopStandingDirectiveHandler` [+] | family key, widget id, config id, correlation token, the generic action-result envelope | lens fields, preview protocol, LG error copy | none | **Healthy if built** — provided F8's `'lexical-gravity'` defaults do not travel with the code |
+| `WorkshopStandingDirectiveService` | between-run guard, serialization, frame replacement order, atomic commit | which family it is serving | none | **Healthy after criterion 2** — including its error strings |
+| `WorkshopStandingDirectiveOperations` [+] | that families exist and each can validate/render/summarize | field grammar of any draft | one entry per family | **Healthy** — mold already proven at `WorkshopWidgetConfigOperations` |
+| `WorkshopStandingDirectiveRail` | family identity, widget label, a formatter registry | how to format a lens | one formatter entry | **Currently unhealthy** — imports `formatLexicalGravitySummary` directly and blanks unknown families (`:25`) |
+| `dispatchWorkshopWidgetActionResult` | that action results fan out to feature consumers | that removal means "Lexical Gravity removed." | none | **Currently unhealthy** — feature copy in a generic seam (**F1**) |
+| `shared/constants/workshopWidgets.ts` | ids, labels, rails, availability | LG weight bounds, reach values, their validators | — | **Unhealthy and unlisted** (**F7**) |
+| `utils/workshopWidgetRecommendation.ts` | recommendation parsing, id liveness | LG prompt copy (`:32`), LG field validation (`:436-441`) | — | **Unhealthy and unlisted** (**F7**) |
+
+### 2.5 Quality scenarios
+
+| Type | Source | Stimulus | Environment | Artifact | Expected response | Response measure |
+|---|---|---|---|---|---|---|
+| Change | Feature implementer | Prose Controller's standing arm is added | After the P7 feature gate opens | standing slice | Add Operations, Presentation, rail-formatter, contract, and feature entries | **Zero diff lines under `**/lexicalGravity/**`** |
+| Change | Feature implementer | A second one-shot widget is added | Existing catalog and shared commit rail | commit route | No message rename required | D2 holds; the current catalog already has 6 `rail: 'oneshot'` entries |
+| Failure | Host result stream | A `prose-controller` apply result arrives while the LG modal is open | Normal webview session | `useLexicalGravity` | Ignore the result | Exact `requestToken && widgetId` filter; **absent today** (**F2**) |
+| Failure | Host result stream | A stale failed apply arrives after a newer apply | Two overlapping requests | LG modal | Ignore the stale result | Echoed token matches only the latest request; **absent today** (**F2**) |
+| Failure | Hydrated session | A `prose-controller` directive reaches the rail | Family is known but feature behavior remains frozen | `WorkshopStandingDirectiveRail` | Render its summary or fail loudly | Never returns the current silent blank string (`:25`) (**F5**) |
+| Failure | Contributor | A generic module imports feature behavior outside an approved registry | Build/test | generic standing files | Architecture test fails | Fitness #4; current path-selected guard cannot see generic files |
+| Failure | Type consumer | `{widgetId:'lexical-gravity', draft: gestureDraft}` is constructed | Typecheck | commit payload | Compile error | Type-level fixture with `@ts-expect-error`; **compiles today** (**F4**) |
+| Runtime | Writer | Applies a lens while a run is active | Active Workshop response | standing service | Reject with "A Workshop response is still running." | Existing `assertBetweenRuns()` test remains green |
+| Change | Phase owner | P2 completes | Sprint close-out | exception ledger | Both P2 entries are gone | `boundaries.test.ts:311-332` |
+
+**Sensitivity point:** D1. It decides whether P2 ends with one honest seam or two half-seams.
+**Tradeoff point:** D2. Message-name honesty for Gesture vs. keeping the one-shot rail open to five declared future widgets.
+**Risk theme:** every generic module that already exists in this slice was written *before* a second family existed, so its "genericness" is untested. The rail, the dispatcher, the frames renderer, and the constants module each encode Lexical Gravity as the default case.
+
+### 2.6 Alternatives
+
+| Alternative | Shape | Benefits | Costs / risks | Verdict |
+|---|---|---|---|---|
+| **Minimal patch** | Move the two routes; widen the ApplyRequest union; stop | Smallest diff; clears both exception entries | Criteria 3 and 4 unmet; presentation side still feature-owned; fitness #4/#8/#9 unbuilt and inherited by P6/P7 | **Rejected** |
+| **Recommended** | Five moves + D1's presentation carve-out + D3's correlation token + four witnesses | One honest family seam on both sides; the reproduction test becomes measurable at P2 rather than P7 | Wire contract changes ripple into paused branches; ~10 production files | **Retained** |
+| **More generalized** | Also fold `Frames`, `Presentation`, and the rail formatter into one Operations registry now, and clear F7's constants | One dispatch point for everything standing | `Frames` has 5 production call sites outside the slice; mixes a broad refactor into the phase that owns contract change | **Rejected for P2** — take D4(b), route F7 to P6 |
+
+### 2.7 Principle and quality tensions
+
+| Principle | Status | Support | Tension | Consequence | Witness |
+|---|---|---|---|---|---|
+| Naming truthfulness | `TENSION` → `STRONG` with D1+D2 | Routes, service, and messages all become honest | D2 could over-correct commit into a false specific | A future one-shot widget renames the rail again | route ledger + catalog |
+| Responsibility / cohesion | `STRONG` | LG handler sheds ~70 lines of family glue; kernel keeps one job | — | — | sprint exit criteria |
+| Open/closed | `ACCEPTABLE` → `STRONG` with Operations | Adding a family extends deliberate closed registries | A new family still edits shared registry entries by design; the false-generic constants remain deferred to P6 under D5 | Reproduction test permits closed-registry edits but requires zero edits to existing feature files | second-family fixture |
+| Change isolation | `TENSION` | Handler side becomes isolated | Presentation side unresolved without D1 | Lexical hook remains the family's remove path | **F1 fix** |
+| Make illegal states unrepresentable | `VIOLATION` → `ACCEPTABLE` | 4 loose pairings become literal-identity contracts | `WorkshopWidgetId` stays 13-wide in genuinely generic envelopes by design | Acceptable — catalog identity is genuinely family-wide | fitness #8 |
+| Reliability (correlation) | `VIOLATION` | — | No token; one filter keys on `action` alone | Cross-family and stale settles are representable today | **F2 fix** + fitness #9 |
+| Observability | `TENSION` | `[WorkshopStandingDirective]` log lines exist (`…LexicalGravityHandler.ts:269-271`, `:299-301`) | They are written by a feature handler and include a lens field | Moving them generic loses the lens detail unless Operations supplies a log summary | name a `describe(config)` entry in Operations |
+
+### 2.8 Ranked findings
+
+| ID | Sev | Finding | Evidence | Smallest fix | Blocks |
+|---|---|---|---|---|---|
+| **F1** | **HIGH** | The original sprint plan fixed only the host side of the standing boundary. In current code, a **generic** rail's remove button is wired to the **Lexical** hook, and a **generic** fan-out dispatcher owns Lexical's removal copy. | `WorkshopApp.tsx:1497` `onRemove={lexicalGravity.remove}`; `WorkshopStandingDirectiveRail.tsx:1` self-describes as "Generic composer-adjacent rail" yet `:11-13` imports `formatLexicalGravitySummary`; `dispatchWorkshopWidgetActionResult.ts:28-35` hardcodes "Lexical Gravity removed." / "…was already removed." / "…could not be removed."; P1 ruled the opposite for widget config and witnessed it at `boundaries.test.ts:289-300`. | **Accepted in D1:** add `useWorkshopStandingDirectives` owning `remove` + generic correlation + removal copy; extend the P1 presentation-ownership witness to the standing message pair. | slice 3 |
+| **F2** | **HIGH** | Current code has no mechanism for the criterion that cross-feature or stale acknowledgements cannot settle another feature. Today a `prose-controller` apply result would settle the Lexical modal. | `useLexicalGravity.ts:125-127` — `if (action === 'apply-standing') setActionResult(...)`, no `widgetId`, no token; `WorkshopWidgetActionResultPayload` (`workshop.ts:1966-1978`) carries no request identity; contrast `useGesturePlayground.ts:97-99` which *does* check `widgetId`, and `:82` which uses a token for menu results. | **Accepted in D3:** add an echoed `requestToken` to commit / apply-standing / remove-standing and their action result; filter on `token && widgetId` in every consumer; install fitness #9 over the three consumers. | slice 3 |
+| **F3** | **MED–HIGH** | The original scope included commit among the Gesture-specific renames, but commit is a **family rail**, not a Gesture concept. Renaming it would create a false specific on the mechanic five declared widgets will reuse. | `workshopWidgets.ts:17` `WorkshopWidgetRail = 'oneshot' \| 'standing' \| 'resource'`; six descriptors carry `rail: 'oneshot'` (`:84, :96, :107, :125, :137, :155`); `WorkshopThreadArtifactWidgetCommit` (`workshop.ts:~915`) is family-generic; only `WorkshopCommitWidgetPayload.draft: WorkshopGestureDraft` is Gesture-bound. | **Accepted in D2:** keep the message generic; narrow the payload to an exact, union-ready Gesture arm. The sprint scope now says "generate/progress/menu." | slice 3 |
+| **F4** | **MED** | The original completion criterion did not name the four invalid pairing surfaces, making completion unreviewable. Current code still permits every invalid pairing. | `workshop.ts:1769` (`WorkshopWidgetGenerateBasePayload.widgetId: WorkshopWidgetId` + `menu: WorkshopGestureMenuGroup[]` at `:1784`), `:1796` (progress with Gesture-only `stage: 'dictionary' \| 'menu'`), `:1814` (`menuResult` with `dictionaryMarkdown`), `:1941` (`commit` with `draft: WorkshopGestureDraft`). All four permit `{widgetId:'lexical-gravity', …gesture body}`. | The accepted sprint plan now lists all four; key each to the literal Gesture identity, keep generic aliases union-ready, and install fitness #8 as a type-level fixture (`@ts-expect-error` on an invalid pairing). | slice 3 |
+| **F5** | **MED** | Two of the four generic→feature dispatch points in current code are not closed registries: one is an `if`/`throw`, the other silently returns an empty string. | `WorkshopStandingDirectiveFrames.ts:22-30` — `if (family === 'lexical-gravity' && …) return …; throw` (no `assertNever`); `WorkshopStandingDirectiveRail.tsx:21-27` — `switch(family) { case 'lexical-gravity': …; default: return '' }`. Contrast the correct shape at `WorkshopStandingDirectivePresentation.ts:22-38, 68-70` (`assertNever`) and `WorkshopWidgetConfigOperations.ts:27-29` (`unsupportedConfig(value: never)`). | Make both exhaustive with a `never` guard or closed registry; the accepted sprint plan now defines fitness #4 as the failing-on-drift witness for every generic→feature dispatch. | slice 1 |
+| **F6** | **MED** | The generic standing service is composed **inside the Lexical feature bundle** of the widget runtime, so the new generic handler cannot receive it without reshaping the runtime contract. | `MessageHandler.ts:320-324` — `widgetRuntime = { gesturePlayground, lexicalGravity: { model, repository, directives } }`; `WorkshopHandler.ts:253-260` declares that shape; `WorkshopHandler.ts:363` passes `widgetRuntime.lexicalGravity.directives` into the Lexical handler. `CoreServices` already holds it correctly as a top-level `workshopStandingDirectiveService` (`MessageHandlerContracts.ts:127`), and `extension.ts:221` constructs it generically — so no composition-root edit is needed. | Add `standingDirectives` as a sibling of `gesturePlayground`/`lexicalGravity` in `WorkshopWidgetRuntime`; the accepted sprint scope now names both runtime files. | slice 2 |
+| **F7** | **MED** | The exception ledger claims to be "exact known false-generic ownership" and is not. Two generic modules own Lexical Gravity semantics, are unlisted, unassigned to a phase, and structurally invisible to the isolation witness (which selects candidate files by **path**). | `shared/constants/workshopWidgets.ts:19-40` — `LEXICAL_GRAVITY_WEIGHT`, `LEXICAL_GRAVITY_REACH`, `isLexicalGravityWeight`, `isLexicalGravityReach` in the *catalog* module; `utils/workshopWidgetRecommendation.ts:32` holds LG writer-facing prompt copy and `:436-441` LG field validation. Neither path matches `/LexicalGravity/i`, so `boundaries.test.ts:274-275` cannot see them. ADR §3 forbids a generic module owning "Lexical lens logic". | D5(a): record both as P6 exceptions with a one-line rationale, and amend the "may only shrink" wording to "may only shrink for a phase once that phase's exceptions are recorded." Alternatively move the LG grammar into `LexicalGravityConfigCodec` and re-export — but that is P6 scope, not P2. | slice 0 |
+| **F8** | **LOW–MED** | The apply/remove bodies that move into the generic handler carry Lexical defaults with them. A generic handler that answers "which widget failed?" with `'lexical-gravity'` is a false generic reintroduced inside the fix. | `WorkshopLexicalGravityHandler.ts:304` — success path `widgetId: active?.widgetId ?? 'lexical-gravity'`; `:314` — failure path hardcodes `widgetId: 'lexical-gravity'` for a request that carries only `family`. Also `WorkshopStandingDirectiveService.ts:53, 56` embed LG writer copy in the generic kernel. | Derive widget identity from the family via the Operations registry; on failure echo the request's `family` and omit `widgetId` (or make the failure arm's identity `family`-keyed). Move the two error strings into the Lexical Operations entry. | slice 2 |
+| **F9** | **LOW** | "A compile-time/minimal fixture proving a second standing family does not edit Lexical files" is ambiguous: `'prose-controller'` is *already* in the family union, and several closed dispatches deliberately `throw` for it. A fixture asserting "compiles" and a fixture asserting "behaves" are different tests. | `workshop.ts:58-60` — `WorkshopStandingDirectiveFamily = 'lexical-gravity' \| 'prose-controller'`; `WorkshopStandingDirectivePresentation.ts:33` throws "Prose Controller standing directives are not implemented" *by design*; `:53-60` already renders a generic marker for it. | State the fixture as: a stub `proseController` Operations entry registered in a test, driven through apply→commit→remove, asserting the diff-free property by inspection plus a route-owner assertion. Say explicitly it is a test-only registration, not shipped behavior (the feature freeze still applies). | slice 4 |
+
+**What survived attack.** I tried to break these and could not:
+
+- **The transaction kernel is genuinely family-agnostic already.** `serialize()` (`…Service.ts:112-116`), `assertBetweenRuns()` (`:118-122`), the frames-then-commit ordering (`:75-85`), and `commitStandingDirectiveMutation` (`WorkshopSessionService.ts:1097-1146`) contain no feature branch. Only the *request type* and the *pre-flight checks* narrow. Criterion 2 is a smaller change than it reads.
+- **The ledger is already correct.** `WorkshopStandingDirectiveLedger` (133 lines) dispatches on `family` as data, mints `pd-N` generically, and has no feature literal anywhere. It needs zero edits.
+- **The session facade is already correct.** `prepareStandingDirectiveUpsert/Removal`, `getStandingDirective(s)`, `prepareWidgetConfig*`, and `getWidgetConfig` (`WorkshopSessionService.ts:1045-1146`) are all family-generic. No aggregate widening is required, so locked constraints 4 and 5 are untouched.
+- **The exemplar and the mold both exist in-repo.** `WORKSHOP_WIDGET_CONFIG_OPERATIONS` (closed registry with a `never` guard) and `WorkshopWidgetHostHandler` (50-line generic route seat from P1) are working precedents for both new modules. Nothing here is speculative design.
+- **`WorkshopStandingDirectivePresentation` is already the right shape** — `switch` on family with `assertNever`, and a *generic* marker arm for `prose-controller`. It proves the pattern works for this exact family.
+- **No persistence risk.** `'prose-controller'` is already a member of the persisted `WorkshopStandingDirectiveFamily` and `WorkshopStandingWidgetCommit.widgetId`. P2 changes no stored shape, so the codec-evolution rules in `CLAUDE.md` and ADR 2026-07-30 do not engage.
+- **The composition root needs no edit.** `extension.ts:221` already builds the directive service from `(session, conversationSettings)` and exposes it as a top-level `CoreServices` member. Only `MessageHandler`'s local bundling is wrong (F6). Locked constraint 3 holds without effort.
+- **Message renames are cheap.** Measured fan-in per cluster: ≤5 production files (`base.ts`, `workshop.ts`, one handler, one hook, one modal/router) plus 2–6 test files. `dist/` hits are build output.
+- **Duplicate-route collision is already impossible.** `MessageRouter.register` throws (`MessageRouter.ts:31-35`), so half of the sprint's "does not collide in `MessageRouter`" fixture is enforced at runtime today; the fixture only needs to prove *ownership*, which the ledger does.
+- **Baseline is green.** `npx jest packages/core/src/__tests__/architecture/boundaries.test.ts --runInBand` → **9/9, 1.9s** at branch point `0f35294`.
+
+### 2.9 Implementation slices
+
+| # | Purpose | Files | Behavior change | Verification | Depends on | Rollback seam |
+|---|---|---|---|---|---|---|
+| 0 | Record findings and close the ledger's honesty gap | sprint doc (F3–F5, F9 wording); `boundaries.test.ts` (F7 entries + rule wording) | none (docs/tests) | architecture suite | **D5** | revert one commit |
+| 1 | Closed dispatch for standing operations | `WorkshopStandingDirectiveOperations.ts` [+]; `…Frames.ts` + `…Presentation.ts` delegate; rail formatter registry; fitness #4 witness | none — same frames, same summaries | `WorkshopStandingDirectiveService.test.ts`, rail test, architecture suite | **D4** | independent commit |
+| 2 | Generic route ownership + kernel de-narrowing | `WorkshopStandingDirectiveHandler.ts` [+]; LG handler −2 routes; `…Service.ts` request union; `WorkshopHandler` + `MessageHandler` runtime shape (F6); route ledger; exception ledger −2 | route owner moves; LG defaults removed (F8) | handler tests split; route-owner witness; `tsc` all projects | 1 | independent commit |
+| 3 | Contract exactness + correlation | 4 Gesture-only message renames; 4 exact payload contracts; `requestToken`; `useWorkshopStandingDirectives` [+]; `useLexicalGravity` −remove; dispatcher −LG copy; fitness #8 + #9 witnesses | **yes — wire contract** (alpha rules) | hook suites, router suite, dispatcher suite, `tsc` | 2, **D1/D2/D3** | independent commit |
+| 4 | Second-family fixture | test-only `proseController` Operations stub driven apply→commit→remove | none (test-only) | new fixture + full architecture suite | 1–3, **F9 wording** | revert one test commit |
+| 5 | Close-out | P2 exceptions empty; sprint doc records deviations (D4(b), F7 deferral) | none | full architecture suite + full jest | 1–4 | — |
+
+### 2.10 Coordination map
+
+| Workstream | Files owned | Shared lock points | Merge order | Owner |
+|---|---|---|---|---|
+| Decision and migration witnesses | Sprint doc, ADR §7, `boundaries.test.ts` exception wording/entries | `boundaries.test.ts` also changes in route ownership | Slice 0 first; route-ledger portion completes with Slice 2 | Sprint 02 branch |
+| Standing operations seam | `WorkshopStandingDirectiveOperations.ts`, `…Frames.ts`, `…Presentation.ts`, formatter registry | Operations contract consumed by handler and test fixture | Slice 1 before handler extraction | Sprint 02 branch |
+| Route and runtime ownership | `WorkshopStandingDirectiveHandler.ts`, `WorkshopLexicalGravityHandler.ts`, `WorkshopHandler.ts`, `MessageHandler.ts`, route ledger | `WorkshopHandler.ts` and `boundaries.test.ts` | Slice 2 after Operations | Sprint 02 branch |
+| Wire and presentation ownership | `base.ts`, `workshop.ts`, `useWorkshopStandingDirectives.ts`, `useLexicalGravity.ts`, dispatcher, rail, app router/composition | Shared message barrel and action-result consumers | Slice 3 after route owner compiles | Sprint 02 branch |
+| Reproduction fixture and close-out | Test-only Prose Controller stub, architecture/type fixtures, sprint close-out | Operations registry and all four witnesses | Slices 4–5 last | Sprint 02 branch |
+
+Paused Conversation Widgets Sprints 02B-B, 03, and 04 do not co-edit this branch; they rebase only after the architecture epic closes. Within Sprint 02, the lock points above make the safe merge order explicit and keep contract changes from landing before their route owner exists.
+
+### 2.11 Decision-reversal check
+
+No unresolved unknown currently reverses D1–D5. The three candidates from the first investigation pass are settled by accepted decisions and source plans:
+
+| Candidate uncertainty | Resolution | Evidence | Remaining impact |
+|---|---|---|---|
+| Where does the removal acknowledgement copy live in P2? | `useWorkshopStandingDirectives` owns generic correlation and acknowledgement copy now (D1). P3 may later re-home shell rendering without returning the copy to a feature hook. | accepted sprint scope and D1; current fan-out seam at `dispatchWorkshopWidgetActionResult.ts:10-36` | None for P2 architecture |
+| Does paused Lexical Gravity v2 need a second apply arm carrying a separate lens IR? | No. Sprint 02B-B replaces the v1 lens with a required v2 `logic` object inside the existing Lexical draft/config flow; it does not introduce a parallel apply contract. | `02b-b-lexical-gravity-interpretive-grammar.md` “Locked decisions” and delivery steps 2–4; ADR 2026-08-01 §§1, 6 | The Lexical union arm evolves after P7; P2 need not invent a second arm |
+| Should generation progress remain generic? | No. Its `dictionary`/`menu` stages and ownership are Gesture-specific; D2 therefore renames progress with generate/menu/cancel while retaining only commit as the generic rail contract. | `workshop.ts:1795-1806`; semantic runway “Transient state” and “Feature-owned one-shot flow”; D2 | Four message renames, not five |
+
+---
+
+## Band 3 — Self-review and Re-plan Verdict
+
+### 3.1 Contradictions found
+
+| Artifact pair | Contradiction | Resolution |
+|---|---|---|
+| Original sprint scope ("standing **and widget-host** contracts under generic owners") ↔ original move list (handler only) | The widget-host half landed on both sides in P1; the standing half was scoped to one side | **F1 / D1** |
+| Sprint scope line 21 ("rename … commit messages honestly") ↔ `workshopWidgets.ts` rail catalog | Commit is a family rail with six declared members | **F3 / D2** |
+| Semantic-runway destination (no `…Frames.ts`) ↔ `Frames`' five production call sites | Folding it is wider than this sprint's boundary | **D4(b)** + ADR §7 deviation note |
+| Exception ledger "exact known" ↔ two unlisted generic modules owning LG grammar | The ledger under-reports | **F7 / D5** |
+| Epic phase table (P2 installs #2, #4, #8, #9) ↔ original sprint scope (one fixture bullet) | Four witnesses, one bullet | Accepted sprint plan now names all four and their invariants |
+| ADR §3 ("generic must not own … one feature's writer-facing copy") ↔ `…Service.ts:53,56` + dispatcher toast | Generic modules write Lexical's copy | **F8 / F1** |
+
+### 3.2 Prospective failure review
+
+| Failure story | Cause | Missing evidence | Prevention |
+|---|---|---|---|
+| Prose Controller ships in P8+; installing it shows the Lexical Gravity modal's success state | LG hook filters on `action` alone; no widget/family key | No correlation field exists | **F2** / D3(a) |
+| Prose Controller's rail entry renders as a blank grey pill | `WorkshopStandingDirectiveRail.tsx:25` `default: return ''` | No exhaustiveness guard | **F5** |
+| P7 audit finds two false generics nobody assigned | They were discovered in P2 and left unrecorded because the ledger "may only shrink" | — | **F7** / D5(a) |
+| A second one-shot widget arrives and the commit message must be renamed *again* | P2 renamed it Gesture-specific | Catalog rail evidence not consulted | **F3** / D2(a) |
+| The generic handler reports `widgetId: 'lexical-gravity'` on a Prose Controller removal failure | Lexical defaults travelled with the moved code | — | **F8** |
+| P3 re-derives a standing presentation owner from scratch | D1 deferred; `useLexicalGravity` kept `remove` | — | D1(a) now |
+
+### 3.3 Reproduction test (measured at end of P2)
+
+**Next variant:** Prose Controller, standing arm only.
+**Adds:** an Operations entry, a Presentation summary arm (the throw at `…Presentation.ts:33` becomes a real case), a rail formatter entry, a feature handler + hook + modal, an apply-payload union arm, its own tests.
+**Must edit (generic, by design):** `WorkshopStandingDirectiveOperations`, `WorkshopStandingDirectivePresentation`, the rail formatter registry, the apply-payload union — **four closed-registry entries.**
+**Must edit (feature-owned):** none — *provided* D1 lands. Without D1, it must also edit `useLexicalGravity`/`WorkshopApp` to unhook `remove`.
+**Verdict:** P2 with D1 delivers the epic's headline property — **zero `lexicalGravity/**` diff lines** — three phases before P7. Without D1 it delivers half of it and hands the rest to P3.
+
+### 3.4 Re-plan verdict: **REFINED**
+
+**Initial plan:** execute the sprint's six scope bullets — new standing handler, split preparation from kernel, add correlation, rename Gesture messages, keep unions exact, add a second-family fixture.
+
+**Final plan:** the same six, plus (1) a presentation-side generic standing owner so the boundary is honest on both sides (D1), (2) `WORKSHOP_COMMIT_WIDGET` **excluded** from the rename list and narrowed by union instead (D2), (3) a request token spanning all three action-bearing requests rather than standing alone (D3), (4) `…Frames.ts` retained as a documented ADR §7 deviation while its renderer entry moves into Operations (D4), (5) two newly discovered false generics recorded as P6 exceptions with the ledger rule amended to permit it (D5), and (6) fitness #2/#4/#8/#9 named individually in scope rather than compressed into one fixture bullet.
+
+**What changed and why:** the sprint's completion criteria are correct and its named moves are correct; what they under-specify is *where the family boundary actually runs*. Three of the five modules that must be generic after P2 — the rail, the fan-out dispatcher, and the widget-runtime bundle — are not in the sprint's file list at all, and two of them are already generic in name while encoding Lexical Gravity in body. Reading the completion criteria against the presentation layer, rather than against the handler layer they were written for, turned "move two routes" into "make the family seam honest on both sides."
+
+**Evidence that caused the change:** `WorkshopStandingDirectiveRail.tsx:1` (self-declared generic) read against `:11-13` (imports the Lexical formatter) and `WorkshopApp.tsx:1497` (`onRemove={lexicalGravity.remove}`); and `workshopWidgets.ts:84-162` (six `rail: 'oneshot'` descriptors) read against scope line 21's instruction to rename commit.
+
+**Remaining uncertainty:** none that reverses the plan. P3 may later relocate generic toast rendering as part of shell decomposition, but D1 fixes the P2 owner as `useWorkshopStandingDirectives`; the copy cannot remain in a feature hook or the current generic fan-out dispatcher.
+
+### 3.5 Implementation gate
+
+| Condition | Pass/fail | Evidence |
+|---|---|---|
+| No unaccepted critical unknown | **PASS** | The three candidate reversal questions are resolved in §2.11; none remains open |
+| Contract consumers / migration / tests identified | **PASS** | Fan-in measured per message cluster (≤5 production files); D2 keeps commit generic, D3 fixes the token scope |
+| Persistence failure and rescue defined | **N/A — PASS** | No stored shape changes; the fixture does not add Prose Controller to the live widget-config union |
+| Runtime flows owned and testable | **PASS** | D3(a) supplies the correlation field; fitness #9 witnesses the three consumers (sprint scope + completion criteria) |
+| Negative-space and reproduction tests pass | **PASS** | D1 gives the standing boundary generic owners on both sides; reproduction target is zero `lexicalGravity/**` diff lines |
+| Tree / responsibilities / contracts / slices agree | **PASS** | All six §3.1 contradictions resolved by D1–D5 and folded into the sprint doc |
+| Human decisions assigned | **PASS** | D1–D5 accepted by Okey on 2026-08-03 and recorded in the sprint doc |
+| Coordination / file ownership recorded | **PASS** | Sole active branch; paused Conversation Widgets branches rebase after the epic (accepted at epic level) |
+
+**Final gate:** `CLEARED` — slices 0–5 completed; verification is recorded in the implementation close-out and sprint document.
+
+---
+
+## Band 4 — Evidence Appendix
+
+### 4.1 Evidence index
+
+| Claim | Anchor |
+|---|---|
+| Family routes registered by the Lexical handler | `WorkshopLexicalGravityHandler.ts:84-91` |
+| Apply/remove bodies to be moved | `…LexicalGravityHandler.ts:248-318` (≈70 lines) |
+| Kernel narrowed to Lexical | `WorkshopStandingDirectiveService.ts:16`, `:48-57` |
+| Kernel is otherwise family-agnostic | `…Service.ts:75-85` (frames before commit), `:112-116` (serialize), `:118-122` (between-runs) |
+| Ledger fully generic | `WorkshopStandingDirectiveLedger.ts:50-133` — no feature literal |
+| Session facade fully generic | `WorkshopSessionService.ts:1045-1146` |
+| Correct closed-registry shapes in-repo | `WorkshopWidgetConfigOperations.ts:27-29, 40-108`; `WorkshopStandingDirectivePresentation.ts:22-38, 68-70` |
+| Incorrect dispatch shapes | `WorkshopStandingDirectiveFrames.ts:22-30`; `WorkshopStandingDirectiveRail.tsx:21-27` |
+| Generic rail imports the Lexical formatter | `WorkshopStandingDirectiveRail.tsx:1, 11-13, 22-24` |
+| Generic dispatcher owns Lexical copy | `dispatchWorkshopWidgetActionResult.ts:28-35` |
+| Rail's remove wired to the Lexical hook | `WorkshopApp.tsx:1497`; hook at `useLexicalGravity.ts:107-109` |
+| No correlation on the action result | `workshop.ts:1966-1978`; consumers `useLexicalGravity.ts:125-127`, `useGesturePlayground.ts:95-101`, `dispatchWorkshopWidgetActionResult.ts:16-24` |
+| Four loose widgetId/draft pairings | `workshop.ts:1768-1785`, `:1795-1806`, `:1813-1827`, `:1940-1946` |
+| Commit is a family rail | `workshopWidgets.ts:17`, `:84, 96, 107, 125, 137, 155` (six `rail: 'oneshot'`); generic `WorkshopThreadArtifactWidgetCommit` in `workshop.ts` |
+| Generic service nested in the feature bundle | `MessageHandler.ts:320-324`; type at `WorkshopHandler.ts:253-260`; use at `:363` |
+| Composition root already generic | `extension.ts:221-224`; `MessageHandlerContracts.ts:127` |
+| Unlisted false generics | `shared/constants/workshopWidgets.ts:19-40`; `utils/workshopWidgetRecommendation.ts:32, 436-441` |
+| Isolation witness is path-selected | `boundaries.test.ts:269-275` (`/GesturePlayground/i`, `/LexicalGravity/i` on the relative path) |
+| Route-owner ledger pins the current (wrong) owners | `boundaries.test.ts:98-106` — commented "Legacy Phase-2 exceptions" |
+| Exception ledger contents and rule | `boundaries.test.ts:146-162` |
+| Duplicate registration already fatal | `MessageRouter.ts:31-35` |
+| `'prose-controller'` already in the persisted union | `workshop.ts:58-60`, `:894`, `:923`, `:944` |
+| Test surface touching standing | 7 files: LG handler (279), standing service, boundaries, rail, dispatcher, `useLexicalGravity`, app router |
+| Message-cluster fan-in (production, excluding `dist/`) | 5 files per cluster for generate/menu/progress/commit/standing; 5 for action result |
+| Relevant source slice unchanged since the earlier evidence SHA | `git diff --name-status c2321c3..0f35294` touches only `promptBudgets`, its test, `WorkshopWidgetConfigs.test.ts`, and `widgetModelsSync.test.ts` |
+| Baseline green | `npx jest …/boundaries.test.ts --runInBand` → 9 passed, 1.9s at `0f35294` |
+
+**Not inspected at this altitude:** `WorkshopGesturePlaygroundModal`'s internal state machine (P3), `workshop.css` (P3), `workshop.ts`'s full family boundaries (P6), `WorkshopHandler`'s non-widget route clusters (P4).
+
+### 4.2 File and module cards
+
+| Path / change | Layer / role | Responsibility and ownership delta | Critical entries / dependencies | Contract or state effect | Verification | Size / evidence |
+|---|---|---|---|---|---|---|
+| `application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts` [+] | Application / family route owner | Gains apply/remove registration, request dispatch, generic result correlation, and standing-operation logs; must not own Lexical draft grammar or copy | `registerRoutes`, apply/remove handlers; calls Operations, directive kernel, session callbacks, transport | Moves two routes; echoes token + exact identity; no persistence change | New handler suite, route-owner ledger, fitness #2/#9 | New ≈100–170 LOC, MODERATE confidence; mold is 50-line `WorkshopWidgetHostHandler` plus ≈70 moved handler lines |
+| `application/services/workshop/directives/WorkshopStandingDirectiveOperations.ts` [+] | Application / closed registry | Owns deliberate family dispatch for draft validation, widget identity, frame rendering, summary/log description | Registry entries call named feature codecs/renderers; consumed by handler, Frames, Presentation, rail formatter adapter | Exact family/draft pairing; no stored shape | Operations tests, exhaustive `never` witness #4, second-family fixture | New ≈80–140 LOC, MODERATE confidence; mold is 108-line `WorkshopWidgetConfigOperations` |
+| `…/WorkshopStandingDirectiveService.ts` [~] | Application / serialized transaction kernel | Loses Lexical pre-flight grammar, literals, and request narrowing; retains queue, between-run guard, frame replacement ordering, atomic commit | `apply`, `remove`, private `serialize`, `assertBetweenRuns`; depends on session + conversation settings | Apply request becomes exact family union; persisted snapshots unchanged | Existing service suite must preserve ordering, rejection, and atomicity | 123 LOC → ≈80–110, MODERATE confidence; anchors `:42-122` |
+| `…/WorkshopStandingDirectiveFrames.ts` [~] and `…Presentation.ts` [~] | Application / thin callers over Operations | Frames retains five public call sites but delegates feature rendering; Presentation delegates feature summary while retaining generic marker behavior (D4) | Existing render/summarize/marker functions remain callable | No frame or summary shape change | Existing service/session/rail tests + golden frame assertions | 64 + 70 LOC → similar or smaller, MODERATE confidence |
+| `…/widgets/lexicalGravity/WorkshopLexicalGravityHandler.ts` [~] | Application / feature handler | Loses family routes, directive service dependency, apply/remove bodies, and generic failure defaults; retains lens catalog/build/preview/save | `registerRoutes` keeps four Lexical routes | No longer consumes generic standing requests | Split/move existing 279-line handler test; feature isolation witness | 347 LOC → ≈250–280, MODERATE confidence; moved body `:248-318` |
+| `WorkshopHandler.ts` [~] + `MessageHandler.ts` [~] | Application / composition wiring | Lift directive runtime from `lexicalGravity` arm to sibling `standingDirectives`; construct/register new handler without changing composition-root ownership | `WorkshopWidgetRuntime`, Workshop handler constructor, MessageHandler local bundle | Internal DI contract only; `CoreServices` unchanged | Typecheck, Workshop assembly tests, forbidden-construction witness | Wiring-scale delta; current anchors `WorkshopHandler.ts:253-364`, `MessageHandler.ts:320-324` |
+| `shared/types/messages/base.ts` [~] + `workshop.ts` [~] | Shared / wire contracts | Rename four Gesture-only messages; keep commit generic; make four payloads exact; add request correlation to three requests and shared result | Message enum, request/result payload unions, exported barrel consumers | **Breaking alpha wire change**; no persistence schema change | Cross-project typecheck, router tests, type fixture #8, correlation witness #9 | `workshop.ts` 1,982 LOC before; high review pressure due fan-in, not due algorithmic complexity |
+| `hooks/domain/workshop/useWorkshopStandingDirectives.ts` [+] | Presentation / generic family hook | Gains remove request, removal correlation, acknowledgement copy; prevents generic rail from depending on Lexical hook | Posts remove message; consumes exact action result; composed by `WorkshopApp`/router | Ephemeral request token only; no persisted hook state | Hook + router + dispatcher tests; presentation half of fitness #2/#9 | New ≈50–90 LOC, MODERATE confidence; mold is `useWorkshopWidgetHost` |
+| `useLexicalGravity.ts` [~], action-result dispatcher [~], rail [~], `WorkshopApp.tsx` [~] | Presentation / feature state + shell wiring | Lexical hook loses remove/generic result ownership; dispatcher loses Lexical copy; rail uses exhaustive formatting; app wires generic hook | Apply result remains feature-owned but exact; remove flows through generic hook | Ephemeral correlation only | Existing hook/rail/dispatcher/router suites | 159 LOC hook → ≈125–140; other deltas wiring-scale |
+| `boundaries.test.ts` [~] + focused fixtures [+] | Test / architecture witnesses | Amend migration-ledger semantics, move route ownership, install #2/#4/#8/#9, prove test-only second family | Static source scans, type fixtures, router/handler exercise | No production contract | Each witness must fail on a deliberate local mutation before close-out | Test-only; exact size follows witness clarity, not a target LOC |
+
+### 4.3 Genealogy and precedent
+
+| Evidence | What changed historically | Architectural lesson | Confidence |
+|---|---|---|---|
+| `50a1f1f feat(widgets)` | Introduced registry, shared contracts, model scope, and session-owned config spine | The catalog and aggregate are intentionally shared; feature workflows are not automatically generic | STRONG |
+| `bd44161 feat(workshop): add lexical gravity standing directive` + `a247a7a` review fix | Added the first standing feature before a second implementation could test the family seam | The present false generics are lineage from a one-member family, not evidence that Lexical should own the family | STRONG |
+| `44dc1ea` / PR #101 | Installed Phase-0 architecture ledgers and migration exceptions | Route ownership and false-generic exceptions must change atomically with code | STRONG |
+| `eeded7d`, `6ff30ed` / PR #102 | Normalized Gesture/Lexical feature slices and added generic widget-host owners on both sides | `WorkshopWidgetHostHandler` + `useWorkshopWidgetHost` are the verified P2 ownership mold | STRONG |
+| `c2321c3..0f35294` | Added prompt-budget and model-sync safeguards only | The current P2 ownership evidence did not drift after the earlier analysis SHA | STRONG |
+
+### 4.4 Fitness witnesses
+
+| Rule | Automated witness | Failure signal |
+|---|---|---|
+| #2 — family standing routes and presentation mechanics have generic owners | Route-owner ledger plus a presentation scan forbidding the remove request and `remove-standing` result ownership in feature hooks | Exact offending route/message and owner path |
+| #4 — every generic→feature dispatch is closed | Source/contract witness requiring a registry object or `never`-guarded exhaustive switch in the standing slice | File and uncovered family/dispatch site |
+| #8 — feature identity and body cannot disagree | Type-level positive fixtures plus `@ts-expect-error` invalid generate/progress/menu/commit pairings | Typecheck unexpectedly accepts an invalid pair or rejects a valid arm |
+| #9 — stale/cross-feature results cannot settle | Hook tests for commit/apply/remove using wrong token, wrong widget, and stale token; exact filter assertion | Consumer accepts any result without both token and identity |
+| Second-family reproduction | Test-only Prose Controller Operations stub driven apply → commit → remove plus route-owner assertion | Lexical feature file edit required, duplicate route registration, or missing registry entry |
+| Baseline architecture | Existing `boundaries.test.ts` suite | Any of the current 9 witnesses regresses during the refactor |
+
+### 4.5 ADR amendment seed
+
+**Context:** The accepted module-boundaries ADR defines generic family mechanics and feature-owned semantics, but its destination map omits `WorkshopStandingDirectiveFrames` and its migration-ledger wording forbids recording newly discovered pre-existing violations.
+
+**Decision candidates:** (1) fold Frames now or retain it as a thin caller; (2) freeze the initial exception list or permit evidence-backed additions with an owning phase.
+
+**Recommended / accepted direction:** Record D4(b) as a §7 deviation: retain Frames because of its five production consumers and move only renderer dispatch into Operations. Record D5(a): a phase may add a newly discovered pre-existing exception when it names the owning cleanup phase; after that phase's inventory is recorded, its list may only shrink.
+
+**Consequences:** P2 stays within its contract/ownership boundary; P6 owns the two newly recorded false generics; the ledger remains an honest evidence inventory rather than a green-by-omission scorecard.
+
+**Unresolved questions:** None for the amendment. The ADR edit itself belongs to Slice 0 and is not represented as landed by this runway.
+
+---
+
+## Band 5 — Reader Terms Appendix
+
+### Technical
+
+| Term | Local meaning in this change | Why the reader needs it | Status |
+|---|---|---|---|
+| **Standing route** | `WORKSHOP_APPLY_STANDING_WIDGET` / `…REMOVE…`. Family-generic by contract, registered by Lexical Gravity's handler today. Moving them is the sprint's headline. | The two lines the whole phase exists to relocate | current |
+| **Transaction kernel** | The part of `WorkshopStandingDirectiveService` that serializes mutations, refuses to run mid-response, replaces prompt frames, then commits atomically. *Must not change* — only its request type does. | Prevents a reviewer reading "split the service" as "rewrite the transaction" | current |
+| **Closed registry** | Explicit dispatch among a compile-time-known set of feature variants, guarded by a mapped `Record`/exhaustive type so a new family fails to compile. *Divergent from the conventional "registry":* nothing registers at runtime. | Fitness #4's subject and the implemented standing operations seam | implemented |
+| **Operations module** | The repo's name for a closed registry supplying per-feature behavior to a generic owner (`WorkshopWidgetConfigOperations`). P2 adds the standing equivalent. | Names the shape of the new file | current (widgets) / proposed (directives) |
+| **False generic / false specific** | A generic-named module encoding one feature (the epic's defect), and its mirror — a feature-named module owning family behavior (the risk P1 flagged). P2 can create the latter by moving Lexical defaults into a generic handler (F8). | Both failure modes are live in this sprint | current |
+| **Action result correlation** | Matching an acknowledgement to the request that caused it, by echoed token plus feature identity. | Prevents stale and cross-feature UI settlement | implemented |
+| **Route owner ledger** | The declared `messageType → file` map in `boundaries.test.ts`. It currently *records* the wrong owners as documented Phase-2 exceptions; P2 corrects the entries. | A green ledger today does not mean correct ownership | current |
+| **Migration exception** | A phase-assigned entry recording known false ownership. Current code says the list may only shrink; D5's accepted target permits recording newly discovered pre-existing violations when an owning phase is named, then requires shrinkage within that phase. | F7 and slice 0 turn on this rule | current rule / accepted target |
+| **Fitness witness** | An executable architecture assertion in `boundaries.test.ts`. P2 owns four: #2 generic standing ownership, #4 closed dispatch, #8 exact pairings, #9 correlation. | The original sprint compressed them; the accepted plan enumerates each one | #2 partial, #4/#8/#9 absent |
+| **Fan-out** | One inbound message dispatched to several consumers at `dispatchWorkshopWidgetActionResult`. P1 gave it a testable seam; P2 must make its filters exact. | F2's surface | current |
+
+### Domain
+
+| Term | Local meaning | Why the reader needs it | Status |
+|---|---|---|---|
+| **Standing family** | A closed key (`lexical-gravity` \| `prose-controller`) naming one persistent prompt-frame slot. At most one active directive per family. | The generic axis P2 makes real | current (one live member) |
+| **Rail** | How a widget joins the room: `oneshot` (commits a thread artifact), `standing` (installs a persistent frame), `resource`. Six catalog entries declare `oneshot`. | F3/D2 turn entirely on this | current |
+| **Prompt frame** | The bounded text a standing directive injects into every subsequent run. Replaced *before* the session commit so provider history and session history cannot disagree. | The invariant P2 must not disturb | current |
+| **Widget config (`wc-N`)** | A session-owned, revisioned snapshot of a widget's authoring draft. Standing widgets edit in place and increment; one-shot stays at revision 1. | The generic/feature seam runs through it | current |
+| **Lexical Gravity** | The live standing widget: project lenses biasing word choice. Owns the family's routes today; loses them here. | The subject of every removal in this sprint | current |
+| **Prose Controller** | The planned second standing family. Already present in the persisted family union and in several dispatches (as an explicit throw), but frozen as a feature. | The reproduction test's subject — a fixture, not shipped behavior | declared, unimplemented |
+| **Feature freeze** | ADR §1 — no new Workshop feature behavior until P7 closes. A Prose Controller *test fixture* is refactor work; a Prose Controller *feature* is not. | Keeps F9's fixture on the right side of the freeze | current |

--- a/docs/pr-reviews/pr-103-shared-route-contract-ownership-review.md
+++ b/docs/pr-reviews/pr-103-shared-route-contract-ownership-review.md
@@ -1,0 +1,314 @@
+# PR Review — Sprint 02: Shared Route and Contract Ownership
+
+**Author:** okeylanders · **PR:** [#103](https://github.com/okeylanders/prose-minion-vscode/pull/103) (Open)
+**Branches:** `sprint/workshop-architecture-refactor-02-shared-ownership` → `epic/workshop-architecture-refactor`
+**Base:** `0f35294` · **Head:** `fbaeb23` · **Scope:** 43 files · +2,163 / −572
+**Reviewed:** 2026-08-04 · **Mode:** `/mr-review` — PR mode, Forge crew (10 specialists + Sensei)
+
+## Resolution ledger
+
+Status legend: **Open** = act before merge · **Deferred** = accepted follow-up with reason · **Addressed** = fixed · **Partially addressed** = fixed with remainder · **N/A** = praise, superseded, or not actionable.
+
+| ID | Sev | Finding | Reviewers | Signal | Status |
+| --- | --- | --- | --- | --- | --- |
+| F-01 | 🟠 High | Overlapping removals overwrite the single `pendingRemovalRef`; the ack that actually removed the directive is discarded and the writer sees "was already removed" | Sam | 1 independent | **Addressed** — token-keyed pending removals settle independently; duplicate same-family requests are refused and each pending rail row is disabled |
+| F-02 | 🟠 High | Correlation makes mismatched acks silent by design — no toast, no log, no timeout, no spinner reset, across three hooks | Oliver | 1 independent (same seam as F-01) | **Addressed** — all three owners log rejected relevant acks; standing removals also time out after 10 seconds, release pending UI, and show an error toast |
+| F-03 | 🟡 Standard | `widgetIdForFamily` runs outside the `try` on the one route whose contract is "always answer"; a registry miss posts no ack at all | Blake, Patricia | 🎯 2 independent | **Addressed** — lookup moved inside the response guard; unknown registry families fail with a domain error and still receive a correlated failure ack |
+| F-04 | 🟡 Standard | Standing rail still imports the application-layer operations singleton directly, dragging ~526 lines of backend validation into the webview bundle | Marcus, Tim | 🎯 2 independent | **Addressed** — summary formatting now reaches the rail through `useWorkshopStandingDirectives`; the rail no longer imports the backend operations/validation graph |
+| F-05 | 🟡 Standard | The new registry claims to mirror `WorkshopWidgetConfigOperations` but uses a mapped type + `satisfies` + an unsafe cast where the exemplar uses `switch` + `never` | Parker | 1 independent | **Addressed** — apply preparation now uses an explicit request union plus exhaustive `switch`/`never` dispatch, with no cast |
+| F-06 | 🟡 Standard | Five near-identical family/widgetId narrowing guards with five different error strings in the Lexical operations entry | Parker | 1 independent | **Addressed** — identity and rendering narrowing now live in two shared checked helpers used by every operation |
+| F-07 | 🟡 Standard | The handler's own cross-widget guard has no test forcing it to fire — the mock always returns a matching `widgetId` | Cal | 1 independent | **Addressed** — regression forces a cross-widget result and asserts the failure ack plus committed-state resync |
+| F-08 | 🟡 Standard | `useWorkshopStandingDirectives` omits the tripartite `State` interface every sibling hook exports | Stan | 1 independent | **Addressed** — exported State/Actions/Persistence now expose the pending widget identities as domain state |
+| F-09 | 🟡 Standard | Post-commit identity guard in `handleApply` throws after the atomic mutation lands and skips `postSessionState` — carried forward unchanged from pre-PR code | Sam | 1 independent | **Addressed** — committed turn/session/dirty state is synchronized before the defense-in-depth identity guard can reject the ack |
+| F-10 | 🟢 Nit | `describe()` renders a full prompt frame just to log its length, and re-checks a condition its callee already threw on | Tim, Parker | 🎯 2 independent | **Addressed** — description uses the checked config's lens, weight, and reach without rendering a prompt frame |
+| F-11 | 🟢 Nit | The `onBlocked` path is the one failure path in the new handler that never touches the output channel | Oliver | 1 independent | **Addressed** — blocked apply/remove mutations log the action and gate reason before posting the failure ack |
+| F-12 | 🟢 Nit | The sprint landed as one commit though ADR §9 forbids moves and behavior changes sharing a commit, and the sprint doc planned six reviewable slices | Ada (orchestrator) | 1 independent | **Deferred** — the reviewed commit is already published; resolution work lands as a separate commit rather than force-rewriting PR history |
+| F-13 | 🟢 Praise | Exactly one action result per request token on every exit path, including the mutation-gate rejection path; feature literals crossed into generic code as data, not defaults | Blake | 1 independent | **N/A** |
+| F-14 | 🟢 Praise | The pre-implementation runway's risk list (F1/F2/F5/F6/F7/F8) is genuinely closed, verified against the diff rather than the sprint doc's checkmarks | Marcus | 1 independent | **N/A** |
+| F-15 | 🟢 Praise | Correlation tests assert *rejection* of stale and foreign acks, not just acceptance of matching ones | Cal | 1 independent | **N/A** |
+| F-16 | 🟢 Praise | The second-family fixture drives a synthetic family through the real injected seam rather than asserting on file diffs | Cal | 1 independent | **N/A** |
+| F-17 | 🟢 Praise | Config-edit ownership is enforced server-side against the session, never trusted from the payload | Patricia | 1 independent | **N/A** |
+| F-18 | 🟢 Praise | Diagnostic detail from the old feature handler survived the extraction intact | Oliver | 1 independent | **N/A** |
+| F-19 | 🟢 Praise | Zero gaps between the sprint's stated requirements and the code, including the D2 union, the ledger P2→P6 move, and the ADR §1 feature freeze | Bria | 1 independent | **N/A** |
+
+---
+
+## Resolution notes
+
+Resolved 2026-08-04. Focused verification covers concurrent and duplicate removals,
+acknowledgement rejection and timeout visibility, runtime registry misses, the
+post-commit cross-widget guard, rail pending state, and the closed-registry
+architecture witness. F-12 remains historical: preserving published review
+history is safer than force-rewriting the branch after review.
+
+---
+
+## Blast Radius
+
+- 43 files · +2,163 / −572 · **1 commit**
+- New production files: 5 · New test files: 3 · Migrations: none · Persisted shapes: **unchanged**
+- Composition root (`extension.ts`): **untouched**, as the sprint promised
+- Wire contract: 4 message renames, 5 payload unions, 1 new correlation field — free under alpha rules
+
+---
+
+## Report Card
+
+| Category | Grade |
+| --- | --- |
+| 🏛️ Architecture | B+ |
+| 🛡️ Security | B |
+| 🧪 Tests | B+ |
+| 📖 Quality | B− |
+| ⚡ Performance | B |
+| 🎯 Domain | A |
+
+---
+
+## Executive Briefing
+
+🟠 **[Sam]** **Overlapping removals drop the acknowledgement that mattered** — a single `pendingRemovalRef` is overwritten by a second `remove()`; the first result (the one that actually removed it) is discarded and the writer sees "was already removed."
+
+🟠 **[Oliver]** **Correlation made mismatched acknowledgements silent by design** — no toast, no log, no timeout, no spinner reset. Three silent-drop sites created by one new pattern.
+
+🟡 **[Blake + Patricia]** 🎯 **`widgetIdForFamily` runs outside the try** on the one route whose entire contract is "always answer." Unreachable today; wrong shape regardless.
+
+🟡 **[Marcus + Tim]** 🎯 **The rail still reaches past its own hook into application services** — and Tim traced the cost: ~526 lines of backend validation code dragged into the webview bundle to reach one formatter.
+
+🟡 **[Parker]** **The registry doesn't read like the registry it claims to mirror** — mapped type + `satisfies` + an unsafe cast, over a single-member union, where the exemplar next door uses a `switch` and a `never`.
+
+---
+
+## 🏛️ Marcus · Architecture & Design
+
+### 🟡 Standard — Rail component still reaches past Domain Hooks into Application services [🎯 Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.tsx:8`
+
+The `onRemove` path is genuinely fixed — D1's presentation-side ownership gap is closed. But `directiveConfig` still imports `WORKSHOP_STANDING_DIRECTIVE_OPERATIONS`, an application-layer singleton, and calls `.formatSummary()` at render time. Not a new violation — the prior code imported `formatLexicalGravitySummary` from the same layer — but this PR touched this exact import line and had the natural opening to route formatting through `useWorkshopStandingDirectives` alongside `remove` and `handleActionResult`, finishing D1's "both sides" story instead of half-finishing it.
+
+### 🟢 Praise — The runway's risk list is genuinely closed, not claimed closed
+
+I traced each HIGH/MED risk from the pre-implementation runway against the diff rather than the sprint doc's checkmarks. F8: the handler echoes the request's own identity on failure instead of defaulting to `'lexical-gravity'`. F2: both feature hooks gate on `requestToken && widgetId`. F5: Frames, Presentation, and the rail all delegate to the closed registry — no `if`/`throw`, no silent `default: return ''`. F6: `WorkshopWidgetRuntime.standingDirectives` is a sibling, not nested under Lexical. F7: the exception ledger was updated in the same commit rather than silently dropped. This is the rare refactor PR where the "what we found vs. what we shipped" story holds up under an independent read.
+
+> *"The bones here were mapped before they were built, and for once the load-bearing walls match the blueprint — my only nit is a rail component still borrowing the application layer's phone instead of dialing through the hook standing right next to it."* — Marcus
+
+---
+
+## 🔥 Blake · Critical / Blocking Issues
+
+### 🟡 Standard — `handleRemove` resolves widget identity outside the try [🎯 Consensus]
+
+`packages/core/src/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts:103`
+
+Every other ack-bearing statement in this file is inside a try that guarantees exactly one `WORKSHOP_WIDGET_ACTION_RESULT`. This one is not. `widgetIdForFamily` is `entries[family].widgetId` — an unguarded index. Contrast `handleApply`, where the equivalent `prepareApply(...)` is correctly inside the try. Not reachable today: `WorkshopStandingDirectiveOperationEntries` is a `Record<Family, Entry>`, so a missing entry fails to compile. Searched diff for a test covering an unmapped family on remove — not found. One-line fix. Not a merge blocker; it is the one asymmetry on a path whose whole contract is "exactly one ack."
+
+### 🟢 Praise — Correlation covers the blocked-mutation path, where this bug class usually hides
+
+The `registerMutation` 4th-parameter change from `(message: string)` to `(reason, message)` is what makes the gate path correlatable. I traced every exit from `handleApply`, `handleRemove`, and `handleCommit` — including `onRoomAccepted` → later failure, guarded by the `accepted` flag: exactly one action result per request token on every path. The transaction kernel is untouched. And the feature literals that moved into generic code moved as **data** on the request (`editConflictMessage`, `alreadyActiveMessage`), not as defaults. That's the correct shape.
+
+> *"One unguarded lookup on the only path whose whole job is 'always answer.' Move it two lines down and I'll go back to bed."* — Blake
+
+---
+
+## 🔍 Sam · Bug Hunter
+
+### 🟠 High — Single `pendingRemovalRef` drops the acknowledgement for an in-flight removal
+
+`packages/core/src/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.ts:47`
+
+`remove()` unconditionally overwrites the ref; `handleActionResult` only accepts an ack matching the *current* value. The rail's button has no per-item in-flight disable — `disabled` is the global `showLiveTurn || roomMutationLocked`, and `roomMutationLocked` tracks runs, wizards, and session actions, **not** a pending removal. So: click 1 → `ref = tokenA`; click 2 before the ack → `ref = tokenB`. The backend serializes correctly and posts `{tokenA, removed: true}` then `{tokenB, removed: false}`. The tokenA ack — the one that actually did the work — fails the identity check and is silently discarded. The writer sees "was already removed." No data corruption; the acknowledgement UX just lies about which request changed state. Worth a queue or in-flight guard before a second family makes this rail routinely show 2+ removable directives.
+
+### 🟡 Standard — Throw-after-commit skips the resync
+
+`packages/core/src/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts:72`
+
+By the time `directives.apply()` resolves, `commitStandingDirectiveMutation` has already run. If this guard fired, the catch posts `ok: false` but never calls `postTurn`/`postSessionState`/`markDirty` — session mutated, client told it failed, no resync. The pre-PR code has the identical shape in `WorkshopLexicalGravityHandler.handleApply`. **Carried forward, not introduced.** Flagged at Standard because today's single-entry registry makes it unreachable — but it's exactly the trap a second family's new wiring could hit.
+
+> *"Found the trap door on the remove rail — it's not the empty-list case, it's the two-carts-on-one-track case: fire remove twice before the first ack lands, and the ref that's supposed to remember 'who I'm waiting for' just forgets the first cart entirely."* — Sam
+
+---
+
+## 📖 Parker · Code Quality
+
+### 🟡 Standard — Registry style diverges sharply from the convention it names
+
+`packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveOperations.ts:18-27, 106-118`
+
+The sprint doc calls this "a closed registry mirroring `WorkshopWidgetConfigOperations`," but they don't read alike. The exemplar is a plain object of functions with `switch (input.widgetId) { … default: return unsupportedConfig(input) }` — compiler-verified `never` fall-through, no casts. This file uses a mapped type keyed by `Payload['widgetId']`, a `satisfies`-typed preparer record, and — because TS can't call a union of narrowed signatures — casts the lookup back to a non-narrowed one. That cast is exactly what the neighbouring `switch`/`never` avoids for free, and `WorkshopApplyStandingWidgetPayload` currently has **one** member, so all this machinery type-checks a single-key object. Drop the mapped type and dispatch with the same `switch` shape: same exactness, zero casts, reads like its neighbour.
+
+### 🟡 Standard — Five near-identical family guards in the Lexical entry
+
+`packages/core/src/application/services/workshop/widgets/lexicalGravity/LexicalGravityStandingDirectiveOperations.ts:20-25`
+
+`render`, `summarize`, `markerContent`, `formatSummary`, and `describe` each re-derive the same narrowing with slightly different member lists and error text ("has the wrong config" / "has the wrong identity" / "cannot format"). One piece of knowledge encoded five ways; a sixth method can silently forget it. A single `asLexicalGravityDirective(directive, config?)` helper says it once.
+
+### 🟢 Nit — `describe()` does redundant work, twice over
+
+`packages/core/src/application/services/workshop/widgets/lexicalGravity/LexicalGravityStandingDirectiveOperations.ts:82-86`
+
+Parker: `renderLexicalGravityDirective` already throws on a wrong `widgetId`, so the re-check right after is dead on the failure path. Tim: it also renders the *entire* prompt frame purely to report `frame.length` in a log line.
+
+> *"The apply-preparer needs a mapped type, a `satisfies`, and an unsafe cast to do what its neighbour does with a `switch` and a `never` — that's not exactness, that's a costume for exactness."* — Parker
+
+---
+
+## 🧪 Cal · Test Coverage & Quality
+
+### 🟡 Standard — The handler's own cross-widget guard has no test forcing it to fire
+
+`packages/core/src/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts:71-73`
+
+This is defense-in-depth against a service bug making one family's apply settle another's config — directly on-point for the sprint's own "cross-feature acknowledgements cannot settle another feature" criterion. The only `handleApply` test mocks `directives.apply` to always return a matching `widgetId`, so the branch never executes. A regression that dropped or reworded this check would go undetected.
+
+### 🟢 Praise — Correlation tests assert rejection, not just acceptance
+
+`packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.test.ts:45-70`
+
+Both the standing hook and `useLexicalGravity` tests fire a stale-token result **and** a wrong-widgetId result, assert nothing settles, and only then send the matching one. That's the harder, more valuable half of a correlation test — most PRs prove only that the happy path settles. This one proves the trapdoor and the railing.
+
+### 🟢 Praise — The second-family fixture exercises the real seam
+
+Rather than asserting on file-diff line counts (which the epic criterion literally names), the test drives a wholly synthetic `prose-controller` family through `apply`/`remove` using only the injected operations seam. Combined with the `Record<WorkshopStandingDirectiveFamily, …>` typing — genuinely exhaustive, a new family without an entry fails to compile — that's real confidence the registry is closed and extensible, not a passing string-scan.
+
+> *"The stale-token check isn't decoration here — I traced it, and it actually gets asserted false before the real one gets asserted true. Now go write the one test that watches your own guard clause throw."* — Cal
+
+---
+
+## 🗂️ Stan · Codebase Standards
+
+### 🟡 Standard — `useWorkshopStandingDirectives` skips the tripartite State interface
+
+`packages/core/src/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.ts:24`
+
+Every other domain hook exports all three interfaces even when one is empty — including this file's own sibling `useWorkshopWidgetHost.ts`, which exports `State`, `Actions`, and `Persistence` at lines 11, 17, 23. `WorkshopWidgetHostPersistence` is declared empty with an explanatory comment, and that comment is reused verbatim here for Persistence — but State is dropped entirely, and the composed return type is `Actions & { persistedState }`. `CLAUDE.md` documents the pattern as all three, always exported.
+
+> *"We already have the 'declare it empty and comment why' move sitting right there in this same file for Persistence — just apply it to State too."* — Stan
+
+---
+
+## ⚡ Tim · Performance
+
+### 🟡 Standard — The rail pulls backend validation code into the webview bundle [🎯 Consensus]
+
+`packages/core/src/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.tsx:8`
+
+Before this PR the rail imported only `formatLexicalGravitySummary` — a pure formatter. Now it imports the `WORKSHOP_STANDING_DIRECTIVE_OPERATIONS` singleton, built from the Lexical entry, which does a **value** import of `validateLexicalGravityDraft` from `LexicalGravityConfigCodec.ts`. The import carries no `type` keyword and `validateLexicalGravityDraft` is called inside `prepareApply` on a live registry entry, so it cannot be tree-shaken. That's `LexicalGravityConfigCodec.ts` (308 lines) plus its downstream `persistedValidation.ts` (218 lines) newly reachable from the webview bundle, to get at one formatting function. No runtime cost at this scale — two families, one directive each. Pure bundle weight plus a layering smell.
+
+> *"Two families, one directive each — the math says this is free today. The bundle-size math says otherwise, and nobody's paying that in a profiler."* — Tim
+
+---
+
+## 🛡️ Patricia · Security
+
+### 🟡 Standard — `family` is dereferenced into the registry before any validation [🎯 Consensus]
+
+`packages/core/src/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts:101-104`
+
+`message.payload.family` arrives off the webview→host IPC boundary as `unknown` at runtime — the type is compile-time only. `widgetIdForFamily` indexes the closed registry with no guard, *before* the try. The throw propagates to `MessageHandler.handleMessage`'s top-level catch, which is why this isn't Blocking — the host never crashes. The narrower real consequence: no `WORKSHOP_WIDGET_ACTION_RESULT` is posted, so `pendingRemovalRef` is never cleared and the specific toast never fires; the writer sees only a generic error banner. Practical risk is low — no hostile third party, only our own bundled webview originates these. A stale webview bundle after a partial reload would hit exactly this path.
+
+### 🟢 Praise — Config-edit ownership is correctly scoped
+
+`packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveService.ts:60-69`
+
+A caller-supplied `widgetConfigId` is accepted for in-place revision only if it matches `active.widgetConfigId`, where `active` is looked up server-side via `session.getStandingDirective(family)` — never trusted from the payload. Combined with the `widgetConfigInput.widgetId !== widgetId` check above it, cross-family config confusion is genuinely hard to construct.
+
+> *"The registry lookup trusts the wire before the try block does — the top-level catch saves the host, but not the toast the user was waiting for."* — Patricia
+
+---
+
+## 🌙 Oliver · Observability
+
+### 🟠 High — Stale/mismatched tokens are dropped with zero trail anywhere
+
+`packages/core/src/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.ts:60`
+
+The early-`return` is the entire fate of a non-matching acknowledgement — no toast, no state update, nothing posted back for the `LogSink` to catch. Before this PR, `useLexicalGravity` set `actionResult` unconditionally, so an ack was always visible even if occasionally stale. Correctness improved; the failure trail got **worse**. The refs back the correlation but aren't wired to any loading state, so a writer who clicks remove and gets no ack sees nothing: button doesn't reset, no error, no timeout. Same shape in `useLexicalGravity` and `useGesturePlayground` — three silent-drop sites from one new pattern.
+
+### 🟢 Nit — The `onBlocked` path never touches the output channel
+
+Unlike every other failure path in the new handler, which routes through `errorMessage()` and logs. The writer does get a clear toast, and this mirrors the pre-existing session-mutation pattern, so it's not raised higher — but the handler is new and could have closed the gap while it was being written.
+
+### 🟢 Praise — Diagnostic detail survived the move intact
+
+Compared against the pre-PR `WorkshopLexicalGravityHandler.handleApply` line for line. Revision number, directive-id → config-id mapping, and the feature-supplied `describe()` detail ("lens X, N chars") all made the trip to the generic handler unchanged. This is exactly the kind of extraction where detail quietly evaporates, and it didn't here.
+
+> *"The host logs like a good citizen; the webview just lets the ack vanish into the void, no note left behind."* — Oliver
+
+---
+
+## 🎯 Bria · Domain Logic
+
+**No findings.** Every questioned area was traced against the diff and each implementation matches its stated requirement: D2's commit payload is a genuinely extensible union, not silently collapsed. The `apply-standing`/`remove-standing` `widgetId` asymmetry is correctly explained by the persisted-shape constraint — the config union has no Prose Controller arm, the family union does. The exception ledger's P2→P6 move matches the sprint doc's deferred list exactly. The Prose Controller registry entry refactors pre-existing placeholder throw behavior rather than shipping new feature logic, so ADR §1's freeze holds. The mutation-gate rejection paths never hardcode `'lexical-gravity'`.
+
+> *"I went looking for the trapdoor between 'family-generic' and 'secretly Lexical' — turns out this crew actually welded it shut."* — Bria
+
+---
+
+## 🎓 Sensei · The Teacher
+
+### Lesson 1 — Precision at the boundary is not free; it's paid for in visibility
+
+Illuminated by: Sam's overlapping removals, Oliver's silent drops
+
+Token correlation made the system more *correct* — a stale ack can no longer overwrite live state — but correctness and observability are different axes, and improving one can starve the other. Before, a wrong-but-visible update at least told you something happened. Now a mismatched ack returns early and tells you nothing. The mechanism went from "sometimes wrong" to "sometimes silent," and silent is the worse failure mode: nobody notices until a writer says "I clicked remove and nothing happened."
+
+→ Carry forward: whenever you add a guard whose job is to *reject* something, ask out loud — when this branch fires, does anything see it? If no, it needs a log line or a UI signal before it ships.
+
+### Lesson 2 — The runway finds what you thought to name, not what the fix introduces
+
+Illuminated by: F1–F9 closing cleanly, while both HIGH findings arise from the mechanism the runway prescribed
+
+A risk runway is a map of anticipated terrain. It's excellent at confirming known cliffs were fenced. It cannot see the cliff the fence itself creates, because the fence didn't exist when the map was drawn. Correlation-by-token was the runway's own answer to an earlier risk, and both HIGH findings are second-order consequences of that answer — not gaps in the original analysis. That isn't a failure of the process; it's the boundary of what pre-implementation analysis can do at all.
+
+→ Carry forward: after implementing a mitigation, run one more pass asking "what new failure mode does *this fix* introduce?" Treat the mitigation as fresh code deserving its own mini-runway, not a checkbox against the original risk.
+
+### Lesson 3 — A thing that calls itself a mirror should survive being held up to one
+
+Illuminated by: Parker's registry-pattern and five-guard findings
+
+When code declares an intent — "mirrors `WorkshopWidgetConfigOperations`," "closed registry" — that declaration becomes a contract with the reader, and a mapped-type-plus-cast reads very differently from the exhaustive switch it claims kinship with. Likewise, five hand-written narrowing guards with five different error strings aren't five domain decisions. They're one type-system demand answered five times by hand, which means one true guard and four impostors waiting to drift.
+
+→ Carry forward: when you claim a file mirrors another, open the exemplar side by side before committing. When a guard repeats near-verbatim, ask whether the compiler asked once and you answered N times.
+
+### Lesson 4 — A route whose contract is "always answer" earns its own paranoia
+
+Illuminated by: Blake and Patricia both flagging the pre-try registry lookup
+
+Two reviewers from different lanes converged on the same three lines without coordinating — a strong signal the code is teaching something structural. When every statement in a function lives inside a try except one, the exception isn't a style choice; it's a seam where the function's implicit promise quietly stops being true. That it's unreachable *today* doesn't change the shape of the promise. It just means the crack hasn't been walked on yet.
+
+→ Carry forward: in any handler whose contract is "always respond," treat every statement between request-received and response-sent as inside the try by default. Moving something out should be deliberate and named, not a leftover of typing order.
+
+### Lesson 5 — A sprint plan is a promise about reviewability
+
+Illuminated by: six planned slices landing as one commit, against the ADR's own moves-≠-behavior rule
+
+A plan naming six independently reviewable slices makes an implicit claim to future reviewers and to future-you running `git blame`: you will be able to isolate cause from consequence here. Collapsing it into one commit doesn't undo the work, but it spends the plan's most valuable asset — bisecting intent from implementation later, when the reason for a line is no longer in anyone's head.
+
+→ Carry forward: when a plan commits to N reviewable slices, treat commit boundaries as a deliverable, not a cleanup step.
+
+> *"The fence you build against yesterday's danger has its own shadow — the discipline is in noticing you're now standing in it."* — Sensei
+
+---
+
+## The Closer
+
+### 🎋 Haiku
+
+> Two names for one door —
+> the handler learns its own name;
+> the ack finds no one.
+
+---
+
+## Summary
+
+This is the strongest PR of the epic so far. Every load-bearing claim the sprint doc makes survived independent verification: the transaction kernel is untouched, no persisted shape moved, `extension.ts` wasn't edited, feature literals crossed into generic code as *data* rather than defaults, and the second-family fixture drives a real seam instead of asserting on diff lines. Blake found no blockers; Bria found no requirement gaps.
+
+The two 🟠 High findings share one seam — the new correlation refs — and neither is a correctness bug in the mechanism itself. They're the shadow it casts: an in-flight guard for overlapping removals, and some trail when an ack is dropped. Both are small, local to the webview hooks, and worth doing before merge since the whole point of the sprint was acknowledgements settling correctly.
+
+**Resolution outcome (2026-08-04): merge-ready.** F-01 through F-11 are addressed; F-12 is deferred because correcting historical commit shape would require force-rewriting the already-published review branch.
+
+---
+
+*Reviewed by: Marcus 🏛️ · Blake 🔥 · Sam 🔍 · Parker 📖 · Cal 🧪 · Stan 🗂️ · Tim ⚡ · Patricia 🛡️ · Oliver 🌙 · Bria 🎯 · Sensei 🎓*

--- a/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/WorkshopHandler.test.ts
@@ -301,8 +301,8 @@ describe('WorkshopHandler — Sprint 06B tool side-pass', () => {
     expect(router.hasHandler(MessageType.WORKSHOP_SET_CONVERSATION_SETTINGS)).toBe(true);
     // Conversation Widgets (ADR 2026-07-22): generate + cancel are free
     // preview routes; commit is mutation-gated.
-    expect(router.hasHandler(MessageType.WORKSHOP_WIDGET_GENERATE)).toBe(true);
-    expect(router.hasHandler(MessageType.CANCEL_WIDGET_GENERATE_REQUEST)).toBe(true);
+    expect(router.hasHandler(MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATE)).toBe(true);
+    expect(router.hasHandler(MessageType.CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST)).toBe(true);
     expect(router.hasHandler(MessageType.WORKSHOP_REQUEST_WIDGET_CONFIG)).toBe(true);
     expect(router.hasHandler(MessageType.WORKSHOP_COMMIT_WIDGET)).toBe(true);
     expect(router.handlerCount).toBe(48);

--- a/packages/core/src/__tests__/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.test.ts
@@ -115,10 +115,11 @@ describe('WorkshopStandingDirectiveHandler', () => {
   it('echoes the blocked request token and widget identity', async () => {
     const postMessage = jest.fn().mockResolvedValue(undefined);
     const registerMutation = jest.fn();
+    const appendLine = jest.fn();
     const handler = new WorkshopStandingDirectiveHandler(
       {} as never,
       postMessage,
-      { appendLine: jest.fn() } as never,
+      { appendLine } as never,
       { postSessionState: jest.fn(), postTurn: jest.fn(), markDirty: jest.fn() }
     );
 
@@ -143,6 +144,94 @@ describe('WorkshopStandingDirectiveHandler', () => {
         requestToken: 'remove-blocked',
         widgetId: 'lexical-gravity',
         ok: false
+      })
+    }));
+    expect(appendLine).toHaveBeenCalledWith(
+      '[WorkshopStandingDirectiveHandler] apply-standing blocked: The room is busy.'
+    );
+    expect(appendLine).toHaveBeenCalledWith(
+      '[WorkshopStandingDirectiveHandler] remove-standing blocked: The room is busy.'
+    );
+  });
+
+  it('catches a remove registry miss and still posts the correlated failure ack', async () => {
+    const directives = { remove: jest.fn() };
+    const postMessage = jest.fn().mockResolvedValue(undefined);
+    const operations = {
+      widgetIdForFamily: jest.fn(() => {
+        throw new Error('registry entry missing');
+      })
+    };
+    const handler = new WorkshopStandingDirectiveHandler(
+      directives as never,
+      postMessage,
+      { appendLine: jest.fn() } as never,
+      { postSessionState: jest.fn(), postTurn: jest.fn(), markDirty: jest.fn() },
+      operations as never
+    );
+
+    await handler.handleRemove(removeMessage('remove-registry-miss'));
+
+    expect(directives.remove).not.toHaveBeenCalled();
+    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({
+        action: 'remove-standing',
+        requestToken: 'remove-registry-miss',
+        widgetId: 'lexical-gravity',
+        ok: false,
+        message: 'registry entry missing'
+      })
+    }));
+  });
+
+  it('rejects a cross-widget apply result after resynchronizing committed state', async () => {
+    const directives = {
+      apply: jest.fn().mockResolvedValue({
+        action: 'installed',
+        directiveId: 'pd-1',
+        directive: {
+          id: 'pd-1',
+          family: 'lexical-gravity',
+          widgetId: 'lexical-gravity',
+          widgetConfigId: 'wc-1',
+          revision: 1,
+          updatedAt: 1
+        },
+        config: {
+          id: 'wc-1',
+          widgetId: 'gesture-playground',
+          revision: 1,
+          createdAt: 1,
+          draft: {}
+        },
+        turn: { id: 'turn-1' }
+      })
+    };
+    const postMessage = jest.fn().mockResolvedValue(undefined);
+    const options = {
+      postSessionState: jest.fn(),
+      postTurn: jest.fn(),
+      markDirty: jest.fn()
+    };
+    const handler = new WorkshopStandingDirectiveHandler(
+      directives as never,
+      postMessage,
+      { appendLine: jest.fn() } as never,
+      options
+    );
+
+    await handler.handleApply(applyMessage('apply-cross-widget'));
+
+    expect(options.postTurn).toHaveBeenCalledWith({ id: 'turn-1' });
+    expect(options.postSessionState).toHaveBeenCalledTimes(1);
+    expect(options.markDirty).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({
+        action: 'apply-standing',
+        requestToken: 'apply-cross-widget',
+        widgetId: 'lexical-gravity',
+        ok: false,
+        message: 'Standing directive lexical-gravity produced the wrong widget config'
       })
     }));
   });

--- a/packages/core/src/__tests__/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.test.ts
@@ -1,0 +1,149 @@
+import {
+  WorkshopStandingDirectiveHandler
+} from '@handlers/domain/workshop/WorkshopStandingDirectiveHandler';
+import {
+  builtInLexicalGravityLens
+} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityLenses';
+import {
+  MessageType,
+  WorkshopApplyStandingWidgetMessage,
+  WorkshopRemoveStandingWidgetMessage
+} from '@messages';
+
+const lexicalDraft = {
+  lensSlug: 'photography',
+  weight: 60,
+  reach: 2 as const,
+  metaphorPull: false,
+  resolvedLens: builtInLexicalGravityLens('photography')!
+};
+
+const applyMessage = (requestToken = 'apply-1'): WorkshopApplyStandingWidgetMessage => ({
+  type: MessageType.WORKSHOP_APPLY_STANDING_WIDGET,
+  source: 'webview.test',
+  timestamp: 1,
+  payload: {
+    requestToken,
+    widgetId: 'lexical-gravity',
+    draft: lexicalDraft
+  }
+});
+
+const removeMessage = (requestToken = 'remove-1'): WorkshopRemoveStandingWidgetMessage => ({
+  type: MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
+  source: 'webview.test',
+  timestamp: 2,
+  payload: { requestToken, family: 'lexical-gravity' }
+});
+
+describe('WorkshopStandingDirectiveHandler', () => {
+  it('owns apply and remove lifecycle responses with exact request correlation', async () => {
+    const config = {
+      id: 'wc-1',
+      widgetId: 'lexical-gravity' as const,
+      revision: 1,
+      directiveId: 'pd-1',
+      createdAt: 1,
+      draft: lexicalDraft
+    };
+    const directive = {
+      id: 'pd-1',
+      family: 'lexical-gravity' as const,
+      widgetId: 'lexical-gravity' as const,
+      widgetConfigId: 'wc-1',
+      revision: 1,
+      updatedAt: 1
+    };
+    const directives = {
+      apply: jest.fn().mockResolvedValue({
+        action: 'installed',
+        directiveId: 'pd-1',
+        directive,
+        config,
+        turn: { id: 'turn-1' }
+      }),
+      remove: jest.fn().mockResolvedValue({
+        removed: true,
+        directiveId: 'pd-1',
+        turn: { id: 'turn-2' }
+      })
+    };
+    const postMessage = jest.fn().mockResolvedValue(undefined);
+    const options = {
+      postSessionState: jest.fn(),
+      postTurn: jest.fn(),
+      markDirty: jest.fn()
+    };
+    const handler = new WorkshopStandingDirectiveHandler(
+      directives as never,
+      postMessage,
+      { appendLine: jest.fn() } as never,
+      options
+    );
+
+    await handler.handleApply(applyMessage());
+    await handler.handleRemove(removeMessage());
+
+    expect(directives.apply).toHaveBeenCalledWith(expect.objectContaining({
+      family: 'lexical-gravity',
+      widgetId: 'lexical-gravity',
+      widgetConfigInput: expect.objectContaining({ widgetId: 'lexical-gravity' })
+    }));
+    expect(directives.remove).toHaveBeenCalledWith('lexical-gravity');
+    expect(postMessage).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      payload: expect.objectContaining({
+        action: 'apply-standing',
+        requestToken: 'apply-1',
+        widgetId: 'lexical-gravity',
+        ok: true
+      })
+    }));
+    expect(postMessage).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      payload: expect.objectContaining({
+        action: 'remove-standing',
+        requestToken: 'remove-1',
+        widgetId: 'lexical-gravity',
+        removed: true
+      })
+    }));
+    expect(options.postTurn).toHaveBeenCalledTimes(2);
+    expect(options.markDirty).toHaveBeenCalledTimes(2);
+  });
+
+  it('echoes the blocked request token and widget identity', async () => {
+    const postMessage = jest.fn().mockResolvedValue(undefined);
+    const registerMutation = jest.fn();
+    const handler = new WorkshopStandingDirectiveHandler(
+      {} as never,
+      postMessage,
+      { appendLine: jest.fn() } as never,
+      { postSessionState: jest.fn(), postTurn: jest.fn(), markDirty: jest.fn() }
+    );
+
+    handler.registerRoutes({} as never, registerMutation);
+    const applyBlocked = registerMutation.mock.calls[0][3];
+    const removeBlocked = registerMutation.mock.calls[1][3];
+    applyBlocked('The room is busy.', applyMessage('apply-blocked'));
+    removeBlocked('The room is busy.', removeMessage('remove-blocked'));
+    await Promise.resolve();
+
+    expect(postMessage).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      payload: expect.objectContaining({
+        action: 'apply-standing',
+        requestToken: 'apply-blocked',
+        widgetId: 'lexical-gravity',
+        ok: false
+      })
+    }));
+    expect(postMessage).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      payload: expect.objectContaining({
+        action: 'remove-standing',
+        requestToken: 'remove-blocked',
+        widgetId: 'lexical-gravity',
+        ok: false
+      })
+    }));
+  });
+});

--- a/packages/core/src/__tests__/application/handlers/domain/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundHandler.test.ts
@@ -13,7 +13,7 @@ import {
   MessageType,
   WorkshopCommitWidgetMessage,
   WorkshopGestureDraft,
-  WorkshopWidgetGenerateMessage
+  WorkshopGesturePlaygroundGenerateMessage
 } from '@messages';
 
 const oversizedContextAttachmentId = `ctx-${'9'.repeat(500)}`;
@@ -52,9 +52,9 @@ const draft = (overrides: Partial<WorkshopGestureDraft> = {}): WorkshopGestureDr
 });
 
 const generateMessage = (
-  overrides: Partial<WorkshopWidgetGenerateMessage['payload']> = {}
-): WorkshopWidgetGenerateMessage => ({
-  type: MessageType.WORKSHOP_WIDGET_GENERATE,
+  overrides: Partial<WorkshopGesturePlaygroundGenerateMessage['payload']> = {}
+): WorkshopGesturePlaygroundGenerateMessage => ({
+  type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATE,
   source: 'webview.workshop',
   timestamp: 1,
   payload: {
@@ -67,7 +67,7 @@ const generateMessage = (
     characterNotes: '',
     sourceReferences: [],
     ...overrides
-  } as WorkshopWidgetGenerateMessage['payload']
+  } as WorkshopGesturePlaygroundGenerateMessage['payload']
 });
 
 const commitMessage = (
@@ -78,6 +78,7 @@ const commitMessage = (
   timestamp: 1,
   payload: {
     widgetId: 'gesture-playground',
+    requestToken: 'commit-1',
     draft: draft(),
     ...overrides
   }
@@ -153,7 +154,7 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
   it('returns the menu under the request token', async () => {
     const { handler, posted, generateMenu } = build();
     await handler.handleGenerate(generateMessage());
-    const results = posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT);
+    const results = posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT);
     expect(results).toHaveLength(1);
     expect(results[0].payload).toEqual(expect.objectContaining({
       ok: true,
@@ -189,7 +190,7 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
 
     await handler.handleGenerate(generateMessage());
 
-    const progress = posted(MessageType.WORKSHOP_WIDGET_GENERATION_PROGRESS)
+    const progress = posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS)
       .map((message) => message.payload);
     expect(progress[0]).toEqual(expect.objectContaining({
       token: 'tok-1',
@@ -297,7 +298,7 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
     }));
 
     expect(generateMenu).not.toHaveBeenCalled();
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)[0].payload).toEqual(
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)[0].payload).toEqual(
       expect.objectContaining({
         ok: false,
         error: expect.stringMatching(expected)
@@ -321,9 +322,9 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
     await handler.handleGenerate(generateMessage({ sourceReferences }));
 
     expect(generateMenu).not.toHaveBeenCalled();
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)[0].payload.error)
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)[0].payload.error)
       .toMatch(/no longer available/i);
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)[0].payload.error)
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)[0].payload.error)
       .not.toMatch(/references exceed/i);
   });
 
@@ -338,7 +339,7 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
 
     await handler.handleGenerate(generateMessage());
 
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)[0].payload).toEqual(
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)[0].payload).toEqual(
       expect.objectContaining({
         ok: false,
         dictionaryMarkdown: expect.stringContaining('The scan survived'),
@@ -346,7 +347,7 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
         truncated: true
       })
     );
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)[0].payload.menu).toBeUndefined();
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)[0].payload.menu).toBeUndefined();
   });
 
   it('reports generation failures as a typed result, not a crash', async () => {
@@ -354,7 +355,7 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
       generateMenu: jest.fn().mockRejectedValue(new Error('unusable menu'))
     });
     await handler.handleGenerate(generateMessage());
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)[0].payload).toEqual(
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)[0].payload).toEqual(
       expect.objectContaining({ ok: false, error: expect.stringContaining('unusable menu') })
     );
   });
@@ -365,7 +366,7 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
       generateMessage({ widgetId: 'lexical-gravity' as never })
     );
     expect(generateMenu).not.toHaveBeenCalled();
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)[0].payload.ok).toBe(false);
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)[0].payload.ok).toBe(false);
   });
 
   it('drops the superseded call silently when a regenerate lands first', async () => {
@@ -387,13 +388,13 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
     const second = handler.handleGenerate(generateMessage({ token: 'tok-new' }));
     rejectFirst(new Error('late failure'));
     await Promise.all([first, second]);
-    const results = posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT);
+    const results = posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT);
     expect(results).toHaveLength(1);
     expect(results[0].payload.token).toBe('tok-new');
     expect(appendLine).toHaveBeenCalledWith(expect.stringContaining(
       'token tok-old, reason=superseded'
     ));
-    expect(posted(MessageType.WORKSHOP_WIDGET_GENERATION_PROGRESS)
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS)
       .map((message) => message.payload))
       .toEqual(expect.arrayContaining([
         expect.objectContaining({
@@ -415,29 +416,29 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
     const pending = handler.handleGenerate(generateMessage());
 
     await handler.handleCancelGenerate({
-      type: MessageType.CANCEL_WIDGET_GENERATE_REQUEST,
+      type: MessageType.CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST,
       source: 'webview.workshop.widget',
       timestamp: 2,
-      payload: { domain: 'workshop-widget', requestId: 'not-the-token' }
+      payload: { domain: 'workshop-gesture-playground', requestId: 'not-the-token' }
     });
     expect(activeSignal?.aborted).toBe(false);
 
     await handler.handleCancelGenerate({
-      type: MessageType.CANCEL_WIDGET_GENERATE_REQUEST,
+      type: MessageType.CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST,
       source: 'webview.workshop.widget',
       timestamp: 3,
-      payload: { domain: 'workshop-widget', requestId: 'tok-1' }
+      payload: { domain: 'workshop-gesture-playground', requestId: 'tok-1' }
     });
     await pending;
 
     expect(activeSignal?.aborted).toBe(true);
-    expect(posted(MessageType.WORKSHOP_WIDGET_GENERATION_PROGRESS))
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS))
       .toEqual(expect.arrayContaining([
         expect.objectContaining({
           payload: expect.objectContaining({ token: 'tok-1', phase: 'cancelled' })
         })
       ]));
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)).toHaveLength(0);
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)).toHaveLength(0);
   });
 
   it('merges fresh stateless additions without disturbing the existing options', async () => {
@@ -466,7 +467,7 @@ describe('WorkshopGesturePlaygroundHandler — generate', () => {
       dictionaryMarkdown: draft().dictionaryMarkdown,
       menu
     }));
-    expect(posted(MessageType.WORKSHOP_WIDGET_MENU_RESULT)[0].payload)
+    expect(posted(MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT)[0].payload)
       .toEqual(expect.objectContaining({
         ok: true,
         mode: 'more',

--- a/packages/core/src/__tests__/application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.test.ts
+++ b/packages/core/src/__tests__/application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.test.ts
@@ -41,13 +41,10 @@ describe('WorkshopLexicalGravityHandler generated-lens saves', () => {
     };
     const postMessage = jest.fn().mockResolvedValue(undefined);
     const handler = new WorkshopLexicalGravityHandler(
-      {} as never,
       model as never,
       repository as never,
-      {} as never,
       postMessage,
-      { appendLine: jest.fn() } as never,
-      { postSessionState: jest.fn(), postTurn: jest.fn(), markDirty: jest.fn() }
+      { appendLine: jest.fn() } as never
     );
     return { generated, handler, postMessage, repository };
   };
@@ -71,13 +68,10 @@ describe('WorkshopLexicalGravityHandler generated-lens saves', () => {
     };
     const postMessage = jest.fn().mockResolvedValue(undefined);
     const handler = new WorkshopLexicalGravityHandler(
-      {} as never,
       model as never,
       {} as never,
-      {} as never,
       postMessage,
-      { appendLine: jest.fn() } as never,
-      { postSessionState: jest.fn(), postTurn: jest.fn(), markDirty: jest.fn() }
+      { appendLine: jest.fn() } as never
     );
 
     await handler.handlePreview({
@@ -188,7 +182,6 @@ describe('WorkshopLexicalGravityHandler generated-lens saves', () => {
     const postMessage = jest.fn().mockResolvedValue(undefined);
     const handler = new WorkshopLexicalGravityHandler(
       {} as never,
-      {} as never,
       {
         list: jest.fn().mockResolvedValue([{
           ...source,
@@ -197,10 +190,8 @@ describe('WorkshopLexicalGravityHandler generated-lens saves', () => {
         }]),
         availability: jest.fn().mockReturnValue({ displayPath: 'prose-minion/lenses' })
       } as never,
-      {} as never,
       postMessage,
-      { appendLine: jest.fn() } as never,
-      { postSessionState: jest.fn(), postTurn: jest.fn(), markDirty: jest.fn() }
+      { appendLine: jest.fn() } as never
     );
 
     await handler.handleRequestLenses({
@@ -215,65 +206,4 @@ describe('WorkshopLexicalGravityHandler generated-lens saves', () => {
       .toEqual(expect.objectContaining({ name: 'Photography', source: 'built-in' }));
   });
 
-  it('logs successful install and idempotent removal lifecycle outcomes', async () => {
-    const resolvedLens = builtInLexicalGravityLens('photography')!;
-    const draft = {
-      lensSlug: 'photography',
-      weight: 60,
-      reach: 2 as const,
-      metaphorPull: false,
-      resolvedLens
-    };
-    const config = {
-      id: 'wc-1',
-      widgetId: 'lexical-gravity' as const,
-      revision: 1,
-      directiveId: 'pd-1',
-      createdAt: 1,
-      draft
-    };
-    const appendLine = jest.fn();
-    const postMessage = jest.fn().mockResolvedValue(undefined);
-    const directives = {
-      apply: jest.fn().mockResolvedValue({
-        action: 'installed',
-        directiveId: 'pd-1',
-        config,
-        turn: { id: 'turn-1-system-1' }
-      }),
-      remove: jest.fn().mockResolvedValue({ removed: false })
-    };
-    const handler = new WorkshopLexicalGravityHandler(
-      { getStandingDirective: jest.fn().mockReturnValue(undefined) } as never,
-      {} as never,
-      {} as never,
-      directives as never,
-      postMessage,
-      { appendLine } as never,
-      { postSessionState: jest.fn(), postTurn: jest.fn(), markDirty: jest.fn() }
-    );
-
-    await handler.handleApply({
-      type: MessageType.WORKSHOP_APPLY_STANDING_WIDGET,
-      source: 'webview.test',
-      timestamp: 1,
-      payload: { widgetId: 'lexical-gravity', draft }
-    });
-    await handler.handleRemove({
-      type: MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
-      source: 'webview.test',
-      timestamp: 2,
-      payload: { family: 'lexical-gravity' }
-    });
-
-    expect(appendLine).toHaveBeenCalledWith(expect.stringContaining(
-      'lexical-gravity installed: pd-1 -> wc-1'
-    ));
-    expect(appendLine).toHaveBeenCalledWith(expect.stringContaining(
-      'lexical-gravity remove no-op'
-    ));
-    expect(postMessage).toHaveBeenLastCalledWith(expect.objectContaining({
-      payload: expect.objectContaining({ action: 'remove-standing', ok: true, removed: false })
-    }));
-  });
 });

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopStandingDirectiveService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopStandingDirectiveService.test.ts
@@ -2,6 +2,10 @@ import {
   WorkshopStandingDirectiveService
 } from '@/application/services/workshop/directives/WorkshopStandingDirectiveService';
 import {
+  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS,
+  WorkshopStandingDirectiveOperations
+} from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
+import {
   renderWorkshopStandingDirectiveFramesForSnapshots,
   renderWorkshopStandingDirectiveFramesFromState
 } from '@/application/services/workshop/directives/WorkshopStandingDirectiveFrames';
@@ -44,7 +48,12 @@ const applyLexicalGravity = (
   service: WorkshopStandingDirectiveService,
   nextDraft: WorkshopLexicalGravityDraft,
   widgetConfigId?: string
-) => service.apply({ family: 'lexical-gravity', draft: nextDraft, widgetConfigId });
+) => service.apply(WORKSHOP_STANDING_DIRECTIVE_OPERATIONS.prepareApply({
+  requestToken: 'service-test',
+  widgetId: 'lexical-gravity',
+  draft: nextDraft,
+  widgetConfigId
+}));
 
 describe('WorkshopStandingDirectiveService', () => {
   it('stages first install until every retained prompt has been replaced', async () => {
@@ -282,5 +291,115 @@ describe('WorkshopStandingDirectiveService', () => {
     mutate(state);
 
     expect(() => parseWorkshopSessionStateV1(state)).toThrow(message);
+  });
+
+  it('runs a test-only second family through apply, aggregate commit, and remove', async () => {
+    // Prose Controller remains feature-frozen and outside the persisted config
+    // union. This structural fake proves the shared kernel/registry seam without
+    // expanding production state or borrowing a Lexical draft as a fallback.
+    const config = {
+      id: 'wc-1',
+      widgetId: 'prose-controller',
+      revision: 1,
+      createdAt: 10,
+      draft: { intensity: 3 }
+    };
+    let activeDirective: {
+      id: string;
+      family: 'prose-controller';
+      widgetId: 'prose-controller';
+      widgetConfigId: string;
+      revision: number;
+      updatedAt: number;
+    } | undefined;
+    let committedConfig: typeof config | undefined;
+    let turnCounter = 0;
+    const session = {
+      getSnapshot: () => ({ activeRequestId: undefined }),
+      getStandingDirective: () => activeDirective,
+      getWidgetConfig: () => committedConfig,
+      prepareWidgetConfigCreation: () => ({
+        kind: 'creation',
+        counter: 1,
+        config
+      }),
+      prepareStandingDirectiveUpsert: () => {
+        const directive = {
+          id: 'pd-1',
+          family: 'prose-controller' as const,
+          widgetId: 'prose-controller' as const,
+          widgetConfigId: 'wc-1',
+          revision: 1,
+          updatedAt: 10
+        };
+        return {
+          action: 'installed',
+          directive,
+          state: { counter: 1, directives: [directive] }
+        };
+      },
+      prepareStandingDirectiveRemoval: () => activeDirective
+        ? {
+            action: 'removed',
+            directive: activeDirective,
+            state: { counter: 1, directives: [] }
+          }
+        : undefined,
+      commitStandingDirectiveMutation: (prepared: {
+        action: 'installed' | 'removed';
+        directive: typeof activeDirective;
+      }, preparedConfig?: { config: typeof config }) => {
+        if (prepared.action === 'removed') {
+          activeDirective = undefined;
+        } else {
+          activeDirective = prepared.directive;
+          committedConfig = preparedConfig?.config;
+        }
+        return { id: `turn-${++turnCounter}` };
+      }
+    };
+    const operations: WorkshopStandingDirectiveOperations = {
+      prepareApply: jest.fn(),
+      widgetIdForFamily: (family) => family === 'prose-controller'
+        ? 'prose-controller'
+        : 'lexical-gravity',
+      render: ({ directive }) => `<prose-controller id="${directive.id}" />`,
+      summarize: jest.fn(),
+      markerContent: jest.fn(),
+      formatSummary: jest.fn(),
+      describe: () => 'test-only Prose Controller frame'
+    };
+    const replaceStandingDirectiveFrames = jest.fn().mockResolvedValue(undefined);
+    const service = new WorkshopStandingDirectiveService(
+      session as never,
+      { replaceStandingDirectiveFrames } as never,
+      operations
+    );
+
+    const applied = await service.apply({
+      family: 'prose-controller',
+      widgetId: 'prose-controller',
+      widgetConfigInput: {
+        widgetId: 'prose-controller',
+        draft: config.draft
+      } as never,
+      editConflictMessage: 'test edit conflict',
+      alreadyActiveMessage: 'test family already active'
+    } as never);
+    const removed = await service.remove('prose-controller');
+
+    expect(applied).toMatchObject({
+      action: 'installed',
+      directiveId: 'pd-1',
+      config: { widgetId: 'prose-controller' }
+    });
+    expect(removed).toMatchObject({ removed: true, directiveId: 'pd-1' });
+    expect(replaceStandingDirectiveFrames).toHaveBeenNthCalledWith(
+      1,
+      ['<prose-controller id="pd-1" />']
+    );
+    expect(replaceStandingDirectiveFrames).toHaveBeenNthCalledWith(2, []);
+    expect(activeDirective).toBeUndefined();
+    expect(turnCounter).toBe(2);
   });
 });

--- a/packages/core/src/__tests__/application/services/workshop/WorkshopStandingDirectiveService.test.ts
+++ b/packages/core/src/__tests__/application/services/workshop/WorkshopStandingDirectiveService.test.ts
@@ -56,6 +56,12 @@ const applyLexicalGravity = (
 }));
 
 describe('WorkshopStandingDirectiveService', () => {
+  it('fails an unknown family lookup with a domain error instead of dereferencing undefined', () => {
+    expect(() => WORKSHOP_STANDING_DIRECTIVE_OPERATIONS.widgetIdForFamily(
+      'future-standing-family' as never
+    )).toThrow('Standing directive family future-standing-family is not implemented');
+  });
+
   it('stages first install until every retained prompt has been replaced', async () => {
     const session = new WorkshopSessionService(() => 100);
     const gate = deferred();

--- a/packages/core/src/__tests__/architecture/boundaries.test.ts
+++ b/packages/core/src/__tests__/architecture/boundaries.test.ts
@@ -59,16 +59,16 @@ const WORKSHOP_HANDLER_ROOT = path.join(HANDLERS_ROOT, 'domain');
  * Phase-0 migration witness for ADR 2026-08-03. MessageRouter already rejects
  * duplicate registrations at runtime; this map adds a declared ownership
  * ledger that pins each inbound widget/standing route to its expected file.
- * Later phases update the owner path as part of the same pure-move commit; the
- * two generic standing routes must leave the Lexical handler in Phase 2.
+ * The two family-generic standing routes belong to the shared handler; feature
+ * handlers retain only their own catalog, preview, generation, and save routes.
  */
 const WORKSHOP_WIDGET_ROUTE_OWNERS = [
   {
-    messageType: 'WORKSHOP_WIDGET_GENERATE',
+    messageType: 'WORKSHOP_GESTURE_PLAYGROUND_GENERATE',
     owner: 'application/handlers/domain/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundHandler.ts'
   },
   {
-    messageType: 'CANCEL_WIDGET_GENERATE_REQUEST',
+    messageType: 'CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST',
     owner: 'application/handlers/domain/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundHandler.ts'
   },
   {
@@ -95,14 +95,13 @@ const WORKSHOP_WIDGET_ROUTE_OWNERS = [
     messageType: 'WORKSHOP_SAVE_LEXICAL_GRAVITY_LENSES',
     owner: 'application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.ts'
   },
-  // Legacy Phase-2 exceptions: family-generic routes have a feature owner.
   {
     messageType: 'WORKSHOP_APPLY_STANDING_WIDGET',
-    owner: 'application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.ts'
+    owner: 'application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts'
   },
   {
     messageType: 'WORKSHOP_REMOVE_STANDING_WIDGET',
-    owner: 'application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.ts'
+    owner: 'application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts'
   }
 ] as const;
 
@@ -130,6 +129,45 @@ const WORKSHOP_WIDGET_HOST_HOOK = path.join(
   SRC_ROOT,
   'presentation/webview/hooks/domain/workshop/useWorkshopWidgetHost.ts'
 );
+const WORKSHOP_STANDING_DIRECTIVE_HOOK = path.join(
+  SRC_ROOT,
+  'presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.ts'
+);
+const WORKSHOP_STANDING_DIRECTIVE_OPERATIONS = path.join(
+  SRC_ROOT,
+  'application/services/workshop/directives/WorkshopStandingDirectiveOperations.ts'
+);
+const WORKSHOP_GENERIC_STANDING_MECHANICS = [
+  path.join(
+    SRC_ROOT,
+    'application/services/workshop/directives/WorkshopStandingDirectiveFrames.ts'
+  ),
+  path.join(
+    SRC_ROOT,
+    'application/services/workshop/directives/WorkshopStandingDirectivePresentation.ts'
+  ),
+  path.join(
+    SRC_ROOT,
+    'presentation/webview/components/workshop/WorkshopStandingDirectiveRail.tsx'
+  )
+];
+const WORKSHOP_GENERIC_STANDING_COPY_SURFACES = [
+  ...WORKSHOP_GENERIC_STANDING_MECHANICS,
+  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS,
+  WORKSHOP_STANDING_DIRECTIVE_HOOK,
+  path.join(
+    SRC_ROOT,
+    'application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts'
+  ),
+  path.join(
+    SRC_ROOT,
+    'application/services/workshop/directives/WorkshopStandingDirectiveService.ts'
+  ),
+  path.join(
+    SRC_ROOT,
+    'presentation/webview/hooks/domain/workshop/dispatchWorkshopWidgetActionResult.ts'
+  )
+];
 const GENERIC_WIDGET_CONFIG_PRESENTATION_REFERENCE = new RegExp(
   [
     'WORKSHOP_REQUEST_WIDGET_CONFIG',
@@ -144,20 +182,22 @@ const GENERIC_WIDGET_CONFIG_PRESENTATION_REFERENCE = new RegExp(
 );
 
 /**
- * Exact known false-generic ownership at the start of the refactor. This list
- * may only shrink. A phase that removes an exception updates this witness in
- * the same commit; Phase 7 requires an empty list.
+ * Exact known false-generic ownership for each inventoried phase. Newly
+ * discovered pre-existing violations may be recorded only with an owning
+ * cleanup phase; once that phase's inventory is recorded, its entries may only
+ * shrink. A phase that removes an exception updates this witness in the same
+ * commit; Phase 7 requires an empty list.
  */
 const WORKSHOP_LEGACY_OWNERSHIP_EXCEPTIONS = [
   {
-    phase: 2,
-    file: 'application/services/workshop/directives/WorkshopStandingDirectiveService.ts',
-    marker: /family: 'lexical-gravity'/
+    phase: 6,
+    file: 'shared/constants/workshopWidgets.ts',
+    marker: /LEXICAL_GRAVITY_WEIGHT/
   },
   {
-    phase: 2,
-    file: 'application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.ts',
-    marker: /MessageType\.WORKSHOP_APPLY_STANDING_WIDGET/
+    phase: 6,
+    file: 'utils/workshopWidgetRecommendation.ts',
+    marker: /For Lexical Gravity/
   }
 ] as const;
 
@@ -299,6 +339,40 @@ describe('architectural boundaries', () => {
     expect(widgetHostSource).toMatch(/handleWidgetConfigData/);
   });
 
+  it('Workshop standing removal has one generic presentation owner', () => {
+    const featureOffenders = WORKSHOP_FEATURE_HOOKS
+      .filter((file) => /WORKSHOP_REMOVE_STANDING_WIDGET/.test(fs.readFileSync(file, 'utf8')))
+      .map((file) => path.relative(SRC_ROOT, file));
+    const standingOwner = fs.readFileSync(WORKSHOP_STANDING_DIRECTIVE_HOOK, 'utf8');
+
+    expect(featureOffenders).toEqual([]);
+    expect(standingOwner).toMatch(/WORKSHOP_REMOVE_STANDING_WIDGET/);
+    expect(standingOwner).toMatch(/requestToken/);
+    expect(standingOwner).toMatch(/workshopWidgetLabel/);
+  });
+
+  it('Workshop standing mechanics dispatch through one closed feature registry', () => {
+    const genericOffenders = WORKSHOP_GENERIC_STANDING_MECHANICS
+      .filter((file) => importsFeature(fs.readFileSync(file, 'utf8'), LEXICAL_FEATURE_REFERENCE))
+      .map((file) => path.relative(SRC_ROOT, file));
+    const operations = fs.readFileSync(WORKSHOP_STANDING_DIRECTIVE_OPERATIONS, 'utf8');
+
+    expect(genericOffenders).toEqual([]);
+    expect(operations).toMatch(/Record<WorkshopStandingDirectiveFamily/);
+    expect(operations).toMatch(
+      /'lexical-gravity': LEXICAL_GRAVITY_STANDING_DIRECTIVE_OPERATIONS/
+    );
+    expect(operations).toMatch(/'prose-controller': proseControllerEntry/);
+  });
+
+  it('Workshop generic standing surfaces carry no Lexical writer-facing copy', () => {
+    const offenders = WORKSHOP_GENERIC_STANDING_COPY_SURFACES
+      .filter((file) => /Lexical Gravity\b/.test(fs.readFileSync(file, 'utf8')))
+      .map((file) => path.relative(SRC_ROOT, file));
+
+    expect(offenders).toEqual([]);
+  });
+
   it('Workshop handlers cannot bypass the session aggregate through internal ledgers', () => {
     const INTERNAL_SESSION_LEDGER = /(?:WorkshopWidgetConfigLedger|WorkshopStandingDirectiveLedger)/;
     const offenders = collectSourceFiles(WORKSHOP_HANDLER_ROOT)
@@ -326,8 +400,8 @@ describe('architectural boundaries', () => {
       .map(({ phase, file }) => `P${phase}:${file}`);
 
     expect(observed).toEqual([
-      'P2:application/services/workshop/directives/WorkshopStandingDirectiveService.ts',
-      'P2:application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.ts'
+      'P6:shared/constants/workshopWidgets.ts',
+      'P6:utils/workshopWidgetRecommendation.ts'
     ]);
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.test.tsx
@@ -14,6 +14,7 @@ describe('WorkshopStandingDirectiveRail', () => {
   it('keeps the active influence visible, editable, and killable', () => {
     const onEdit = jest.fn();
     const onRemove = jest.fn();
+    const formatSummary = jest.fn().mockReturnValue('Photography · 60% · 2° · metaphor');
     render(<WorkshopStandingDirectiveRail
       directives={[{
         id: 'pd-1',
@@ -27,6 +28,7 @@ describe('WorkshopStandingDirectiveRail', () => {
         reach: 2,
         metaphorPull: true
       }]}
+      formatSummary={formatSummary}
       onEdit={onEdit}
       onRemove={onRemove}
     />);
@@ -40,5 +42,35 @@ describe('WorkshopStandingDirectiveRail', () => {
       family: 'lexical-gravity',
       widgetId: 'lexical-gravity'
     }));
+    expect(formatSummary).toHaveBeenCalledWith(expect.objectContaining({
+      family: 'lexical-gravity'
+    }));
+  });
+
+  it('disables only the directive whose removal is pending', () => {
+    render(<WorkshopStandingDirectiveRail
+      directives={[{
+        id: 'pd-1',
+        family: 'lexical-gravity',
+        widgetId: 'lexical-gravity',
+        widgetConfigId: 'wc-1',
+        revision: 2,
+        updatedAt: 100,
+        lensName: 'Photography',
+        weight: 60,
+        reach: 2,
+        metaphorPull: true
+      }]}
+      removingWidgetIds={['lexical-gravity']}
+      formatSummary={() => 'Photography'}
+      onEdit={jest.fn()}
+      onRemove={jest.fn()}
+    />);
+
+    expect((screen.getByRole('button', {
+      name: 'Remove Lexical Gravity'
+    }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Edit' }) as HTMLButtonElement).disabled)
+      .toBe(false);
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.test.tsx
@@ -36,6 +36,9 @@ describe('WorkshopStandingDirectiveRail', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
     fireEvent.click(screen.getByRole('button', { name: 'Remove Lexical Gravity' }));
     expect(onEdit).toHaveBeenCalledWith('wc-1');
-    expect(onRemove).toHaveBeenCalledWith('lexical-gravity');
+    expect(onRemove).toHaveBeenCalledWith(expect.objectContaining({
+      family: 'lexical-gravity',
+      widgetId: 'lexical-gravity'
+    }));
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/components/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundModal.test.tsx
+++ b/packages/core/src/__tests__/presentation/webview/components/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundModal.test.tsx
@@ -621,6 +621,7 @@ describe('WorkshopGesturePlaygroundModal', () => {
       {...props}
       actionResult={{
         action: 'commit',
+        requestToken: 'commit-success',
         widgetId: 'gesture-playground',
         ok: true,
         widgetConfigId: 'wc-2',
@@ -640,6 +641,7 @@ describe('WorkshopGesturePlaygroundModal', () => {
       {...props}
       actionResult={{
         action: 'commit',
+        requestToken: 'commit-failure',
         widgetId: 'gesture-playground',
         ok: false,
         message: 'Wait for the current session save to finish.'

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/dispatchWorkshopWidgetActionResult.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/dispatchWorkshopWidgetActionResult.test.ts
@@ -11,90 +11,32 @@ describe('dispatchWorkshopWidgetActionResult', () => {
     };
     const handleGestureActionResult = jest.fn();
     const handleLexicalActionResult = jest.fn();
-    const showToast = jest.fn();
+    const handleStandingDirectiveActionResult = jest.fn();
 
     dispatchWorkshopWidgetActionResult(message, {
       handleGestureActionResult,
       handleLexicalActionResult,
-      showToast
+      handleStandingDirectiveActionResult
     });
 
-    return { message, handleGestureActionResult, handleLexicalActionResult, showToast };
+    return {
+      message,
+      handleGestureActionResult,
+      handleLexicalActionResult,
+      handleStandingDirectiveActionResult
+    };
   };
 
-  it('fans non-removal results out to both feature hooks without a shell toast', () => {
+  it('fans shared results out to both features and the generic standing owner', () => {
     const result = dispatch({
       action: 'commit',
+      requestToken: 'commit-1',
       widgetId: 'gesture-playground',
       ok: true
     });
 
     expect(result.handleGestureActionResult).toHaveBeenCalledWith(result.message);
     expect(result.handleLexicalActionResult).toHaveBeenCalledWith(result.message);
-    expect(result.showToast).not.toHaveBeenCalled();
-  });
-
-  it('acknowledges a standing directive that was removed', () => {
-    const {
-      message,
-      handleGestureActionResult,
-      handleLexicalActionResult,
-      showToast
-    } = dispatch({
-      action: 'remove-standing',
-      widgetId: 'lexical-gravity',
-      ok: true,
-      removed: true
-    });
-
-    expect(handleGestureActionResult).toHaveBeenCalledWith(message);
-    expect(handleLexicalActionResult).toHaveBeenCalledWith(message);
-    expect(showToast).toHaveBeenCalledWith({
-      message: 'Lexical Gravity removed.',
-      icon: 'check'
-    });
-  });
-
-  it('reports that an already-absent standing directive needed no removal', () => {
-    const { showToast } = dispatch({
-      action: 'remove-standing',
-      widgetId: 'lexical-gravity',
-      ok: true,
-      removed: false
-    });
-
-    expect(showToast).toHaveBeenCalledWith({
-      message: 'Lexical Gravity was already removed.',
-      icon: 'info'
-    });
-  });
-
-  it('shows the host error when standing removal fails', () => {
-    const { showToast } = dispatch({
-      action: 'remove-standing',
-      widgetId: 'lexical-gravity',
-      ok: false,
-      message: 'The session is unavailable.'
-    });
-
-    expect(showToast).toHaveBeenCalledWith({
-      message: 'The session is unavailable.',
-      icon: 'x',
-      tone: 'error'
-    });
-  });
-
-  it('uses a stable fallback when a removal failure has no host message', () => {
-    const { showToast } = dispatch({
-      action: 'remove-standing',
-      widgetId: 'lexical-gravity',
-      ok: false
-    });
-
-    expect(showToast).toHaveBeenCalledWith({
-      message: 'Lexical Gravity could not be removed.',
-      icon: 'x',
-      tone: 'error'
-    });
+    expect(result.handleStandingDirectiveActionResult).toHaveBeenCalledWith(result.message);
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.test.ts
@@ -15,12 +15,15 @@ import { useVSCodeApi } from '@hooks/useVSCodeApi';
 
 describe('useWorkshopStandingDirectives', () => {
   afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
   it('owns removal requests and accepts only the matching result identity', () => {
     const vscode = createMockVSCode();
     const showToast = jest.fn();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
     const { result } = renderHook(() => useWorkshopStandingDirectives(showToast));
 
@@ -30,6 +33,7 @@ describe('useWorkshopStandingDirectives', () => {
     }));
 
     const request = vscode.postMessage.mock.calls[0][0];
+    expect(result.current.removingWidgetIds).toEqual(['lexical-gravity']);
     expect(request).toMatchObject({
       type: MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
       payload: {
@@ -51,6 +55,10 @@ describe('useWorkshopStandingDirectives', () => {
       }
     }));
     expect(showToast).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenLastCalledWith(
+      expect.stringContaining('no pending request owns this token'),
+      expect.objectContaining({ widgetId: 'lexical-gravity' })
+    );
 
     act(() => result.current.handleActionResult({
       type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
@@ -65,6 +73,10 @@ describe('useWorkshopStandingDirectives', () => {
       }
     }));
     expect(showToast).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenLastCalledWith(
+      expect.stringContaining('expected widget lexical-gravity'),
+      expect.objectContaining({ widgetId: 'prose-controller' })
+    );
 
     act(() => result.current.handleActionResult({
       type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
@@ -83,6 +95,7 @@ describe('useWorkshopStandingDirectives', () => {
       message: 'Lexical Gravity removed.',
       icon: 'check'
     });
+    expect(result.current.removingWidgetIds).toEqual([]);
   });
 
   it('uses generic catalog copy for a second standing family', () => {
@@ -113,5 +126,131 @@ describe('useWorkshopStandingDirectives', () => {
       message: 'Prose Controller was already removed.',
       icon: 'info'
     });
+  });
+
+  it('tracks concurrent removals independently and settles each acknowledgement', () => {
+    const vscode = createMockVSCode();
+    const showToast = jest.fn();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
+    const { result } = renderHook(() => useWorkshopStandingDirectives(showToast));
+
+    act(() => result.current.remove({
+      family: 'lexical-gravity',
+      widgetId: 'lexical-gravity'
+    }));
+    act(() => result.current.remove({
+      family: 'prose-controller',
+      widgetId: 'prose-controller'
+    }));
+    const [lexicalRequest, proseRequest] = vscode.postMessage.mock.calls
+      .map(([message]) => message);
+    expect(result.current.removingWidgetIds).toEqual([
+      'lexical-gravity',
+      'prose-controller'
+    ]);
+
+    act(() => result.current.handleActionResult({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.standing-directives',
+      timestamp: 1,
+      payload: {
+        action: 'remove-standing',
+        requestToken: lexicalRequest.payload.requestToken,
+        widgetId: 'lexical-gravity',
+        ok: true,
+        removed: true
+      }
+    }));
+    expect(result.current.removingWidgetIds).toEqual(['prose-controller']);
+
+    act(() => result.current.handleActionResult({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.standing-directives',
+      timestamp: 2,
+      payload: {
+        action: 'remove-standing',
+        requestToken: proseRequest.payload.requestToken,
+        widgetId: 'prose-controller',
+        ok: true,
+        removed: true
+      }
+    }));
+
+    expect(result.current.removingWidgetIds).toEqual([]);
+    expect(showToast).toHaveBeenNthCalledWith(1, {
+      message: 'Lexical Gravity removed.',
+      icon: 'check'
+    });
+    expect(showToast).toHaveBeenNthCalledWith(2, {
+      message: 'Prose Controller removed.',
+      icon: 'check'
+    });
+  });
+
+  it('does not post a duplicate removal for one family while its request is pending', () => {
+    const vscode = createMockVSCode();
+    const showToast = jest.fn();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
+    const { result } = renderHook(() => useWorkshopStandingDirectives(showToast));
+    const directive = {
+      family: 'lexical-gravity' as const,
+      widgetId: 'lexical-gravity' as const
+    };
+
+    act(() => {
+      result.current.remove(directive);
+      result.current.remove(directive);
+    });
+
+    expect(vscode.postMessage).toHaveBeenCalledTimes(1);
+    expect(showToast).toHaveBeenCalledWith({
+      message: 'Lexical Gravity removal is already in progress.',
+      icon: 'info'
+    });
+  });
+
+  it('releases a pending removal with a visible failure when its ack times out', () => {
+    jest.useFakeTimers();
+    const vscode = createMockVSCode();
+    const showToast = jest.fn();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
+    const { result } = renderHook(() => useWorkshopStandingDirectives(showToast));
+
+    act(() => result.current.remove({
+      family: 'lexical-gravity',
+      widgetId: 'lexical-gravity'
+    }));
+    act(() => jest.advanceTimersByTime(10_000));
+
+    expect(result.current.removingWidgetIds).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      '[useWorkshopStandingDirectives] Remove acknowledgement timed out',
+      expect.objectContaining({ widgetId: 'lexical-gravity' })
+    );
+    expect(showToast).toHaveBeenCalledWith({
+      message: 'Lexical Gravity removal was not confirmed.',
+      icon: 'x',
+      tone: 'error'
+    });
+  });
+
+  it('formats summaries without exposing application operations to the rail', () => {
+    const vscode = createMockVSCode();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
+    const { result } = renderHook(() => useWorkshopStandingDirectives(jest.fn()));
+
+    expect(result.current.formatSummary({
+      id: 'pd-1',
+      family: 'lexical-gravity',
+      widgetId: 'lexical-gravity',
+      widgetConfigId: 'wc-1',
+      revision: 1,
+      updatedAt: 1,
+      lensName: 'Photography',
+      weight: 60,
+      reach: 2,
+      metaphorPull: true
+    })).toBe('Photography · 60% · 2° · metaphor');
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import {
+  useWorkshopStandingDirectives
+} from '@hooks/domain/workshop/useWorkshopStandingDirectives';
+import { MessageType } from '@messages';
+import { createMockVSCode } from '@/__tests__/mocks/vscode';
+
+jest.mock('@hooks/useVSCodeApi');
+
+import { useVSCodeApi } from '@hooks/useVSCodeApi';
+
+describe('useWorkshopStandingDirectives', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('owns removal requests and accepts only the matching result identity', () => {
+    const vscode = createMockVSCode();
+    const showToast = jest.fn();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
+    const { result } = renderHook(() => useWorkshopStandingDirectives(showToast));
+
+    act(() => result.current.remove({
+      family: 'lexical-gravity',
+      widgetId: 'lexical-gravity'
+    }));
+
+    const request = vscode.postMessage.mock.calls[0][0];
+    expect(request).toMatchObject({
+      type: MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
+      payload: {
+        family: 'lexical-gravity',
+        requestToken: expect.any(String)
+      }
+    });
+
+    act(() => result.current.handleActionResult({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.standing-directives',
+      timestamp: 1,
+      payload: {
+        action: 'remove-standing',
+        requestToken: `${request.payload.requestToken}-stale`,
+        widgetId: 'lexical-gravity',
+        ok: true,
+        removed: true
+      }
+    }));
+    expect(showToast).not.toHaveBeenCalled();
+
+    act(() => result.current.handleActionResult({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.standing-directives',
+      timestamp: 2,
+      payload: {
+        action: 'remove-standing',
+        requestToken: request.payload.requestToken,
+        widgetId: 'prose-controller',
+        ok: true,
+        removed: true
+      }
+    }));
+    expect(showToast).not.toHaveBeenCalled();
+
+    act(() => result.current.handleActionResult({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.standing-directives',
+      timestamp: 3,
+      payload: {
+        action: 'remove-standing',
+        requestToken: request.payload.requestToken,
+        widgetId: 'lexical-gravity',
+        ok: true,
+        removed: true
+      }
+    }));
+
+    expect(showToast).toHaveBeenCalledWith({
+      message: 'Lexical Gravity removed.',
+      icon: 'check'
+    });
+  });
+
+  it('uses generic catalog copy for a second standing family', () => {
+    const vscode = createMockVSCode();
+    const showToast = jest.fn();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
+    const { result } = renderHook(() => useWorkshopStandingDirectives(showToast));
+
+    act(() => result.current.remove({
+      family: 'prose-controller',
+      widgetId: 'prose-controller'
+    }));
+    const requestToken = vscode.postMessage.mock.calls[0][0].payload.requestToken;
+    act(() => result.current.handleActionResult({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.standing-directives',
+      timestamp: 1,
+      payload: {
+        action: 'remove-standing',
+        requestToken,
+        widgetId: 'prose-controller',
+        ok: true,
+        removed: false
+      }
+    }));
+
+    expect(showToast).toHaveBeenCalledWith({
+      message: 'Prose Controller was already removed.',
+      icon: 'info'
+    });
+  });
+});

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/widgets/useGesturePlayground.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/widgets/useGesturePlayground.test.ts
@@ -17,6 +17,7 @@ describe('useGesturePlayground', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -51,6 +52,7 @@ describe('useGesturePlayground', () => {
 
   it('ignores a stale commit acknowledgement with the right action and widget', () => {
     const vscode = createMockVSCode();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
     const { result } = renderHook(() => useGesturePlayground());
 
@@ -73,6 +75,10 @@ describe('useGesturePlayground', () => {
     }));
 
     expect(result.current.widgetActionResult).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('no current commit request owns this token'),
+      expect.objectContaining({ requestToken: `${requestToken}-stale` })
+    );
   });
 
   it('tracks token-keyed progress and clears it when that result settles', () => {

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/widgets/useGesturePlayground.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/widgets/useGesturePlayground.test.ts
@@ -21,12 +21,20 @@ describe('useGesturePlayground', () => {
   });
 
   it('owns Gesture commit acknowledgements until the modal consumes them', () => {
+    const vscode = createMockVSCode();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
     const { result } = renderHook(() => useGesturePlayground());
+    act(() => result.current.commitWidget({
+      widgetId: 'gesture-playground',
+      draft: {} as never
+    }));
+    const requestToken = vscode.postMessage.mock.calls[0][0].payload.requestToken;
     const response: WorkshopWidgetActionResultMessage = {
       type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
       source: 'extension.workshop.widget',
       payload: {
         action: 'commit',
+        requestToken,
         widgetId: 'gesture-playground',
         ok: false,
         message: 'The session is still saving.'
@@ -41,11 +49,37 @@ describe('useGesturePlayground', () => {
     expect(result.current.widgetActionResult).toBeNull();
   });
 
+  it('ignores a stale commit acknowledgement with the right action and widget', () => {
+    const vscode = createMockVSCode();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
+    const { result } = renderHook(() => useGesturePlayground());
+
+    act(() => result.current.commitWidget({
+      widgetId: 'gesture-playground',
+      draft: {} as never
+    }));
+    const requestToken = vscode.postMessage.mock.calls[0][0].payload.requestToken;
+
+    act(() => result.current.handleWidgetActionResult({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.widget',
+      payload: {
+        action: 'commit',
+        requestToken: `${requestToken}-stale`,
+        widgetId: 'gesture-playground',
+        ok: true
+      },
+      timestamp: 0
+    }));
+
+    expect(result.current.widgetActionResult).toBeNull();
+  });
+
   it('tracks token-keyed progress and clears it when that result settles', () => {
     const { result } = renderHook(() => useGesturePlayground());
 
     act(() => result.current.handleWidgetGenerationProgress({
-      type: MessageType.WORKSHOP_WIDGET_GENERATION_PROGRESS,
+      type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS,
       source: 'extension.workshop',
       payload: {
         widgetId: 'gesture-playground',
@@ -66,7 +100,7 @@ describe('useGesturePlayground', () => {
     });
 
     act(() => result.current.handleWidgetMenuResult({
-      type: MessageType.WORKSHOP_WIDGET_MENU_RESULT,
+      type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT,
       source: 'extension.workshop',
       payload: {
         widgetId: 'gesture-playground',
@@ -85,7 +119,7 @@ describe('useGesturePlayground', () => {
     const { result } = renderHook(() => useGesturePlayground());
 
     act(() => result.current.handleWidgetGenerationProgress({
-      type: MessageType.WORKSHOP_WIDGET_GENERATION_PROGRESS,
+      type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS,
       source: 'extension.workshop',
       payload: {
         widgetId: 'gesture-playground',
@@ -99,7 +133,7 @@ describe('useGesturePlayground', () => {
       timestamp: 1
     }));
     act(() => result.current.handleWidgetMenuResult({
-      type: MessageType.WORKSHOP_WIDGET_MENU_RESULT,
+      type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT,
       source: 'extension.workshop',
       payload: {
         widgetId: 'gesture-playground',

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/widgets/useLexicalGravity.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/widgets/useLexicalGravity.test.ts
@@ -21,13 +21,18 @@ describe('useLexicalGravity', () => {
   });
 
   it('owns apply acknowledgements and ignores sibling feature commits', () => {
+    const vscode = createMockVSCode();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
     const { result } = renderHook(() => useLexicalGravity());
+    act(() => result.current.apply({} as never));
+    const requestToken = vscode.postMessage.mock.calls[0][0].payload.requestToken;
     const applyResult: WorkshopWidgetActionResultMessage = {
       type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
       source: 'extension.workshop.lexical-gravity',
       timestamp: 1,
       payload: {
         action: 'apply-standing',
+        requestToken,
         widgetId: 'lexical-gravity',
         ok: true,
         widgetConfigId: 'wc-1'
@@ -39,6 +44,7 @@ describe('useLexicalGravity', () => {
       timestamp: 2,
       payload: {
         action: 'commit',
+        requestToken: 'commit-elsewhere',
         widgetId: 'gesture-playground',
         ok: true,
         widgetConfigId: 'wc-2'
@@ -52,6 +58,30 @@ describe('useLexicalGravity', () => {
     expect(result.current.actionResult).toEqual(applyResult.payload);
 
     act(() => result.current.consumeActionResult());
+    expect(result.current.actionResult).toBeNull();
+  });
+
+  it('ignores an older apply result after a newer request owns the UI', () => {
+    const vscode = createMockVSCode();
+    (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
+    const { result } = renderHook(() => useLexicalGravity());
+
+    act(() => result.current.apply({} as never));
+    const oldToken = vscode.postMessage.mock.calls[0][0].payload.requestToken;
+    act(() => result.current.apply({} as never));
+
+    act(() => result.current.handleActionResult({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.standing-directives',
+      timestamp: 1,
+      payload: {
+        action: 'apply-standing',
+        requestToken: oldToken,
+        widgetId: 'lexical-gravity',
+        ok: true
+      }
+    }));
+
     expect(result.current.actionResult).toBeNull();
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/widgets/useLexicalGravity.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/domain/workshop/widgets/useLexicalGravity.test.ts
@@ -17,6 +17,7 @@ describe('useLexicalGravity', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -63,6 +64,7 @@ describe('useLexicalGravity', () => {
 
   it('ignores an older apply result after a newer request owns the UI', () => {
     const vscode = createMockVSCode();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     (useVSCodeApi as jest.Mock).mockReturnValue(vscode);
     const { result } = renderHook(() => useLexicalGravity());
 
@@ -83,5 +85,9 @@ describe('useLexicalGravity', () => {
     }));
 
     expect(result.current.actionResult).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('no current apply request owns this token'),
+      expect.objectContaining({ requestToken: oldToken })
+    );
   });
 });

--- a/packages/core/src/__tests__/presentation/webview/hooks/useWorkshopAppMessageRouter.test.ts
+++ b/packages/core/src/__tests__/presentation/webview/hooks/useWorkshopAppMessageRouter.test.ts
@@ -31,12 +31,12 @@ const makeDeps = (): WorkshopAppMessageRouterDeps => ({
     handleCandidates: jest.fn(),
     handleLensesSaved: jest.fn()
   } as never,
+  standingDirectives: { handleActionResult: jest.fn() } as never,
   excerptVerify: { handleSelectionData: jest.fn() } as never,
   modelsSettings: { handleModelData: jest.fn(), handleSettingsData: jest.fn() } as never,
   tokenTracking: { handleTokenUsageUpdate: jest.fn() } as never,
   accountBalance: { handleAccountBalanceData: jest.fn() } as never,
   startupNotice: { handleStartupNoticeData: jest.fn() } as never,
-  showToast: jest.fn(),
   handleApiKeyStatus: jest.fn(),
   handleStatusMessage: jest.fn(),
   handleErrorMessage: jest.fn(),
@@ -60,6 +60,7 @@ describe('buildWorkshopAppMessageRoutes', () => {
       timestamp: 2,
       payload: {
         action: 'remove-standing',
+        requestToken: 'remove-1',
         widgetId: 'lexical-gravity',
         ok: true,
         removed: true
@@ -72,9 +73,6 @@ describe('buildWorkshopAppMessageRoutes', () => {
     expect(deps.widgetHost.handleWidgetConfigData).toHaveBeenCalledWith(configMessage);
     expect(deps.gesturePlayground.handleWidgetActionResult).toHaveBeenCalledWith(actionMessage);
     expect(deps.lexicalGravity.handleActionResult).toHaveBeenCalledWith(actionMessage);
-    expect(deps.showToast).toHaveBeenCalledWith({
-      message: 'Lexical Gravity removed.',
-      icon: 'check'
-    });
+    expect(deps.standingDirectives.handleActionResult).toHaveBeenCalledWith(actionMessage);
   });
 });

--- a/packages/core/src/__tests__/shared/streamingCancelMessages.test.ts
+++ b/packages/core/src/__tests__/shared/streamingCancelMessages.test.ts
@@ -16,7 +16,7 @@ describe('createCancelRequestMessage', () => {
     ['context', MessageType.CANCEL_CONTEXT_REQUEST],
     ['search', MessageType.CANCEL_CATEGORY_SEARCH_REQUEST],
     ['workshop', MessageType.CANCEL_WORKSHOP_REQUEST],
-    ['workshop-widget', MessageType.CANCEL_WIDGET_GENERATE_REQUEST]
+    ['workshop-gesture-playground', MessageType.CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST]
   ] as const)('builds a %s cancel message', (domain, type) => {
     expect(createCancelRequestMessage(domain, 'request-1', 'webview.test')).toEqual({
       type,

--- a/packages/core/src/__tests__/shared/workshopWidgetContracts.test.ts
+++ b/packages/core/src/__tests__/shared/workshopWidgetContracts.test.ts
@@ -1,0 +1,91 @@
+import {
+  WorkshopApplyStandingWidgetPayload,
+  WorkshopCommitWidgetPayload,
+  WorkshopGesturePlaygroundGeneratePayload,
+  WorkshopGesturePlaygroundGenerationProgressPayload,
+  WorkshopGesturePlaygroundMenuResultPayload,
+  WorkshopLexicalGravityDraft,
+  WorkshopWidgetActionResultPayload
+} from '@messages';
+
+describe('Workshop widget contract exactness', () => {
+  it('makes Gesture-only bodies impossible to pair with a sibling widget id', () => {
+    const generate: WorkshopGesturePlaygroundGeneratePayload = {
+      widgetId: 'gesture-playground',
+      token: 'generate-1',
+      mode: 'full',
+      targetPhrase: 'she smiled',
+      writerInstructions: '',
+      contextText: '',
+      characterNotes: '',
+      sourceReferences: []
+    };
+    const progress: WorkshopGesturePlaygroundGenerationProgressPayload = {
+      widgetId: 'gesture-playground',
+      token: 'generate-1',
+      phase: 'started',
+      stage: 'dictionary',
+      outputCharacters: 0,
+      estimatedOutputTokens: 0,
+      outputTokenLimit: 1_000
+    };
+    const result: WorkshopGesturePlaygroundMenuResultPayload = {
+      widgetId: 'gesture-playground',
+      token: 'generate-1',
+      mode: 'full',
+      ok: false,
+      error: 'Stopped.'
+    };
+
+    const invalidGenerate: WorkshopGesturePlaygroundGeneratePayload = {
+      ...generate,
+      // @ts-expect-error Gesture generation cannot claim a sibling widget.
+      widgetId: 'lexical-gravity'
+    };
+    const invalidProgress: WorkshopGesturePlaygroundGenerationProgressPayload = {
+      ...progress,
+      // @ts-expect-error Gesture progress cannot claim a sibling widget.
+      widgetId: 'lexical-gravity'
+    };
+    const invalidResult: WorkshopGesturePlaygroundMenuResultPayload = {
+      ...result,
+      // @ts-expect-error Gesture menu results cannot claim a sibling widget.
+      widgetId: 'lexical-gravity'
+    };
+    const invalidCommit: WorkshopCommitWidgetPayload = {
+      widgetId: 'gesture-playground',
+      requestToken: 'commit-1',
+      // @ts-expect-error A Lexical draft cannot travel under the Gesture commit arm.
+      draft: {} as WorkshopLexicalGravityDraft
+    };
+    const invalidApply: WorkshopApplyStandingWidgetPayload = {
+      requestToken: 'apply-1',
+      // @ts-expect-error A standing draft cannot claim the one-shot Gesture rail.
+      widgetId: 'gesture-playground',
+      draft: {} as WorkshopLexicalGravityDraft
+    };
+    // @ts-expect-error Apply acknowledgements cannot claim the Gesture identity.
+    const invalidAction: WorkshopWidgetActionResultPayload = {
+      action: 'apply-standing',
+      requestToken: 'apply-1',
+      widgetId: 'gesture-playground',
+      ok: true
+    };
+
+    expect([
+      generate.widgetId,
+      progress.widgetId,
+      result.widgetId
+    ]).toEqual([
+      'gesture-playground',
+      'gesture-playground',
+      'gesture-playground'
+    ]);
+    void invalidGenerate;
+    void invalidProgress;
+    void invalidResult;
+    void invalidCommit;
+    void invalidApply;
+    void invalidAction;
+  });
+});

--- a/packages/core/src/application/handlers/MessageHandler.ts
+++ b/packages/core/src/application/handlers/MessageHandler.ts
@@ -318,10 +318,10 @@ export class MessageHandler {
       workshopSessionPersistenceCoordinator,
       {
         gesturePlayground: gesturePlaygroundService,
+        standingDirectives: workshopStandingDirectiveService,
         lexicalGravity: {
           model: lexicalGravityModelService,
-          repository: lexicalGravityLensRepository,
-          directives: workshopStandingDirectiveService
+          repository: lexicalGravityLensRepository
         }
       },
       outputChannel

--- a/packages/core/src/application/handlers/domain/WorkshopHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopHandler.ts
@@ -167,6 +167,9 @@ import { MessageRouter } from '@handlers/MessageRouter';
 import { WorkshopSessionMessageHandler } from '@handlers/domain/WorkshopSessionMessageHandler';
 import { WorkshopGesturePlaygroundHandler } from '@handlers/domain/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundHandler';
 import { WorkshopWidgetHostHandler } from '@handlers/domain/workshop/widgets/WorkshopWidgetHostHandler';
+import {
+  WorkshopStandingDirectiveHandler
+} from '@handlers/domain/workshop/WorkshopStandingDirectiveHandler';
 import { GesturePlaygroundService } from '@services/widgets/GesturePlaygroundService';
 
 // Generate unique request IDs (module-scoped counter, same idiom as AnalysisHandler)
@@ -252,10 +255,10 @@ export const isWorkshopHostReturnShortcut = (text: string, personaLabel: string)
  */
 export interface WorkshopWidgetRuntime {
   gesturePlayground: GesturePlaygroundService;
+  standingDirectives: WorkshopStandingDirectiveService;
   lexicalGravity: {
     model: LexicalGravityModelService;
     repository: LexicalGravityLensRepository;
-    directives: WorkshopStandingDirectiveService;
   };
 }
 
@@ -275,6 +278,7 @@ export class WorkshopHandler {
   private readonly sessionMessageHandler: WorkshopSessionMessageHandler;
   private readonly gesturePlaygroundHandler: WorkshopGesturePlaygroundHandler;
   private readonly widgetHostHandler: WorkshopWidgetHostHandler;
+  private readonly standingDirectiveHandler: WorkshopStandingDirectiveHandler;
   private readonly lexicalGravityHandler: WorkshopLexicalGravityHandler;
 
   /** The single in-flight Context wizard run — independent of activeRun. */
@@ -358,10 +362,13 @@ export class WorkshopHandler {
       this.outputChannel
     );
     this.lexicalGravityHandler = new WorkshopLexicalGravityHandler(
-      this.session,
       widgetRuntime.lexicalGravity.model,
       widgetRuntime.lexicalGravity.repository,
-      widgetRuntime.lexicalGravity.directives,
+      this.postMessage,
+      this.outputChannel
+    );
+    this.standingDirectiveHandler = new WorkshopStandingDirectiveHandler(
+      widgetRuntime.standingDirectives,
       this.postMessage,
       this.outputChannel,
       {
@@ -380,10 +387,13 @@ export class WorkshopHandler {
       messageType: MessageType,
       handler: (message: never) => Promise<void>,
       sessionAction?: WorkshopSessionAction,
-      onBlocked?: (message: string) => void
+      onBlocked?: (reason: string, message: never) => void
     ): void => {
       router.register(messageType, async (message) => {
-        if (this.rejectRoomMutationDuringSessionOperation(sessionAction, onBlocked)) {
+        const reportBlocked = onBlocked
+          ? (reason: string) => onBlocked(reason, message as never)
+          : undefined;
+        if (this.rejectRoomMutationDuringSessionOperation(sessionAction, reportBlocked)) {
           return;
         }
         await handler(message as never);
@@ -465,6 +475,7 @@ export class WorkshopHandler {
     this.sessionMessageHandler.registerRoutes(router, registerMutation);
     this.gesturePlaygroundHandler.registerRoutes(router, registerMutation);
     this.widgetHostHandler.registerRoutes(router);
+    this.standingDirectiveHandler.registerRoutes(router, registerMutation);
     this.lexicalGravityHandler.registerRoutes(router, registerMutation);
     router.register(MessageType.CANCEL_WORKSHOP_REQUEST, this.handleCancelRequest.bind(this));
   }

--- a/packages/core/src/application/handlers/domain/WorkshopSessionMessageHandler.ts
+++ b/packages/core/src/application/handlers/domain/WorkshopSessionMessageHandler.ts
@@ -34,7 +34,7 @@ export type WorkshopMutationRouteRegistrar = (
   messageType: MessageType,
   handler: (message: never) => Promise<void>,
   sessionAction?: WorkshopSessionAction,
-  onBlocked?: (message: string) => void
+  onBlocked?: (reason: string, message: never) => void
 ) => void;
 
 export interface WorkshopSessionMessageHandlerOptions {

--- a/packages/core/src/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts
+++ b/packages/core/src/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts
@@ -1,0 +1,150 @@
+/** Family-generic IPC owner for Workshop standing-directive mechanics. */
+
+import { MessageRouter } from '@/application/handlers/MessageRouter';
+import { MessageTransport } from '@/application/handlers/MessageHandlerContracts';
+import { WorkshopMutationRouteRegistrar } from '@handlers/domain/WorkshopSessionMessageHandler';
+import { WorkshopStandingDirectiveService } from
+  '@/application/services/workshop/directives/WorkshopStandingDirectiveService';
+import {
+  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS,
+  WorkshopStandingDirectiveOperations
+} from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
+import { LogSink } from '@/platform';
+import {
+  MessageType,
+  WorkshopApplyStandingWidgetMessage,
+  WorkshopRemoveStandingWidgetMessage,
+  WorkshopTurn,
+  WorkshopWidgetActionResultMessage
+} from '@messages';
+
+export interface WorkshopStandingDirectiveHandlerOptions {
+  postSessionState: () => void;
+  postTurn: (turn: WorkshopTurn) => void;
+  markDirty: (reason: string) => void;
+}
+
+export class WorkshopStandingDirectiveHandler {
+  constructor(
+    private readonly directives: WorkshopStandingDirectiveService,
+    private readonly postMessage: MessageTransport,
+    private readonly outputChannel: LogSink,
+    private readonly options: WorkshopStandingDirectiveHandlerOptions,
+    private readonly operations: WorkshopStandingDirectiveOperations =
+      WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
+  ) {}
+
+  registerRoutes(
+    router: MessageRouter,
+    registerMutation: WorkshopMutationRouteRegistrar
+  ): void {
+    registerMutation(
+      MessageType.WORKSHOP_APPLY_STANDING_WIDGET,
+      this.handleApply.bind(this),
+      undefined,
+      (reason, message: WorkshopApplyStandingWidgetMessage) => void this.postAction({
+        action: 'apply-standing',
+        requestToken: message.payload.requestToken,
+        widgetId: message.payload.widgetId,
+        ok: false,
+        message: reason
+      })
+    );
+    registerMutation(
+      MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
+      this.handleRemove.bind(this),
+      undefined,
+      (reason, message: WorkshopRemoveStandingWidgetMessage) => void this.postAction({
+        action: 'remove-standing',
+        requestToken: message.payload.requestToken,
+        widgetId: this.operations.widgetIdForFamily(message.payload.family),
+        ok: false,
+        message: reason
+      })
+    );
+  }
+
+  async handleApply(message: WorkshopApplyStandingWidgetMessage): Promise<void> {
+    const { requestToken } = message.payload;
+    try {
+      const request = this.operations.prepareApply(message.payload);
+      const result = await this.directives.apply(request);
+      if (result.config.widgetId !== request.widgetId) {
+        throw new Error(`Standing directive ${request.family} produced the wrong widget config`);
+      }
+      this.options.postTurn(result.turn);
+      this.options.postSessionState();
+      this.options.markDirty(`${request.widgetId} ${result.action}`);
+      this.outputChannel.appendLine(
+        `[WorkshopStandingDirectiveHandler] ${request.family} ${result.action}: ${result.directiveId} -> ${result.config.id} (revision ${result.config.revision}, ${this.operations.describe({ directive: result.directive, config: result.config })})`
+      );
+      await this.postAction({
+        action: 'apply-standing',
+        requestToken,
+        widgetId: request.widgetId,
+        ok: true,
+        widgetConfigId: result.config.id,
+        directiveId: result.directiveId,
+        turnId: result.turn.id
+      });
+    } catch (error) {
+      await this.postAction({
+        action: 'apply-standing',
+        requestToken,
+        widgetId: message.payload.widgetId,
+        ok: false,
+        message: this.errorMessage(error)
+      });
+    }
+  }
+
+  async handleRemove(message: WorkshopRemoveStandingWidgetMessage): Promise<void> {
+    const { family, requestToken } = message.payload;
+    const widgetId = this.operations.widgetIdForFamily(family);
+    try {
+      const result = await this.directives.remove(family);
+      if (result.turn) {this.options.postTurn(result.turn);}
+      if (result.removed) {
+        this.options.postSessionState();
+        this.options.markDirty(`${family} removed`);
+      }
+      this.outputChannel.appendLine(
+        `[WorkshopStandingDirectiveHandler] ${family} ${result.removed ? 'removed' : 'remove no-op'}${result.directiveId ? `: ${result.directiveId}` : ''}`
+      );
+      await this.postAction({
+        action: 'remove-standing',
+        requestToken,
+        widgetId,
+        ok: true,
+        removed: result.removed,
+        directiveId: result.directiveId,
+        turnId: result.turn?.id
+      });
+    } catch (error) {
+      await this.postAction({
+        action: 'remove-standing',
+        requestToken,
+        widgetId,
+        ok: false,
+        message: this.errorMessage(error)
+      });
+    }
+  }
+
+  private async postAction(
+    payload: WorkshopWidgetActionResultMessage['payload']
+  ): Promise<void> {
+    await this.postMessage({
+      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
+      source: 'extension.workshop.standing-directives',
+      timestamp: Date.now(),
+      payload
+    } satisfies WorkshopWidgetActionResultMessage);
+  }
+
+  private errorMessage(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    this.outputChannel.appendLine(`[WorkshopStandingDirectiveHandler] ${message}`);
+    return message;
+  }
+}

--- a/packages/core/src/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts
+++ b/packages/core/src/application/handlers/domain/workshop/WorkshopStandingDirectiveHandler.ts
@@ -42,25 +42,31 @@ export class WorkshopStandingDirectiveHandler {
       MessageType.WORKSHOP_APPLY_STANDING_WIDGET,
       this.handleApply.bind(this),
       undefined,
-      (reason, message: WorkshopApplyStandingWidgetMessage) => void this.postAction({
-        action: 'apply-standing',
-        requestToken: message.payload.requestToken,
-        widgetId: message.payload.widgetId,
-        ok: false,
-        message: reason
-      })
+      (reason, message: WorkshopApplyStandingWidgetMessage) => void this.postBlockedAction(
+        reason,
+        {
+          action: 'apply-standing',
+          requestToken: message.payload.requestToken,
+          widgetId: message.payload.widgetId,
+          ok: false,
+          message: reason
+        }
+      )
     );
     registerMutation(
       MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
       this.handleRemove.bind(this),
       undefined,
-      (reason, message: WorkshopRemoveStandingWidgetMessage) => void this.postAction({
-        action: 'remove-standing',
-        requestToken: message.payload.requestToken,
-        widgetId: this.operations.widgetIdForFamily(message.payload.family),
-        ok: false,
-        message: reason
-      })
+      (reason, message: WorkshopRemoveStandingWidgetMessage) => void this.postBlockedAction(
+        reason,
+        {
+          action: 'remove-standing',
+          requestToken: message.payload.requestToken,
+          widgetId: message.payload.family,
+          ok: false,
+          message: reason
+        }
+      )
     );
   }
 
@@ -69,12 +75,12 @@ export class WorkshopStandingDirectiveHandler {
     try {
       const request = this.operations.prepareApply(message.payload);
       const result = await this.directives.apply(request);
-      if (result.config.widgetId !== request.widgetId) {
-        throw new Error(`Standing directive ${request.family} produced the wrong widget config`);
-      }
       this.options.postTurn(result.turn);
       this.options.postSessionState();
       this.options.markDirty(`${request.widgetId} ${result.action}`);
+      if (result.config.widgetId !== request.widgetId) {
+        throw new Error(`Standing directive ${request.family} produced the wrong widget config`);
+      }
       this.outputChannel.appendLine(
         `[WorkshopStandingDirectiveHandler] ${request.family} ${result.action}: ${result.directiveId} -> ${result.config.id} (revision ${result.config.revision}, ${this.operations.describe({ directive: result.directive, config: result.config })})`
       );
@@ -100,8 +106,9 @@ export class WorkshopStandingDirectiveHandler {
 
   async handleRemove(message: WorkshopRemoveStandingWidgetMessage): Promise<void> {
     const { family, requestToken } = message.payload;
-    const widgetId = this.operations.widgetIdForFamily(family);
+    let widgetId = family;
     try {
+      widgetId = this.operations.widgetIdForFamily(family);
       const result = await this.directives.remove(family);
       if (result.turn) {this.options.postTurn(result.turn);}
       if (result.removed) {
@@ -129,6 +136,16 @@ export class WorkshopStandingDirectiveHandler {
         message: this.errorMessage(error)
       });
     }
+  }
+
+  private async postBlockedAction(
+    reason: string,
+    payload: WorkshopWidgetActionResultMessage['payload']
+  ): Promise<void> {
+    this.outputChannel.appendLine(
+      `[WorkshopStandingDirectiveHandler] ${payload.action} blocked: ${reason}`
+    );
+    await this.postAction(payload);
   }
 
   private async postAction(

--- a/packages/core/src/application/handlers/domain/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundHandler.ts
+++ b/packages/core/src/application/handlers/domain/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundHandler.ts
@@ -23,16 +23,16 @@ import {
 import { LogSink } from '@/platform';
 import {
   MessageType,
+  CancelGesturePlaygroundGenerateRequestMessage,
   WorkshopCommitWidgetMessage,
+  WorkshopGesturePlaygroundGenerateMessage,
+  WorkshopGesturePlaygroundGenerationProgressMessage,
+  WorkshopGesturePlaygroundMenuResultMessage,
   WorkshopGestureDraft,
   WorkshopGestureMenuGroup,
   WorkshopWidgetActionResultMessage,
   WorkshopWidgetActionResultPayload,
-  WorkshopWidgetGenerateMessage,
-  WorkshopWidgetGenerationProgressMessage,
-  WorkshopWidgetSourceReference,
-  CancelWidgetGenerateRequestMessage,
-  WorkshopWidgetMenuResultMessage
+  WorkshopWidgetSourceReference
 } from '@messages';
 import { isLiveWorkshopWidgetId, workshopWidgetLabel } from '@shared/constants/workshopWidgets';
 import { PROMPT_BUDGETS } from '@shared/constants/promptBudgets';
@@ -71,7 +71,7 @@ export interface WorkshopGesturePlaygroundHandlerOptions {
 }
 
 type GestureGenerationStage =
-  WorkshopWidgetGenerationProgressMessage['payload']['stage'];
+  WorkshopGesturePlaygroundGenerationProgressMessage['payload']['stage'];
 
 const GESTURE_PROGRESS_REPORT_INTERVAL_CHARACTERS = 1_000;
 
@@ -99,20 +99,24 @@ export class WorkshopGesturePlaygroundHandler {
     registerMutation: WorkshopMutationRouteRegistrar
   ): void {
     // Generate is a pre-commit preview: no session state, no mutation gate.
-    router.register(MessageType.WORKSHOP_WIDGET_GENERATE, this.handleGenerate.bind(this));
     router.register(
-      MessageType.CANCEL_WIDGET_GENERATE_REQUEST,
+      MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATE,
+      this.handleGenerate.bind(this)
+    );
+    router.register(
+      MessageType.CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST,
       this.handleCancelGenerate.bind(this)
     );
     registerMutation(
       MessageType.WORKSHOP_COMMIT_WIDGET,
       this.handleCommit.bind(this),
       undefined,
-      (message) => this.postActionResult({
+      (reason, message: WorkshopCommitWidgetMessage) => this.postActionResult({
         action: 'commit',
+        requestToken: message.payload.requestToken,
         widgetId: 'gesture-playground',
         ok: false,
-        message
+        message: reason
       })
     );
   }
@@ -122,7 +126,7 @@ export class WorkshopGesturePlaygroundHandler {
     this.activeGeneration = undefined;
   }
 
-  async handleGenerate(message: WorkshopWidgetGenerateMessage): Promise<void> {
+  async handleGenerate(message: WorkshopGesturePlaygroundGenerateMessage): Promise<void> {
     const {
       widgetId,
       token,
@@ -314,7 +318,9 @@ export class WorkshopGesturePlaygroundHandler {
     }
   }
 
-  async handleCancelGenerate(message: CancelWidgetGenerateRequestMessage): Promise<void> {
+  async handleCancelGenerate(
+    message: CancelGesturePlaygroundGenerateRequestMessage
+  ): Promise<void> {
     if (
       this.activeGeneration
       && message.payload.requestId === this.activeGeneration.token
@@ -330,10 +336,11 @@ export class WorkshopGesturePlaygroundHandler {
    * belongs to the Workshop run surface and cannot revoke an accepted widget.
    */
   async handleCommit(message: WorkshopCommitWidgetMessage): Promise<void> {
-    const { widgetId, draft, clonedFromConfigId } = message.payload;
+    const { widgetId, requestToken, draft, clonedFromConfigId } = message.payload;
     if (widgetId !== 'gesture-playground' || !isLiveWorkshopWidgetId(widgetId)) {
       this.postActionResult({
         action: 'commit',
+        requestToken,
         widgetId,
         ok: false,
         message: 'That widget is not available yet.'
@@ -342,13 +349,20 @@ export class WorkshopGesturePlaygroundHandler {
     }
     const invalid = this.validateGestureDraft(draft);
     if (invalid) {
-      this.postActionResult({ action: 'commit', widgetId, ok: false, message: invalid });
+      this.postActionResult({
+        action: 'commit',
+        requestToken,
+        widgetId,
+        ok: false,
+        message: invalid
+      });
       return;
     }
     const target = this.session.getChatTarget();
     if (target.kind === 'tool') {
       this.postActionResult({
         action: 'commit',
+        requestToken,
         widgetId,
         ok: false,
         message: 'Switch to a persona target before committing a widget — tool sidecars do not take gesture directions.'
@@ -358,6 +372,7 @@ export class WorkshopGesturePlaygroundHandler {
     if (this.options.isRoomRunActive()) {
       this.postActionResult({
         action: 'commit',
+        requestToken,
         widgetId,
         ok: false,
         message: 'Wait for the current Workshop response to finish before committing another widget.'
@@ -406,6 +421,7 @@ export class WorkshopGesturePlaygroundHandler {
           this.options.postSessionState();
           this.postActionResult({
             action: 'commit',
+            requestToken,
             widgetId,
             ok: true,
             widgetConfigId: config.id,
@@ -419,6 +435,7 @@ export class WorkshopGesturePlaygroundHandler {
       if (!accepted) {
         this.postActionResult({
           action: 'commit',
+          requestToken,
           widgetId,
           ok: false,
           widgetConfigId: config.id,
@@ -436,6 +453,7 @@ export class WorkshopGesturePlaygroundHandler {
       if (!accepted) {
         this.postActionResult({
           action: 'commit',
+          requestToken,
           widgetId,
           ok: false,
           widgetConfigId: configId,
@@ -575,9 +593,9 @@ export class WorkshopGesturePlaygroundHandler {
     });
   }
 
-  private postMenuResult(payload: WorkshopWidgetMenuResultMessage['payload']): void {
-    const result: WorkshopWidgetMenuResultMessage = {
-      type: MessageType.WORKSHOP_WIDGET_MENU_RESULT,
+  private postMenuResult(payload: WorkshopGesturePlaygroundMenuResultMessage['payload']): void {
+    const result: WorkshopGesturePlaygroundMenuResultMessage = {
+      type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT,
       source: 'extension.workshop',
       payload,
       timestamp: Date.now()
@@ -586,10 +604,10 @@ export class WorkshopGesturePlaygroundHandler {
   }
 
   private postGenerationProgress(
-    payload: WorkshopWidgetGenerationProgressMessage['payload']
+    payload: WorkshopGesturePlaygroundGenerationProgressMessage['payload']
   ): void {
-    const progress: WorkshopWidgetGenerationProgressMessage = {
-      type: MessageType.WORKSHOP_WIDGET_GENERATION_PROGRESS,
+    const progress: WorkshopGesturePlaygroundGenerationProgressMessage = {
+      type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS,
       source: 'extension.workshop',
       payload,
       timestamp: Date.now()

--- a/packages/core/src/application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.ts
+++ b/packages/core/src/application/handlers/domain/workshop/widgets/lexicalGravity/WorkshopLexicalGravityHandler.ts
@@ -1,10 +1,8 @@
-/** Focused IPC adapter for Lexical Gravity and the standing directive rail. */
+/** Focused IPC adapter for Lexical Gravity's catalog, preview, build, and save workflow. */
 
 import { MessageRouter } from '@/application/handlers/MessageRouter';
 import { MessageTransport } from '@/application/handlers/MessageHandlerContracts';
 import { WorkshopMutationRouteRegistrar } from '@handlers/domain/WorkshopSessionMessageHandler';
-import { WorkshopSessionService } from '@/application/services/workshop/WorkshopSessionService';
-import { WorkshopStandingDirectiveService } from '@/application/services/workshop/directives/WorkshopStandingDirectiveService';
 import { LexicalGravityLensRepository } from '@/infrastructure/storage/LexicalGravityLensRepository';
 import { LexicalGravityModelService } from '@services/widgets/LexicalGravityModelService';
 import {
@@ -15,13 +13,9 @@ import {
 import {
   validateLexicalGravityDraft
 } from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityConfigCodec';
-import {
-  buildLexicalGravityDirectiveFrame
-} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityDirective';
 import { LogSink } from '@/platform';
 import {
   MessageType,
-  WorkshopApplyStandingWidgetMessage,
   WorkshopBuildLexicalGravityLensMessage,
   WorkshopLexicalGravityLensCandidate,
   WorkshopLexicalGravityLensCandidatesMessage,
@@ -29,17 +23,9 @@ import {
   WorkshopLexicalGravityLensesSavedMessage,
   WorkshopLexicalGravityPreviewResultMessage,
   WorkshopPreviewLexicalGravityMessage,
-  WorkshopRemoveStandingWidgetMessage,
   WorkshopRequestLexicalGravityLensesMessage,
-  WorkshopSaveLexicalGravityLensesMessage,
-  WorkshopWidgetActionResultMessage
+  WorkshopSaveLexicalGravityLensesMessage
 } from '@messages';
-
-export interface WorkshopLexicalGravityHandlerOptions {
-  postSessionState: () => void;
-  postTurn: (turn: ReturnType<WorkshopSessionService['commitStandingDirectiveMutation']>) => void;
-  markDirty: (reason: string) => void;
-}
 
 export class WorkshopLexicalGravityHandler {
   private previewRun?: AbortController;
@@ -52,13 +38,10 @@ export class WorkshopLexicalGravityHandler {
   };
 
   constructor(
-    private readonly session: WorkshopSessionService,
     private readonly model: LexicalGravityModelService,
     private readonly repository: LexicalGravityLensRepository,
-    private readonly directives: WorkshopStandingDirectiveService,
     private readonly postMessage: MessageTransport,
-    private readonly outputChannel: LogSink,
-    private readonly options: WorkshopLexicalGravityHandlerOptions
+    private readonly outputChannel: LogSink
   ) {}
 
   registerRoutes(
@@ -80,14 +63,6 @@ export class WorkshopLexicalGravityHandler {
     registerMutation(
       MessageType.WORKSHOP_SAVE_LEXICAL_GRAVITY_LENSES,
       this.handleSave.bind(this)
-    );
-    registerMutation(
-      MessageType.WORKSHOP_APPLY_STANDING_WIDGET,
-      this.handleApply.bind(this)
-    );
-    registerMutation(
-      MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
-      this.handleRemove.bind(this)
     );
   }
 
@@ -245,78 +220,6 @@ export class WorkshopLexicalGravityHandler {
     }
   }
 
-  async handleApply(message: WorkshopApplyStandingWidgetMessage): Promise<void> {
-    try {
-      if (message.payload.widgetId !== 'lexical-gravity') {
-        throw new Error('That standing widget is not available yet.');
-      }
-      const draft = validateLexicalGravityDraft(message.payload.draft);
-      const result = await this.directives.apply({
-        family: 'lexical-gravity',
-        draft,
-        widgetConfigId: message.payload.widgetConfigId
-      });
-      if (result.config.widgetId !== 'lexical-gravity') {
-        throw new Error('Lexical Gravity produced the wrong widget configuration');
-      }
-      this.options.postTurn(result.turn);
-      this.options.postSessionState();
-      this.options.markDirty(`Lexical Gravity ${result.action}`);
-      const frameLength = buildLexicalGravityDirectiveFrame(
-        { id: result.directiveId, revision: result.config.revision },
-        result.config.draft
-      ).length;
-      this.outputChannel.appendLine(
-        `[WorkshopStandingDirective] lexical-gravity ${result.action}: ${result.directiveId} -> ${result.config.id} (revision ${result.config.revision}, lens ${result.config.draft.lensSlug}, ${frameLength} chars)`
-      );
-      await this.postAction({
-        action: 'apply-standing',
-        widgetId: 'lexical-gravity',
-        ok: true,
-        widgetConfigId: result.config.id,
-        directiveId: result.directiveId,
-        turnId: result.turn.id
-      });
-    } catch (error) {
-      await this.postAction({
-        action: 'apply-standing',
-        widgetId: 'lexical-gravity',
-        ok: false,
-        message: this.errorMessage(error)
-      });
-    }
-  }
-
-  async handleRemove(message: WorkshopRemoveStandingWidgetMessage): Promise<void> {
-    try {
-      const active = this.session.getStandingDirective(message.payload.family);
-      const result = await this.directives.remove(message.payload.family);
-      if (result.turn) {this.options.postTurn(result.turn);}
-      if (result.removed) {
-        this.options.postSessionState();
-        this.options.markDirty(`${message.payload.family} removed`);
-      }
-      this.outputChannel.appendLine(
-        `[WorkshopStandingDirective] ${message.payload.family} ${result.removed ? 'removed' : 'remove no-op'}${result.directiveId ? `: ${result.directiveId}` : ''}`
-      );
-      await this.postAction({
-        action: 'remove-standing',
-        widgetId: active?.widgetId ?? 'lexical-gravity',
-        ok: true,
-        removed: result.removed,
-        directiveId: result.directiveId,
-        turnId: result.turn?.id
-      });
-    } catch (error) {
-      await this.postAction({
-        action: 'remove-standing',
-        widgetId: 'lexical-gravity',
-        ok: false,
-        message: this.errorMessage(error)
-      });
-    }
-  }
-
   private async postCandidates(
     payload: WorkshopLexicalGravityLensCandidatesMessage['payload']
   ): Promise<void> {
@@ -326,17 +229,6 @@ export class WorkshopLexicalGravityHandler {
       timestamp: Date.now(),
       payload
     } satisfies WorkshopLexicalGravityLensCandidatesMessage);
-  }
-
-  private async postAction(
-    payload: WorkshopWidgetActionResultMessage['payload']
-  ): Promise<void> {
-    await this.postMessage({
-      type: MessageType.WORKSHOP_WIDGET_ACTION_RESULT,
-      source: 'extension.workshop.lexical-gravity',
-      timestamp: Date.now(),
-      payload
-    } satisfies WorkshopWidgetActionResultMessage);
   }
 
   private errorMessage(error: unknown): string {

--- a/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveFrames.ts
+++ b/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveFrames.ts
@@ -7,58 +7,53 @@ import {
 import type { WorkshopSessionService } from '@/application/services/workshop/WorkshopSessionService';
 import type { WorkshopSessionStateV1 } from '@/application/services/workshop/WorkshopSessionStateV1';
 import {
-  buildLexicalGravityDirectiveFrame
-} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityDirective';
-
-export interface WorkshopStandingDirectiveRendering {
-  directive: WorkshopStandingDirectiveSnapshot;
-  config: WorkshopWidgetConfigSnapshot;
-}
+  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS,
+  WorkshopStandingDirectiveOperations,
+  WorkshopStandingDirectiveRendering
+} from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
 
 export function renderWorkshopStandingDirective(
-  input: WorkshopStandingDirectiveRendering
+  input: WorkshopStandingDirectiveRendering,
+  operations: WorkshopStandingDirectiveOperations = WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
 ): string {
-  const { directive, config } = input;
-  if (
-    directive.family === 'lexical-gravity'
-    && directive.widgetId === 'lexical-gravity'
-    && config.widgetId === 'lexical-gravity'
-  ) {
-    return buildLexicalGravityDirectiveFrame(directive, config.draft);
-  }
-  throw new Error(`No standing directive renderer registered for ${directive.family}`);
+  return operations.render(input);
 }
 
 export function renderWorkshopStandingDirectiveFrames(
-  session: WorkshopSessionService
+  session: WorkshopSessionService,
+  operations: WorkshopStandingDirectiveOperations = WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
 ): string[] {
   return renderWorkshopStandingDirectiveFramesForSnapshots(
     session.getStandingDirectives(),
-    (configId) => session.getWidgetConfig(configId)
+    (configId) => session.getWidgetConfig(configId),
+    operations
   );
 }
 
 export function renderWorkshopStandingDirectiveFramesForSnapshots(
   directives: readonly WorkshopStandingDirectiveSnapshot[],
-  resolveConfig: (configId: string) => WorkshopWidgetConfigSnapshot | undefined
+  resolveConfig: (configId: string) => WorkshopWidgetConfigSnapshot | undefined,
+  operations: WorkshopStandingDirectiveOperations = WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
 ): string[] {
   return directives.map((directive) => {
     const config = resolveConfig(directive.widgetConfigId);
     if (!config) {
       throw new Error(`Standing directive ${directive.id} has no widget config`);
     }
-    return renderWorkshopStandingDirective({ directive, config });
+    return renderWorkshopStandingDirective({ directive, config }, operations);
   });
 }
 
 export function renderWorkshopStandingDirectiveFramesFromState(
-  state: WorkshopSessionStateV1
+  state: WorkshopSessionStateV1,
+  operations: WorkshopStandingDirectiveOperations = WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
 ): string[] {
   const configsById = new Map(
     (state.widgetConfigs ?? []).map((config) => [config.id, config])
   );
   return renderWorkshopStandingDirectiveFramesForSnapshots(
     state.standingDirectives ?? [],
-    (configId) => configsById.get(configId)
+    (configId) => configsById.get(configId),
+    operations
   );
 }

--- a/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveOperations.ts
+++ b/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveOperations.ts
@@ -15,16 +15,18 @@ import {
 } from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityStandingDirectiveOperations';
 import { workshopWidgetLabel } from '@shared/constants/workshopWidgets';
 
-export type WorkshopStandingDirectiveApplyRequest = {
-  [Payload in WorkshopApplyStandingWidgetPayload as Payload['widgetId']]: {
-    family: Extract<WorkshopStandingDirectiveFamily, Payload['widgetId']>;
-    widgetId: Payload['widgetId'];
-    widgetConfigInput: Extract<WorkshopWidgetConfigInput, { widgetId: Payload['widgetId'] }>;
-    widgetConfigId?: string;
-    editConflictMessage: string;
-    alreadyActiveMessage: string;
-  }
-}[WorkshopApplyStandingWidgetPayload['widgetId']];
+export interface WorkshopLexicalGravityStandingDirectiveApplyRequest {
+  family: 'lexical-gravity';
+  widgetId: 'lexical-gravity';
+  widgetConfigInput: Extract<WorkshopWidgetConfigInput, { widgetId: 'lexical-gravity' }>;
+  widgetConfigId?: string;
+  editConflictMessage: string;
+  alreadyActiveMessage: string;
+}
+
+/** Each live standing feature contributes one exact prepared-request arm. */
+export type WorkshopStandingDirectiveApplyRequest =
+  WorkshopLexicalGravityStandingDirectiveApplyRequest;
 
 export interface WorkshopStandingDirectiveRendering {
   directive: WorkshopStandingDirectiveSnapshot;
@@ -53,12 +55,6 @@ export type WorkshopStandingDirectiveOperationEntries = Readonly<
   Record<WorkshopStandingDirectiveFamily, WorkshopStandingDirectiveOperationEntry>
 >;
 
-type WorkshopStandingApplyPreparers = {
-  [WidgetId in WorkshopApplyStandingWidgetPayload['widgetId']]: (
-    payload: Extract<WorkshopApplyStandingWidgetPayload, { widgetId: WidgetId }>
-  ) => WorkshopStandingDirectiveApplyRequest;
-};
-
 export interface WorkshopStandingDirectiveOperations {
   prepareApply(payload: WorkshopApplyStandingWidgetPayload): WorkshopStandingDirectiveApplyRequest;
   widgetIdForFamily(
@@ -79,8 +75,12 @@ export interface WorkshopStandingDirectiveOperations {
   describe(input: WorkshopStandingDirectiveRendering): string;
 }
 
-const unsupportedFamily = (family: WorkshopStandingDirectiveFamily): never => {
-  throw new Error(`Standing directive family ${family} is not implemented`);
+const unsupportedFamily = (family: unknown): never => {
+  throw new Error(`Standing directive family ${String(family)} is not implemented`);
+};
+
+const unsupportedApplyWidget = (widgetId: never): never => {
+  throw new Error(`Unsupported standing directive apply widget: ${String(widgetId)}`);
 };
 
 const proseControllerEntry: WorkshopStandingDirectiveOperationEntry = {
@@ -103,29 +103,32 @@ const proseControllerEntry: WorkshopStandingDirectiveOperationEntry = {
 export function createWorkshopStandingDirectiveOperations(
   entries: WorkshopStandingDirectiveOperationEntries
 ): WorkshopStandingDirectiveOperations {
-  const applyPreparers = {
-    'lexical-gravity': (payload) => entries['lexical-gravity'].prepareApply(payload)
-  } satisfies WorkshopStandingApplyPreparers;
+  const entryForFamily = (
+    family: WorkshopStandingDirectiveFamily
+  ): WorkshopStandingDirectiveOperationEntry =>
+    entries[family] ?? unsupportedFamily(family);
 
   return {
     prepareApply: (payload) => {
-      const prepare = applyPreparers[payload.widgetId] as (
-        input: WorkshopApplyStandingWidgetPayload
-      ) => WorkshopStandingDirectiveApplyRequest;
-      return prepare(payload);
+      switch (payload.widgetId) {
+        case 'lexical-gravity':
+          return entries['lexical-gravity'].prepareApply(payload);
+        default:
+          return unsupportedApplyWidget(payload.widgetId);
+      }
     },
-    widgetIdForFamily: (family) => entries[family].widgetId,
-    render: (input) => entries[input.directive.family].render(input),
-    summarize: (directive, config) => entries[directive.family].summarize(directive, config),
+    widgetIdForFamily: (family) => entryForFamily(family).widgetId,
+    render: (input) => entryForFamily(input.directive.family).render(input),
+    summarize: (directive, config) => entryForFamily(directive.family).summarize(directive, config),
     markerContent: (action, directive, previousConfig, currentConfig) =>
-      entries[directive.family].markerContent(
+      entryForFamily(directive.family).markerContent(
         action,
         directive,
         previousConfig,
         currentConfig
       ),
-    formatSummary: (summary) => entries[summary.family].formatSummary(summary),
-    describe: (input) => entries[input.directive.family].describe(input)
+    formatSummary: (summary) => entryForFamily(summary.family).formatSummary(summary),
+    describe: (input) => entryForFamily(input.directive.family).describe(input)
   };
 }
 

--- a/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveOperations.ts
+++ b/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveOperations.ts
@@ -1,0 +1,136 @@
+/** Closed family registry for standing-directive feature operations. */
+
+import {
+  WorkshopApplyStandingWidgetPayload,
+  WorkshopStandingDirectiveFamily,
+  WorkshopStandingDirectiveSnapshot,
+  WorkshopStandingDirectiveSummary,
+  WorkshopWidgetConfigSnapshot
+} from '@messages';
+import {
+  WorkshopWidgetConfigInput
+} from '@/application/services/workshop/widgets/WorkshopWidgetConfigLedger';
+import {
+  LEXICAL_GRAVITY_STANDING_DIRECTIVE_OPERATIONS
+} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityStandingDirectiveOperations';
+import { workshopWidgetLabel } from '@shared/constants/workshopWidgets';
+
+export type WorkshopStandingDirectiveApplyRequest = {
+  [Payload in WorkshopApplyStandingWidgetPayload as Payload['widgetId']]: {
+    family: Extract<WorkshopStandingDirectiveFamily, Payload['widgetId']>;
+    widgetId: Payload['widgetId'];
+    widgetConfigInput: Extract<WorkshopWidgetConfigInput, { widgetId: Payload['widgetId'] }>;
+    widgetConfigId?: string;
+    editConflictMessage: string;
+    alreadyActiveMessage: string;
+  }
+}[WorkshopApplyStandingWidgetPayload['widgetId']];
+
+export interface WorkshopStandingDirectiveRendering {
+  directive: WorkshopStandingDirectiveSnapshot;
+  config: WorkshopWidgetConfigSnapshot;
+}
+
+export interface WorkshopStandingDirectiveOperationEntry {
+  readonly widgetId: WorkshopStandingDirectiveSnapshot['widgetId'];
+  prepareApply(payload: WorkshopApplyStandingWidgetPayload): WorkshopStandingDirectiveApplyRequest;
+  render(input: WorkshopStandingDirectiveRendering): string;
+  summarize(
+    directive: WorkshopStandingDirectiveSnapshot,
+    config: WorkshopWidgetConfigSnapshot
+  ): WorkshopStandingDirectiveSummary;
+  markerContent(
+    action: 'installed' | 'shifted' | 'removed',
+    directive: WorkshopStandingDirectiveSnapshot,
+    previousConfig?: WorkshopWidgetConfigSnapshot,
+    currentConfig?: WorkshopWidgetConfigSnapshot
+  ): string;
+  formatSummary(summary: WorkshopStandingDirectiveSummary): string;
+  describe(input: WorkshopStandingDirectiveRendering): string;
+}
+
+export type WorkshopStandingDirectiveOperationEntries = Readonly<
+  Record<WorkshopStandingDirectiveFamily, WorkshopStandingDirectiveOperationEntry>
+>;
+
+type WorkshopStandingApplyPreparers = {
+  [WidgetId in WorkshopApplyStandingWidgetPayload['widgetId']]: (
+    payload: Extract<WorkshopApplyStandingWidgetPayload, { widgetId: WidgetId }>
+  ) => WorkshopStandingDirectiveApplyRequest;
+};
+
+export interface WorkshopStandingDirectiveOperations {
+  prepareApply(payload: WorkshopApplyStandingWidgetPayload): WorkshopStandingDirectiveApplyRequest;
+  widgetIdForFamily(
+    family: WorkshopStandingDirectiveFamily
+  ): WorkshopStandingDirectiveSnapshot['widgetId'];
+  render(input: WorkshopStandingDirectiveRendering): string;
+  summarize(
+    directive: WorkshopStandingDirectiveSnapshot,
+    config: WorkshopWidgetConfigSnapshot
+  ): WorkshopStandingDirectiveSummary;
+  markerContent(
+    action: 'installed' | 'shifted' | 'removed',
+    directive: WorkshopStandingDirectiveSnapshot,
+    previousConfig?: WorkshopWidgetConfigSnapshot,
+    currentConfig?: WorkshopWidgetConfigSnapshot
+  ): string;
+  formatSummary(summary: WorkshopStandingDirectiveSummary): string;
+  describe(input: WorkshopStandingDirectiveRendering): string;
+}
+
+const unsupportedFamily = (family: WorkshopStandingDirectiveFamily): never => {
+  throw new Error(`Standing directive family ${family} is not implemented`);
+};
+
+const proseControllerEntry: WorkshopStandingDirectiveOperationEntry = {
+  widgetId: 'prose-controller',
+  prepareApply: () => unsupportedFamily('prose-controller'),
+  render: () => unsupportedFamily('prose-controller'),
+  summarize: () => unsupportedFamily('prose-controller'),
+  markerContent: (action, directive) => {
+    const verb = action === 'installed'
+      ? 'Installed'
+      : action === 'shifted'
+        ? 'Shifted'
+        : 'Removed';
+    return `${verb} ${workshopWidgetLabel(directive.widgetId)}.`;
+  },
+  formatSummary: () => unsupportedFamily('prose-controller'),
+  describe: () => unsupportedFamily('prose-controller')
+};
+
+export function createWorkshopStandingDirectiveOperations(
+  entries: WorkshopStandingDirectiveOperationEntries
+): WorkshopStandingDirectiveOperations {
+  const applyPreparers = {
+    'lexical-gravity': (payload) => entries['lexical-gravity'].prepareApply(payload)
+  } satisfies WorkshopStandingApplyPreparers;
+
+  return {
+    prepareApply: (payload) => {
+      const prepare = applyPreparers[payload.widgetId] as (
+        input: WorkshopApplyStandingWidgetPayload
+      ) => WorkshopStandingDirectiveApplyRequest;
+      return prepare(payload);
+    },
+    widgetIdForFamily: (family) => entries[family].widgetId,
+    render: (input) => entries[input.directive.family].render(input),
+    summarize: (directive, config) => entries[directive.family].summarize(directive, config),
+    markerContent: (action, directive, previousConfig, currentConfig) =>
+      entries[directive.family].markerContent(
+        action,
+        directive,
+        previousConfig,
+        currentConfig
+      ),
+    formatSummary: (summary) => entries[summary.family].formatSummary(summary),
+    describe: (input) => entries[input.directive.family].describe(input)
+  };
+}
+
+export const WORKSHOP_STANDING_DIRECTIVE_OPERATIONS =
+  createWorkshopStandingDirectiveOperations({
+    'lexical-gravity': LEXICAL_GRAVITY_STANDING_DIRECTIVE_OPERATIONS,
+    'prose-controller': proseControllerEntry
+  });

--- a/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectivePresentation.ts
+++ b/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectivePresentation.ts
@@ -5,66 +5,33 @@ import {
   WorkshopStandingDirectiveSummary,
   WorkshopWidgetConfigSnapshot
 } from '@messages';
-import { workshopWidgetLabel } from '@shared/constants/workshopWidgets';
 import {
-  lexicalGravityMarkerContent
-} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityDirective';
-import {
-  summarizeLexicalGravityDraft
-} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityConfigCodec';
+  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS,
+  WorkshopStandingDirectiveOperations
+} from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
 
 export function summarizeWorkshopStandingDirective(
   directive: WorkshopStandingDirectiveSnapshot,
-  config: WorkshopWidgetConfigSnapshot
+  config: WorkshopWidgetConfigSnapshot,
+  operations: WorkshopStandingDirectiveOperations = WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
 ): WorkshopStandingDirectiveSummary {
   if (directive.widgetId !== config.widgetId) {
     throw new Error(`Standing directive ${directive.id} has no matching widget config`);
   }
-  switch (directive.family) {
-    case 'lexical-gravity': {
-      if (directive.widgetId !== 'lexical-gravity' || config.widgetId !== 'lexical-gravity') {
-        throw new Error(`Lexical Gravity directive ${directive.id} has the wrong config`);
-      }
-      return {
-        ...directive,
-        family: 'lexical-gravity',
-        widgetId: 'lexical-gravity',
-        ...summarizeLexicalGravityDraft(config.draft)
-      };
-    }
-    case 'prose-controller':
-      throw new Error('Prose Controller standing directives are not implemented');
-    default:
-      return assertNever(directive.family);
-  }
+  return operations.summarize(directive, config);
 }
 
 export function workshopStandingDirectiveMarkerContent(
   action: 'installed' | 'shifted' | 'removed',
   directive: WorkshopStandingDirectiveSnapshot,
   previousConfig?: WorkshopWidgetConfigSnapshot,
-  currentConfig?: WorkshopWidgetConfigSnapshot
+  currentConfig?: WorkshopWidgetConfigSnapshot,
+  operations: WorkshopStandingDirectiveOperations = WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
 ): string {
-  switch (directive.family) {
-    case 'lexical-gravity':
-      return lexicalGravityMarkerContent(
-        action,
-        previousConfig?.widgetId === 'lexical-gravity' ? previousConfig : undefined,
-        currentConfig?.widgetId === 'lexical-gravity' ? currentConfig : undefined
-      );
-    case 'prose-controller': {
-      const verb = action === 'installed'
-        ? 'Installed'
-        : action === 'shifted'
-          ? 'Shifted'
-          : 'Removed';
-      return `${verb} ${workshopWidgetLabel(directive.widgetId)}.`;
-    }
-    default:
-      return assertNever(directive.family);
-  }
-}
-
-function assertNever(value: never): never {
-  throw new Error(`Unsupported standing directive family: ${String(value)}`);
+  return operations.markerContent(
+    action,
+    directive,
+    previousConfig,
+    currentConfig
+  );
 }

--- a/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveService.ts
+++ b/packages/core/src/application/services/workshop/directives/WorkshopStandingDirectiveService.ts
@@ -1,8 +1,8 @@
 /** Serialized application use cases for standing prose directives. */
 
 import {
-  WorkshopLexicalGravityDraft,
   WorkshopStandingDirectiveFamily,
+  WorkshopStandingDirectiveSnapshot,
   WorkshopTurn,
   WorkshopWidgetConfigSnapshot
 } from '@messages';
@@ -11,16 +11,19 @@ import { WorkshopConversationSettingsService } from '@/application/services/work
 import {
   renderWorkshopStandingDirectiveFramesForSnapshots
 } from '@/application/services/workshop/directives/WorkshopStandingDirectiveFrames';
+import {
+  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS,
+  WorkshopStandingDirectiveApplyRequest,
+  WorkshopStandingDirectiveOperations
+} from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
 
-export type WorkshopStandingDirectiveApplyRequest = {
-  family: 'lexical-gravity';
-  draft: WorkshopLexicalGravityDraft;
-  widgetConfigId?: string;
-};
+export type { WorkshopStandingDirectiveApplyRequest } from
+  '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
 
 export interface WorkshopStandingDirectiveApplyResult {
   action: 'installed' | 'shifted';
   directiveId: string;
+  directive: WorkshopStandingDirectiveSnapshot;
   config: WorkshopWidgetConfigSnapshot;
   turn: WorkshopTurn;
 }
@@ -36,7 +39,9 @@ export class WorkshopStandingDirectiveService {
 
   constructor(
     private readonly session: WorkshopSessionService,
-    private readonly conversationSettings: WorkshopConversationSettingsService
+    private readonly conversationSettings: WorkshopConversationSettingsService,
+    private readonly operations: WorkshopStandingDirectiveOperations =
+      WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
   ) {}
 
   async apply(
@@ -44,31 +49,35 @@ export class WorkshopStandingDirectiveService {
   ): Promise<WorkshopStandingDirectiveApplyResult> {
     return this.serialize(async () => {
       this.assertBetweenRuns();
-      const { draft, family, widgetConfigId } = request;
-      if (family !== 'lexical-gravity') {
-        throw new Error(`Standing directive family ${String(family)} is not implemented`);
+      const {
+        family,
+        widgetId,
+        widgetConfigInput,
+        widgetConfigId,
+        editConflictMessage,
+        alreadyActiveMessage
+      } = request;
+      if (this.operations.widgetIdForFamily(family) !== widgetId) {
+        throw new Error(`Standing directive family ${family} does not own ${widgetId}`);
       }
-      const active = this.session.getStandingDirective('lexical-gravity');
+      if (widgetConfigInput.widgetId !== widgetId) {
+        throw new Error(`Standing directive ${family} received config for ${widgetConfigInput.widgetId}`);
+      }
+      const active = this.session.getStandingDirective(family);
       if (widgetConfigId && active?.widgetConfigId !== widgetConfigId) {
-        throw new Error('Lexical Gravity can edit only its currently active configuration.');
+        throw new Error(editConflictMessage);
       }
       if (!widgetConfigId && active) {
-        throw new Error('Lexical Gravity is already active; reopen it to shift the directive.');
+        throw new Error(alreadyActiveMessage);
       }
 
       const preparedConfig = widgetConfigId
-        ? this.session.prepareWidgetConfigRevision(widgetConfigId, {
-            widgetId: 'lexical-gravity',
-            draft
-          })
-        : this.session.prepareWidgetConfigCreation({
-            widgetId: 'lexical-gravity',
-            draft
-          });
+        ? this.session.prepareWidgetConfigRevision(widgetConfigId, widgetConfigInput)
+        : this.session.prepareWidgetConfigCreation(widgetConfigInput);
       const config = preparedConfig.config;
       const preparedDirective = this.session.prepareStandingDirectiveUpsert({
-        family: 'lexical-gravity',
-        widgetId: 'lexical-gravity',
+        family,
+        widgetId,
         widgetConfigId: config.id,
         revision: config.revision
       });
@@ -76,7 +85,8 @@ export class WorkshopStandingDirectiveService {
         preparedDirective.state.directives,
         (configId) => configId === config.id
           ? config
-          : this.session.getWidgetConfig(configId)
+          : this.session.getWidgetConfig(configId),
+        this.operations
       );
       await this.conversationSettings.replaceStandingDirectiveFrames(frames);
       const turn = this.session.commitStandingDirectiveMutation(
@@ -86,6 +96,7 @@ export class WorkshopStandingDirectiveService {
       return {
         action: preparedDirective.action,
         directiveId: preparedDirective.directive.id,
+        directive: preparedDirective.directive,
         config: this.session.getWidgetConfig(config.id)!,
         turn
       };
@@ -101,7 +112,8 @@ export class WorkshopStandingDirectiveService {
       if (!prepared) {return { removed: false };}
       const frames = renderWorkshopStandingDirectiveFramesForSnapshots(
         prepared.state.directives,
-        (configId) => this.session.getWidgetConfig(configId)
+        (configId) => this.session.getWidgetConfig(configId),
+        this.operations
       );
       await this.conversationSettings.replaceStandingDirectiveFrames(frames);
       const turn = this.session.commitStandingDirectiveMutation(prepared);

--- a/packages/core/src/application/services/workshop/widgets/lexicalGravity/LexicalGravityStandingDirectiveOperations.ts
+++ b/packages/core/src/application/services/workshop/widgets/lexicalGravity/LexicalGravityStandingDirectiveOperations.ts
@@ -1,6 +1,10 @@
 /** Lexical Gravity semantics plugged into the shared standing transaction. */
 
 import type {
+  WorkshopLexicalGravityWidgetConfigSnapshot,
+  WorkshopStandingDirectiveSnapshot
+} from '@messages';
+import type {
   WorkshopStandingDirectiveOperationEntry,
   WorkshopStandingDirectiveRendering
 } from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
@@ -14,17 +18,41 @@ import {
   lexicalGravityMarkerContent
 } from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityDirective';
 
-const renderLexicalGravityDirective = ({
-  directive,
-  config
-}: WorkshopStandingDirectiveRendering): string => {
+type LexicalGravityDirective = WorkshopStandingDirectiveSnapshot & {
+  family: 'lexical-gravity';
+  widgetId: 'lexical-gravity';
+};
+
+interface LexicalGravityRendering {
+  directive: LexicalGravityDirective;
+  config: WorkshopLexicalGravityWidgetConfigSnapshot;
+}
+
+const asLexicalGravityDirective = (
+  directive: WorkshopStandingDirectiveSnapshot
+): LexicalGravityDirective => {
   if (
     directive.family !== 'lexical-gravity'
     || directive.widgetId !== 'lexical-gravity'
-    || config.widgetId !== 'lexical-gravity'
   ) {
+    throw new Error(`Lexical Gravity directive ${directive.id} has the wrong identity`);
+  }
+  return directive as LexicalGravityDirective;
+};
+
+const asLexicalGravityRendering = ({
+  directive,
+  config
+}: WorkshopStandingDirectiveRendering): LexicalGravityRendering => {
+  const lexicalDirective = asLexicalGravityDirective(directive);
+  if (config.widgetId !== 'lexical-gravity') {
     throw new Error(`Lexical Gravity directive ${directive.id} has the wrong config`);
   }
+  return { directive: lexicalDirective, config };
+};
+
+const renderLexicalGravityDirective = (input: WorkshopStandingDirectiveRendering): string => {
+  const { directive, config } = asLexicalGravityRendering(input);
   return buildLexicalGravityDirectiveFrame(directive, config.draft);
 };
 
@@ -46,25 +74,17 @@ export const LEXICAL_GRAVITY_STANDING_DIRECTIVE_OPERATIONS = {
   render: renderLexicalGravityDirective,
 
   summarize: (directive, config) => {
-    if (
-      directive.family !== 'lexical-gravity'
-      || directive.widgetId !== 'lexical-gravity'
-      || config.widgetId !== 'lexical-gravity'
-    ) {
-      throw new Error(`Lexical Gravity directive ${directive.id} has the wrong config`);
-    }
+    const lexical = asLexicalGravityRendering({ directive, config });
     return {
-      ...directive,
+      ...lexical.directive,
       family: 'lexical-gravity',
       widgetId: 'lexical-gravity',
-      ...summarizeLexicalGravityDraft(config.draft)
+      ...summarizeLexicalGravityDraft(lexical.config.draft)
     };
   },
 
   markerContent: (action, directive, previousConfig, currentConfig) => {
-    if (directive.family !== 'lexical-gravity' || directive.widgetId !== 'lexical-gravity') {
-      throw new Error(`Lexical Gravity directive ${directive.id} has the wrong identity`);
-    }
+    asLexicalGravityDirective(directive);
     return lexicalGravityMarkerContent(
       action,
       previousConfig?.widgetId === 'lexical-gravity' ? previousConfig : undefined,
@@ -72,18 +92,10 @@ export const LEXICAL_GRAVITY_STANDING_DIRECTIVE_OPERATIONS = {
     );
   },
 
-  formatSummary: (summary) => {
-    if (summary.family !== 'lexical-gravity') {
-      throw new Error(`Lexical Gravity cannot format ${summary.family}`);
-    }
-    return formatLexicalGravitySummary(summary);
-  },
+  formatSummary: formatLexicalGravitySummary,
 
   describe: (input) => {
-    const frame = renderLexicalGravityDirective(input);
-    if (input.config.widgetId !== 'lexical-gravity') {
-      throw new Error(`Lexical Gravity directive ${input.directive.id} has the wrong config`);
-    }
-    return `lens ${input.config.draft.lensSlug}, ${frame.length} chars`;
+    const { config } = asLexicalGravityRendering(input);
+    return `lens ${config.draft.lensSlug}, ${config.draft.weight}% weight, ${config.draft.reach}° reach`;
   }
 } satisfies WorkshopStandingDirectiveOperationEntry;

--- a/packages/core/src/application/services/workshop/widgets/lexicalGravity/LexicalGravityStandingDirectiveOperations.ts
+++ b/packages/core/src/application/services/workshop/widgets/lexicalGravity/LexicalGravityStandingDirectiveOperations.ts
@@ -1,0 +1,89 @@
+/** Lexical Gravity semantics plugged into the shared standing transaction. */
+
+import type {
+  WorkshopStandingDirectiveOperationEntry,
+  WorkshopStandingDirectiveRendering
+} from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
+import {
+  summarizeLexicalGravityDraft,
+  validateLexicalGravityDraft
+} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityConfigCodec';
+import {
+  buildLexicalGravityDirectiveFrame,
+  formatLexicalGravitySummary,
+  lexicalGravityMarkerContent
+} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityDirective';
+
+const renderLexicalGravityDirective = ({
+  directive,
+  config
+}: WorkshopStandingDirectiveRendering): string => {
+  if (
+    directive.family !== 'lexical-gravity'
+    || directive.widgetId !== 'lexical-gravity'
+    || config.widgetId !== 'lexical-gravity'
+  ) {
+    throw new Error(`Lexical Gravity directive ${directive.id} has the wrong config`);
+  }
+  return buildLexicalGravityDirectiveFrame(directive, config.draft);
+};
+
+export const LEXICAL_GRAVITY_STANDING_DIRECTIVE_OPERATIONS = {
+  widgetId: 'lexical-gravity',
+
+  prepareApply: (payload) => {
+    const draft = validateLexicalGravityDraft(payload.draft);
+    return {
+      family: 'lexical-gravity',
+      widgetId: 'lexical-gravity',
+      widgetConfigInput: { widgetId: 'lexical-gravity', draft },
+      widgetConfigId: payload.widgetConfigId,
+      editConflictMessage: 'Lexical Gravity can edit only its currently active configuration.',
+      alreadyActiveMessage: 'Lexical Gravity is already active; reopen it to shift the directive.'
+    };
+  },
+
+  render: renderLexicalGravityDirective,
+
+  summarize: (directive, config) => {
+    if (
+      directive.family !== 'lexical-gravity'
+      || directive.widgetId !== 'lexical-gravity'
+      || config.widgetId !== 'lexical-gravity'
+    ) {
+      throw new Error(`Lexical Gravity directive ${directive.id} has the wrong config`);
+    }
+    return {
+      ...directive,
+      family: 'lexical-gravity',
+      widgetId: 'lexical-gravity',
+      ...summarizeLexicalGravityDraft(config.draft)
+    };
+  },
+
+  markerContent: (action, directive, previousConfig, currentConfig) => {
+    if (directive.family !== 'lexical-gravity' || directive.widgetId !== 'lexical-gravity') {
+      throw new Error(`Lexical Gravity directive ${directive.id} has the wrong identity`);
+    }
+    return lexicalGravityMarkerContent(
+      action,
+      previousConfig?.widgetId === 'lexical-gravity' ? previousConfig : undefined,
+      currentConfig?.widgetId === 'lexical-gravity' ? currentConfig : undefined
+    );
+  },
+
+  formatSummary: (summary) => {
+    if (summary.family !== 'lexical-gravity') {
+      throw new Error(`Lexical Gravity cannot format ${summary.family}`);
+    }
+    return formatLexicalGravitySummary(summary);
+  },
+
+  describe: (input) => {
+    const frame = renderLexicalGravityDirective(input);
+    if (input.config.widgetId !== 'lexical-gravity') {
+      throw new Error(`Lexical Gravity directive ${input.directive.id} has the wrong config`);
+    }
+    return `lens ${input.config.draft.lensSlug}, ${frame.length} chars`;
+  }
+} satisfies WorkshopStandingDirectiveOperationEntry;

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -1498,6 +1498,8 @@ export const WorkshopApp: React.FC = () => {
             <WorkshopStandingDirectiveRail
               directives={workshop.standingDirectives}
               disabled={showLiveTurn || roomMutationLocked}
+              removingWidgetIds={standingDirectives.removingWidgetIds}
+              formatSummary={standingDirectives.formatSummary}
               onEdit={openWidgetConfig}
               onRemove={standingDirectives.remove}
             />

--- a/packages/core/src/presentation/webview/WorkshopApp.tsx
+++ b/packages/core/src/presentation/webview/WorkshopApp.tsx
@@ -118,6 +118,9 @@ import {
   useGesturePlayground
 } from '@hooks/domain/workshop/widgets/useGesturePlayground';
 import { useLexicalGravity } from '@hooks/domain/workshop/widgets/useLexicalGravity';
+import {
+  useWorkshopStandingDirectives
+} from '@hooks/domain/workshop/useWorkshopStandingDirectives';
 import { useWorkshopExcerptVerify } from './hooks/domain/useWorkshopExcerptVerify';
 import { useWorkshopThreadAutoscroll } from './hooks/useWorkshopThreadAutoscroll';
 import { useModelsSettings } from './hooks/domain/useModelsSettings';
@@ -215,6 +218,7 @@ export const WorkshopApp: React.FC = () => {
   const showToast = React.useCallback((next: WorkshopToastState) => {
     setToast(next);
   }, []);
+  const standingDirectives = useWorkshopStandingDirectives(showToast);
 
   React.useEffect(() => {
     if (!toast) {
@@ -275,12 +279,12 @@ export const WorkshopApp: React.FC = () => {
     widgetHost,
     gesturePlayground,
     lexicalGravity,
+    standingDirectives,
     excerptVerify,
     modelsSettings,
     tokenTracking,
     accountBalance,
     startupNotice,
-    showToast,
     handleApiKeyStatus,
     handleStatusMessage,
     handleErrorMessage,
@@ -293,6 +297,7 @@ export const WorkshopApp: React.FC = () => {
     ...widgetHost.persistedState,
     ...gesturePlayground.persistedState,
     ...lexicalGravity.persistedState,
+    ...standingDirectives.persistedState,
     ...excerptVerify.persistedState,
     ...modelsSettings.persistedState,
     ...tokenTracking.persistedState,
@@ -1494,7 +1499,7 @@ export const WorkshopApp: React.FC = () => {
               directives={workshop.standingDirectives}
               disabled={showLiveTurn || roomMutationLocked}
               onEdit={openWidgetConfig}
-              onRemove={lexicalGravity.remove}
+              onRemove={standingDirectives.remove}
             />
             <WorkshopComposer
               canMessage={workshop.canMessage && !roomMutationLocked}

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.tsx
@@ -1,31 +1,24 @@
 /** Generic composer-adjacent rail for active standing directive families. */
 
 import * as React from 'react';
-import {
-  WorkshopStandingDirectiveFamily,
-  WorkshopStandingDirectiveSummary
-} from '@messages';
+import { WorkshopStandingDirectiveSummary } from '@messages';
 import { Icon } from '@components/shared/Icon';
 import { workshopWidgetLabel } from '@shared/constants/workshopWidgets';
 import {
-  formatLexicalGravitySummary
-} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityDirective';
+  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
+} from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
 
 interface WorkshopStandingDirectiveRailProps {
   directives: WorkshopStandingDirectiveSummary[];
   disabled?: boolean;
   onEdit: (widgetConfigId: string) => void;
-  onRemove: (family: WorkshopStandingDirectiveFamily) => void;
+  onRemove: (
+    directive: Pick<WorkshopStandingDirectiveSummary, 'family' | 'widgetId'>
+  ) => void;
 }
 
-const directiveConfig = (directive: WorkshopStandingDirectiveSummary): string => {
-  switch (directive.family) {
-    case 'lexical-gravity':
-      return formatLexicalGravitySummary(directive);
-    default:
-      return '';
-  }
-};
+const directiveConfig = (directive: WorkshopStandingDirectiveSummary): string =>
+  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS.formatSummary(directive);
 
 export const WorkshopStandingDirectiveRail: React.FC<WorkshopStandingDirectiveRailProps> = ({
   directives,
@@ -49,7 +42,7 @@ export const WorkshopStandingDirectiveRail: React.FC<WorkshopStandingDirectiveRa
             disabled={disabled}
             title={`Remove ${workshopWidgetLabel(directive.widgetId)}`}
             aria-label={`Remove ${workshopWidgetLabel(directive.widgetId)}`}
-            onClick={() => onRemove(directive.family)}
+            onClick={() => onRemove(directive)}
           >
             <Icon name="x" size={11} />
           </button>

--- a/packages/core/src/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/WorkshopStandingDirectiveRail.tsx
@@ -1,28 +1,29 @@
 /** Generic composer-adjacent rail for active standing directive families. */
 
 import * as React from 'react';
-import { WorkshopStandingDirectiveSummary } from '@messages';
+import {
+  WorkshopStandingDirectiveSnapshot,
+  WorkshopStandingDirectiveSummary
+} from '@messages';
 import { Icon } from '@components/shared/Icon';
 import { workshopWidgetLabel } from '@shared/constants/workshopWidgets';
-import {
-  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS
-} from '@/application/services/workshop/directives/WorkshopStandingDirectiveOperations';
 
 interface WorkshopStandingDirectiveRailProps {
   directives: WorkshopStandingDirectiveSummary[];
   disabled?: boolean;
+  removingWidgetIds?: readonly WorkshopStandingDirectiveSnapshot['widgetId'][];
+  formatSummary: (directive: WorkshopStandingDirectiveSummary) => string;
   onEdit: (widgetConfigId: string) => void;
   onRemove: (
     directive: Pick<WorkshopStandingDirectiveSummary, 'family' | 'widgetId'>
   ) => void;
 }
 
-const directiveConfig = (directive: WorkshopStandingDirectiveSummary): string =>
-  WORKSHOP_STANDING_DIRECTIVE_OPERATIONS.formatSummary(directive);
-
 export const WorkshopStandingDirectiveRail: React.FC<WorkshopStandingDirectiveRailProps> = ({
   directives,
   disabled,
+  removingWidgetIds = [],
+  formatSummary,
   onEdit,
   onRemove
 }) => {
@@ -33,13 +34,13 @@ export const WorkshopStandingDirectiveRail: React.FC<WorkshopStandingDirectiveRa
         <div className="pm-ws-standing-active" key={directive.id}>
           <span className="pm-ws-standing-pulse" aria-hidden="true" />
           <b>{workshopWidgetLabel(directive.widgetId)}</b>
-          <span className="pm-ws-standing-config">{directiveConfig(directive)}</span>
+          <span className="pm-ws-standing-config">{formatSummary(directive)}</span>
           <span className="pm-ws-standing-spacer" />
           <button type="button" disabled={disabled} onClick={() => onEdit(directive.widgetConfigId)}>Edit</button>
           <button
             type="button"
             className="pm-ws-standing-kill"
-            disabled={disabled}
+            disabled={disabled || removingWidgetIds.includes(directive.widgetId)}
             title={`Remove ${workshopWidgetLabel(directive.widgetId)}`}
             aria-label={`Remove ${workshopWidgetLabel(directive.widgetId)}`}
             onClick={() => onRemove(directive)}

--- a/packages/core/src/presentation/webview/components/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundModal.tsx
+++ b/packages/core/src/presentation/webview/components/workshop/widgets/gesturePlayground/WorkshopGesturePlaygroundModal.tsx
@@ -23,9 +23,9 @@ import {
   WorkshopGestureDraft,
   WorkshopGestureMenuGroup,
   WorkshopGestureWidgetConfigSnapshot,
-  WorkshopWidgetGeneratePayload,
-  WorkshopWidgetGenerationProgressPayload,
-  WorkshopWidgetMenuResultPayload,
+  WorkshopGesturePlaygroundGeneratePayload,
+  WorkshopGesturePlaygroundGenerationProgressPayload,
+  WorkshopGesturePlaygroundMenuResultPayload,
   WorkshopWidgetRecommendationSeed,
   WorkshopWidgetActionResultPayload,
   WorkshopWidgetSourceReference,
@@ -47,12 +47,12 @@ export type WorkshopGestureOpening =
 interface WorkshopGesturePlaygroundModalProps {
   open: boolean;
   opening: WorkshopGestureOpening;
-  menuResult: WorkshopWidgetMenuResultPayload | null;
-  generationProgress: WorkshopWidgetGenerationProgressPayload | null;
+  menuResult: WorkshopGesturePlaygroundMenuResultPayload | null;
+  generationProgress: WorkshopGesturePlaygroundGenerationProgressPayload | null;
   actionResult: WorkshopWidgetActionResultPayload | null;
   activeExcerpt: WorkshopExcerptSnapshot | null;
   contextAttachments: WorkshopContextAttachmentSnapshot[];
-  onGenerate: (payload: WorkshopWidgetGeneratePayload) => void;
+  onGenerate: (payload: WorkshopGesturePlaygroundGeneratePayload) => void;
   onCancelGenerate: (requestId: string) => void;
   onCommit: (draft: WorkshopGestureDraft, clonedFromConfigId?: string) => void;
   onConsumeActionResult: () => void;
@@ -76,7 +76,7 @@ const sourceReferenceKey = (reference: WorkshopWidgetSourceReference): string =>
     ? reference.kind
     : `${reference.kind}:${reference.attachmentId}`;
 
-const stageLabels: Record<WorkshopWidgetGenerationProgressPayload['stage'], string> = {
+const stageLabels: Record<WorkshopGesturePlaygroundGenerationProgressPayload['stage'], string> = {
   requesting: 'Preparing the request',
   dictionary: 'Building the gesture dictionary',
   menu: 'Building creative alternatives',

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/createWorkshopWidgetActionRequestToken.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/createWorkshopWidgetActionRequestToken.ts
@@ -1,0 +1,10 @@
+/** Monotonic webview-local correlation token for shared widget mutations. */
+let workshopWidgetActionCounter = 0;
+
+export type WorkshopWidgetActionRequest = 'commit' | 'apply-standing' | 'remove-standing';
+
+export function createWorkshopWidgetActionRequestToken(
+  action: WorkshopWidgetActionRequest
+): string {
+  return `${action}-${Date.now()}-${++workshopWidgetActionCounter}`;
+}

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/dispatchWorkshopWidgetActionResult.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/dispatchWorkshopWidgetActionResult.ts
@@ -1,16 +1,15 @@
 import { WorkshopWidgetActionResultMessage } from '@messages';
-import { WorkshopToastState } from '@components/workshop/WorkshopToast';
 
 export interface WorkshopWidgetActionResultConsumers {
   handleGestureActionResult: (message: WorkshopWidgetActionResultMessage) => void;
   handleLexicalActionResult: (message: WorkshopWidgetActionResultMessage) => void;
-  showToast: (toast: WorkshopToastState) => void;
+  handleStandingDirectiveActionResult: (message: WorkshopWidgetActionResultMessage) => void;
 }
 
 /**
  * Preserves the Workshop action-result fan-out at one testable composition seam.
- * Each feature hook filters the shared envelope for its own actions; the shell
- * additionally owns the writer-facing acknowledgement for standing removal.
+ * Each owner filters the shared envelope for its exact action, widget, and
+ * request token. The dispatcher owns fan-out only; it contains no feature copy.
  */
 export function dispatchWorkshopWidgetActionResult(
   message: WorkshopWidgetActionResultMessage,
@@ -18,20 +17,5 @@ export function dispatchWorkshopWidgetActionResult(
 ): void {
   consumers.handleGestureActionResult(message);
   consumers.handleLexicalActionResult(message);
-  if (message.payload.action !== 'remove-standing') {
-    return;
-  }
-
-  consumers.showToast(message.payload.ok
-    ? {
-        message: message.payload.removed
-          ? 'Lexical Gravity removed.'
-          : 'Lexical Gravity was already removed.',
-        icon: message.payload.removed ? 'check' : 'info'
-      }
-    : {
-        message: message.payload.message ?? 'Lexical Gravity could not be removed.',
-        icon: 'x',
-        tone: 'error'
-      });
+  consumers.handleStandingDirectiveActionResult(message);
 }

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/reportWorkshopWidgetActionCorrelationIssue.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/reportWorkshopWidgetActionCorrelationIssue.ts
@@ -1,0 +1,17 @@
+/** Visible diagnostic trail for rejected Workshop widget acknowledgements. */
+
+import { WorkshopWidgetActionResultMessage } from '@messages';
+
+export function reportWorkshopWidgetActionCorrelationIssue(
+  owner: string,
+  message: WorkshopWidgetActionResultMessage,
+  reason: string
+): void {
+  console.warn(
+    `[${owner}] Ignored ${message.payload.action} acknowledgement: ${reason}`,
+    {
+      requestToken: message.payload.requestToken,
+      widgetId: message.payload.widgetId
+    }
+  );
+}

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.ts
@@ -7,11 +7,20 @@ import {
   createWorkshopWidgetActionRequestToken
 } from '@hooks/domain/workshop/createWorkshopWidgetActionRequestToken';
 import {
+  reportWorkshopWidgetActionCorrelationIssue
+} from '@hooks/domain/workshop/reportWorkshopWidgetActionCorrelationIssue';
+import {
+  formatLexicalGravitySummary
+} from '@/application/services/workshop/widgets/lexicalGravity/LexicalGravityDirective';
+import {
   MessageType,
   WorkshopStandingDirectiveFamily,
+  WorkshopStandingDirectiveSummary,
   WorkshopWidgetActionResultMessage
 } from '@messages';
 import { workshopWidgetLabel } from '@shared/constants/workshopWidgets';
+
+const REMOVE_ACK_TIMEOUT_MS = 10_000;
 
 export type StandingDirectiveIdentity = {
   [Family in WorkshopStandingDirectiveFamily]: {
@@ -20,50 +29,128 @@ export type StandingDirectiveIdentity = {
   }
 }[WorkshopStandingDirectiveFamily];
 
+export interface WorkshopStandingDirectiveState {
+  removingWidgetIds: readonly StandingDirectiveIdentity['widgetId'][];
+}
+
 export interface WorkshopStandingDirectiveActions {
   remove: (directive: StandingDirectiveIdentity) => void;
   handleActionResult: (message: WorkshopWidgetActionResultMessage) => void;
+  formatSummary: (summary: WorkshopStandingDirectiveSummary) => string;
 }
 
 export interface WorkshopStandingDirectivePersistence {
   // Host/session storage owns every durable value in this domain.
 }
 
-export type UseWorkshopStandingDirectivesReturn = WorkshopStandingDirectiveActions & {
-  persistedState: WorkshopStandingDirectivePersistence;
+export type UseWorkshopStandingDirectivesReturn = WorkshopStandingDirectiveState &
+  WorkshopStandingDirectiveActions & {
+    persistedState: WorkshopStandingDirectivePersistence;
+  };
+
+interface PendingRemoval {
+  widgetId: StandingDirectiveIdentity['widgetId'];
+  timeoutId: number;
+}
+
+const unsupportedSummaryFamily = (family: never): never => {
+  throw new Error(`Unsupported standing directive summary family: ${String(family)}`);
+};
+
+const formatStandingDirectiveSummary = (
+  summary: WorkshopStandingDirectiveSummary
+): string => {
+  switch (summary.family) {
+    case 'lexical-gravity':
+      return formatLexicalGravitySummary(summary);
+    default:
+      return unsupportedSummaryFamily(summary.family);
+  }
 };
 
 export function useWorkshopStandingDirectives(
   showToast: (toast: WorkshopToastState) => void
 ): UseWorkshopStandingDirectivesReturn {
   const vscode = useVSCodeApi();
-  const pendingRemovalRef = React.useRef<{
-    requestToken: string;
-    widgetId: StandingDirectiveIdentity['widgetId'];
-  }>();
+  const pendingRemovalsRef = React.useRef(new Map<string, PendingRemoval>());
+  const [removingWidgetIds, setRemovingWidgetIds] =
+    React.useState<readonly StandingDirectiveIdentity['widgetId'][]>([]);
+
+  const syncRemovingWidgetIds = React.useCallback(() => {
+    setRemovingWidgetIds(Array.from(
+      new Set(Array.from(pendingRemovalsRef.current.values(), ({ widgetId }) => widgetId))
+    ));
+  }, []);
+
+  React.useEffect(() => () => {
+    pendingRemovalsRef.current.forEach(({ timeoutId }) => window.clearTimeout(timeoutId));
+    pendingRemovalsRef.current.clear();
+  }, []);
 
   const remove = React.useCallback((directive: StandingDirectiveIdentity) => {
+    const label = workshopWidgetLabel(directive.widgetId);
+    const alreadyPending = Array.from(pendingRemovalsRef.current.values())
+      .some(({ widgetId }) => widgetId === directive.widgetId);
+    if (alreadyPending) {
+      showToast({ message: `${label} removal is already in progress.`, icon: 'info' });
+      return;
+    }
+
     const requestToken = createWorkshopWidgetActionRequestToken('remove-standing');
-    pendingRemovalRef.current = { requestToken, widgetId: directive.widgetId };
+    const timeoutId = window.setTimeout(() => {
+      const pending = pendingRemovalsRef.current.get(requestToken);
+      if (!pending) {return;}
+      pendingRemovalsRef.current.delete(requestToken);
+      syncRemovingWidgetIds();
+      console.warn(
+        '[useWorkshopStandingDirectives] Remove acknowledgement timed out',
+        { requestToken, widgetId: pending.widgetId }
+      );
+      showToast({
+        message: `${workshopWidgetLabel(pending.widgetId)} removal was not confirmed.`,
+        icon: 'x',
+        tone: 'error'
+      });
+    }, REMOVE_ACK_TIMEOUT_MS);
+    pendingRemovalsRef.current.set(requestToken, {
+      widgetId: directive.widgetId,
+      timeoutId
+    });
+    syncRemovingWidgetIds();
     vscode.postMessage({
       type: MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
       source: 'webview.workshop.standing-directives',
       payload: { requestToken, family: directive.family },
       timestamp: Date.now()
     });
-  }, [vscode]);
+  }, [showToast, syncRemovingWidgetIds, vscode]);
 
   const handleActionResult = React.useCallback((message: WorkshopWidgetActionResultMessage) => {
-    const pending = pendingRemovalRef.current;
-    if (
-      message.payload.action !== 'remove-standing'
-      || message.payload.requestToken !== pending?.requestToken
-      || message.payload.widgetId !== pending.widgetId
-    ) {
+    if (message.payload.action !== 'remove-standing') {
       return;
     }
 
-    pendingRemovalRef.current = undefined;
+    const pending = pendingRemovalsRef.current.get(message.payload.requestToken);
+    if (!pending) {
+      reportWorkshopWidgetActionCorrelationIssue(
+        'useWorkshopStandingDirectives',
+        message,
+        'no pending request owns this token'
+      );
+      return;
+    }
+    if (message.payload.widgetId !== pending.widgetId) {
+      reportWorkshopWidgetActionCorrelationIssue(
+        'useWorkshopStandingDirectives',
+        message,
+        `expected widget ${pending.widgetId}`
+      );
+      return;
+    }
+
+    window.clearTimeout(pending.timeoutId);
+    pendingRemovalsRef.current.delete(message.payload.requestToken);
+    syncRemovingWidgetIds();
     const label = workshopWidgetLabel(message.payload.widgetId);
     showToast(message.payload.ok
       ? {
@@ -77,7 +164,13 @@ export function useWorkshopStandingDirectives(
           icon: 'x',
           tone: 'error'
         });
-  }, [showToast]);
+  }, [showToast, syncRemovingWidgetIds]);
 
-  return { remove, handleActionResult, persistedState: {} };
+  return {
+    removingWidgetIds,
+    remove,
+    handleActionResult,
+    formatSummary: formatStandingDirectiveSummary,
+    persistedState: {}
+  };
 }

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/useWorkshopStandingDirectives.ts
@@ -1,0 +1,83 @@
+/** Generic webview owner for standing-directive lifecycle actions. */
+
+import * as React from 'react';
+import { WorkshopToastState } from '@components/workshop/WorkshopToast';
+import { useVSCodeApi } from '@hooks/useVSCodeApi';
+import {
+  createWorkshopWidgetActionRequestToken
+} from '@hooks/domain/workshop/createWorkshopWidgetActionRequestToken';
+import {
+  MessageType,
+  WorkshopStandingDirectiveFamily,
+  WorkshopWidgetActionResultMessage
+} from '@messages';
+import { workshopWidgetLabel } from '@shared/constants/workshopWidgets';
+
+export type StandingDirectiveIdentity = {
+  [Family in WorkshopStandingDirectiveFamily]: {
+    family: Family;
+    widgetId: Family;
+  }
+}[WorkshopStandingDirectiveFamily];
+
+export interface WorkshopStandingDirectiveActions {
+  remove: (directive: StandingDirectiveIdentity) => void;
+  handleActionResult: (message: WorkshopWidgetActionResultMessage) => void;
+}
+
+export interface WorkshopStandingDirectivePersistence {
+  // Host/session storage owns every durable value in this domain.
+}
+
+export type UseWorkshopStandingDirectivesReturn = WorkshopStandingDirectiveActions & {
+  persistedState: WorkshopStandingDirectivePersistence;
+};
+
+export function useWorkshopStandingDirectives(
+  showToast: (toast: WorkshopToastState) => void
+): UseWorkshopStandingDirectivesReturn {
+  const vscode = useVSCodeApi();
+  const pendingRemovalRef = React.useRef<{
+    requestToken: string;
+    widgetId: StandingDirectiveIdentity['widgetId'];
+  }>();
+
+  const remove = React.useCallback((directive: StandingDirectiveIdentity) => {
+    const requestToken = createWorkshopWidgetActionRequestToken('remove-standing');
+    pendingRemovalRef.current = { requestToken, widgetId: directive.widgetId };
+    vscode.postMessage({
+      type: MessageType.WORKSHOP_REMOVE_STANDING_WIDGET,
+      source: 'webview.workshop.standing-directives',
+      payload: { requestToken, family: directive.family },
+      timestamp: Date.now()
+    });
+  }, [vscode]);
+
+  const handleActionResult = React.useCallback((message: WorkshopWidgetActionResultMessage) => {
+    const pending = pendingRemovalRef.current;
+    if (
+      message.payload.action !== 'remove-standing'
+      || message.payload.requestToken !== pending?.requestToken
+      || message.payload.widgetId !== pending.widgetId
+    ) {
+      return;
+    }
+
+    pendingRemovalRef.current = undefined;
+    const label = workshopWidgetLabel(message.payload.widgetId);
+    showToast(message.payload.ok
+      ? {
+          message: message.payload.removed
+            ? `${label} removed.`
+            : `${label} was already removed.`,
+          icon: message.payload.removed ? 'check' : 'info'
+        }
+      : {
+          message: message.payload.message ?? `${label} could not be removed.`,
+          icon: 'x',
+          tone: 'error'
+        });
+  }, [showToast]);
+
+  return { remove, handleActionResult, persistedState: {} };
+}

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/widgets/useGesturePlayground.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/widgets/useGesturePlayground.ts
@@ -7,6 +7,9 @@ import {
   createWorkshopWidgetActionRequestToken
 } from '@hooks/domain/workshop/createWorkshopWidgetActionRequestToken';
 import {
+  reportWorkshopWidgetActionCorrelationIssue
+} from '@hooks/domain/workshop/reportWorkshopWidgetActionCorrelationIssue';
+import {
   MessageType,
   WorkshopCommitWidgetPayload,
   WorkshopGesturePlaygroundGeneratePayload,
@@ -108,14 +111,32 @@ export function useGesturePlayground(): UseGesturePlaygroundReturn {
 
   const handleWidgetActionResult = React.useCallback(
     (message: WorkshopWidgetActionResultMessage) => {
-      if (
-        message.payload.action === 'commit'
-        && message.payload.widgetId === 'gesture-playground'
-        && message.payload.requestToken === latestCommitRequestTokenRef.current
-      ) {
-        latestCommitRequestTokenRef.current = undefined;
-        setWidgetActionResult(message.payload);
+      const requestToken = message.payload.requestToken;
+      const widgetId: string = message.payload.widgetId;
+      if (message.payload.action !== 'commit') {
+        return;
       }
+      const expectedToken = latestCommitRequestTokenRef.current;
+      if (widgetId !== 'gesture-playground') {
+        if (requestToken === expectedToken) {
+          reportWorkshopWidgetActionCorrelationIssue(
+            'useGesturePlayground',
+            message,
+            'expected widget gesture-playground'
+          );
+        }
+        return;
+      }
+      if (requestToken !== expectedToken) {
+        reportWorkshopWidgetActionCorrelationIssue(
+          'useGesturePlayground',
+          message,
+          'no current commit request owns this token'
+        );
+        return;
+      }
+      latestCommitRequestTokenRef.current = undefined;
+      setWidgetActionResult(message.payload);
     },
     []
   );

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/widgets/useGesturePlayground.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/widgets/useGesturePlayground.ts
@@ -4,29 +4,34 @@ import * as React from 'react';
 import { useVSCodeApi } from '@hooks/useVSCodeApi';
 import { createCancelRequestMessage } from '@shared/streamingCancelMessages';
 import {
+  createWorkshopWidgetActionRequestToken
+} from '@hooks/domain/workshop/createWorkshopWidgetActionRequestToken';
+import {
   MessageType,
   WorkshopCommitWidgetPayload,
+  WorkshopGesturePlaygroundGeneratePayload,
+  WorkshopGesturePlaygroundGenerationProgressMessage,
+  WorkshopGesturePlaygroundGenerationProgressPayload,
+  WorkshopGesturePlaygroundMenuResultMessage,
+  WorkshopGesturePlaygroundMenuResultPayload,
   WorkshopWidgetActionResultMessage,
-  WorkshopWidgetActionResultPayload,
-  WorkshopWidgetGeneratePayload,
-  WorkshopWidgetGenerationProgressMessage,
-  WorkshopWidgetGenerationProgressPayload,
-  WorkshopWidgetMenuResultMessage,
-  WorkshopWidgetMenuResultPayload
+  WorkshopWidgetActionResultPayload
 } from '@messages';
 
 export interface GesturePlaygroundState {
-  widgetMenuResult: WorkshopWidgetMenuResultPayload | null;
-  widgetGenerationProgress: WorkshopWidgetGenerationProgressPayload | null;
+  widgetMenuResult: WorkshopGesturePlaygroundMenuResultPayload | null;
+  widgetGenerationProgress: WorkshopGesturePlaygroundGenerationProgressPayload | null;
   widgetActionResult: WorkshopWidgetActionResultPayload | null;
 }
 
 export interface GesturePlaygroundActions {
-  generateWidgetMenu: (payload: WorkshopWidgetGeneratePayload) => void;
+  generateWidgetMenu: (payload: WorkshopGesturePlaygroundGeneratePayload) => void;
   cancelWidgetGenerate: (requestId: string) => void;
-  commitWidget: (payload: WorkshopCommitWidgetPayload) => void;
-  handleWidgetMenuResult: (message: WorkshopWidgetMenuResultMessage) => void;
-  handleWidgetGenerationProgress: (message: WorkshopWidgetGenerationProgressMessage) => void;
+  commitWidget: (payload: Omit<WorkshopCommitWidgetPayload, 'requestToken'>) => void;
+  handleWidgetMenuResult: (message: WorkshopGesturePlaygroundMenuResultMessage) => void;
+  handleWidgetGenerationProgress: (
+    message: WorkshopGesturePlaygroundGenerationProgressMessage
+  ) => void;
   handleWidgetActionResult: (message: WorkshopWidgetActionResultMessage) => void;
   consumeWidgetActionResult: () => void;
 }
@@ -42,10 +47,11 @@ export type UseGesturePlaygroundReturn = GesturePlaygroundState &
 
 export function useGesturePlayground(): UseGesturePlaygroundReturn {
   const vscode = useVSCodeApi();
+  const latestCommitRequestTokenRef = React.useRef<string>();
   const [widgetMenuResult, setWidgetMenuResult] =
-    React.useState<WorkshopWidgetMenuResultPayload | null>(null);
+    React.useState<WorkshopGesturePlaygroundMenuResultPayload | null>(null);
   const [widgetGenerationProgress, setWidgetGenerationProgress] =
-    React.useState<WorkshopWidgetGenerationProgressPayload | null>(null);
+    React.useState<WorkshopGesturePlaygroundGenerationProgressPayload | null>(null);
   const [widgetActionResult, setWidgetActionResult] =
     React.useState<WorkshopWidgetActionResultPayload | null>(null);
 
@@ -58,25 +64,33 @@ export function useGesturePlayground(): UseGesturePlaygroundReturn {
     });
   }, [vscode]);
 
-  const generateWidgetMenu = React.useCallback((payload: WorkshopWidgetGeneratePayload) => {
+  const generateWidgetMenu = React.useCallback((payload: WorkshopGesturePlaygroundGeneratePayload) => {
     setWidgetMenuResult(null);
     setWidgetGenerationProgress(null);
-    post(MessageType.WORKSHOP_WIDGET_GENERATE, payload);
+    post(MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATE, payload);
   }, [post]);
 
   const cancelWidgetGenerate = React.useCallback((requestId: string) => {
     vscode.postMessage(
-      createCancelRequestMessage('workshop-widget', requestId, 'webview.workshop.widget')
+      createCancelRequestMessage(
+        'workshop-gesture-playground',
+        requestId,
+        'webview.workshop.gesture-playground'
+      )
     );
   }, [vscode]);
 
-  const commitWidget = React.useCallback((payload: WorkshopCommitWidgetPayload) => {
+  const commitWidget = React.useCallback((
+    payload: Omit<WorkshopCommitWidgetPayload, 'requestToken'>
+  ) => {
+    const requestToken = createWorkshopWidgetActionRequestToken('commit');
+    latestCommitRequestTokenRef.current = requestToken;
     setWidgetActionResult(null);
-    post(MessageType.WORKSHOP_COMMIT_WIDGET, payload);
+    post(MessageType.WORKSHOP_COMMIT_WIDGET, { ...payload, requestToken });
   }, [post]);
 
   const handleWidgetMenuResult = React.useCallback(
-    (message: WorkshopWidgetMenuResultMessage) => {
+    (message: WorkshopGesturePlaygroundMenuResultMessage) => {
       setWidgetMenuResult(message.payload);
       setWidgetGenerationProgress((current) =>
         current?.token === message.payload.token ? null : current
@@ -86,7 +100,7 @@ export function useGesturePlayground(): UseGesturePlaygroundReturn {
   );
 
   const handleWidgetGenerationProgress = React.useCallback(
-    (message: WorkshopWidgetGenerationProgressMessage) => {
+    (message: WorkshopGesturePlaygroundGenerationProgressMessage) => {
       setWidgetGenerationProgress(message.payload);
     },
     []
@@ -97,7 +111,9 @@ export function useGesturePlayground(): UseGesturePlaygroundReturn {
       if (
         message.payload.action === 'commit'
         && message.payload.widgetId === 'gesture-playground'
+        && message.payload.requestToken === latestCommitRequestTokenRef.current
       ) {
+        latestCommitRequestTokenRef.current = undefined;
         setWidgetActionResult(message.payload);
       }
     },

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/widgets/useLexicalGravity.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/widgets/useLexicalGravity.ts
@@ -3,6 +3,9 @@
 import * as React from 'react';
 import { useVSCodeApi } from '@hooks/useVSCodeApi';
 import {
+  createWorkshopWidgetActionRequestToken
+} from '@hooks/domain/workshop/createWorkshopWidgetActionRequestToken';
+import {
   MessageType,
   WorkshopLexicalGravityDraft,
   WorkshopLexicalGravityLens,
@@ -13,7 +16,6 @@ import {
   WorkshopLexicalGravityPreviewResultPayload,
   WorkshopLexicalGravityLensesSavedMessage,
   WorkshopLexicalGravityLensesSavedPayload,
-  WorkshopStandingDirectiveFamily,
   WorkshopWidgetActionResultMessage,
   WorkshopWidgetActionResultPayload
 } from '@messages';
@@ -38,7 +40,6 @@ export interface LexicalGravityActions {
     candidateIds: string[]
   ) => void;
   apply: (draft: WorkshopLexicalGravityDraft, widgetConfigId?: string) => void;
-  remove: (family: WorkshopStandingDirectiveFamily) => void;
   handleLensesData: (message: WorkshopLexicalGravityLensesDataMessage) => void;
   handlePreviewResult: (message: WorkshopLexicalGravityPreviewResultMessage) => void;
   handleCandidates: (message: WorkshopLexicalGravityLensCandidatesMessage) => void;
@@ -58,6 +59,7 @@ export type UseLexicalGravityReturn = LexicalGravityState & LexicalGravityAction
 
 export function useLexicalGravity(): UseLexicalGravityReturn {
   const vscode = useVSCodeApi();
+  const latestApplyRequestTokenRef = React.useRef<string>();
   const [lenses, setLenses] = React.useState<WorkshopLexicalGravityLens[]>([]);
   const [storagePath, setStoragePath] = React.useState<string>();
   const [catalogError, setCatalogError] = React.useState<string>();
@@ -98,14 +100,15 @@ export function useLexicalGravity(): UseLexicalGravityReturn {
     draft: WorkshopLexicalGravityDraft,
     widgetConfigId?: string
   ) => {
+    const requestToken = createWorkshopWidgetActionRequestToken('apply-standing');
+    latestApplyRequestTokenRef.current = requestToken;
+    setActionResult(null);
     post(MessageType.WORKSHOP_APPLY_STANDING_WIDGET, {
+      requestToken,
       widgetId: 'lexical-gravity',
       draft,
       widgetConfigId
     });
-  }, [post]);
-  const remove = React.useCallback((family: WorkshopStandingDirectiveFamily) => {
-    post(MessageType.WORKSHOP_REMOVE_STANDING_WIDGET, { family });
   }, [post]);
 
   const handleLensesData = React.useCallback((message: WorkshopLexicalGravityLensesDataMessage) => {
@@ -123,7 +126,14 @@ export function useLexicalGravity(): UseLexicalGravityReturn {
     setLensesSaved(message.payload);
   }, []);
   const handleActionResult = React.useCallback((message: WorkshopWidgetActionResultMessage) => {
-    if (message.payload.action === 'apply-standing') {setActionResult(message.payload);}
+    if (
+      message.payload.action === 'apply-standing'
+      && message.payload.widgetId === 'lexical-gravity'
+      && message.payload.requestToken === latestApplyRequestTokenRef.current
+    ) {
+      latestApplyRequestTokenRef.current = undefined;
+      setActionResult(message.payload);
+    }
   }, []);
   const clearTransientResults = React.useCallback(() => {
     setPreviewResult(null);
@@ -146,7 +156,6 @@ export function useLexicalGravity(): UseLexicalGravityReturn {
     buildLens,
     saveLenses,
     apply,
-    remove,
     handleLensesData,
     handlePreviewResult,
     handleCandidates,

--- a/packages/core/src/presentation/webview/hooks/domain/workshop/widgets/useLexicalGravity.ts
+++ b/packages/core/src/presentation/webview/hooks/domain/workshop/widgets/useLexicalGravity.ts
@@ -6,6 +6,9 @@ import {
   createWorkshopWidgetActionRequestToken
 } from '@hooks/domain/workshop/createWorkshopWidgetActionRequestToken';
 import {
+  reportWorkshopWidgetActionCorrelationIssue
+} from '@hooks/domain/workshop/reportWorkshopWidgetActionCorrelationIssue';
+import {
   MessageType,
   WorkshopLexicalGravityDraft,
   WorkshopLexicalGravityLens,
@@ -126,14 +129,32 @@ export function useLexicalGravity(): UseLexicalGravityReturn {
     setLensesSaved(message.payload);
   }, []);
   const handleActionResult = React.useCallback((message: WorkshopWidgetActionResultMessage) => {
-    if (
-      message.payload.action === 'apply-standing'
-      && message.payload.widgetId === 'lexical-gravity'
-      && message.payload.requestToken === latestApplyRequestTokenRef.current
-    ) {
-      latestApplyRequestTokenRef.current = undefined;
-      setActionResult(message.payload);
+    const requestToken = message.payload.requestToken;
+    const widgetId: string = message.payload.widgetId;
+    if (message.payload.action !== 'apply-standing') {
+      return;
     }
+    const expectedToken = latestApplyRequestTokenRef.current;
+    if (widgetId !== 'lexical-gravity') {
+      if (requestToken === expectedToken) {
+        reportWorkshopWidgetActionCorrelationIssue(
+          'useLexicalGravity',
+          message,
+          'expected widget lexical-gravity'
+        );
+      }
+      return;
+    }
+    if (requestToken !== expectedToken) {
+      reportWorkshopWidgetActionCorrelationIssue(
+        'useLexicalGravity',
+        message,
+        'no current apply request owns this token'
+      );
+      return;
+    }
+    latestApplyRequestTokenRef.current = undefined;
+    setActionResult(message.payload);
   }, []);
   const clearTransientResults = React.useCallback(() => {
     setPreviewResult(null);

--- a/packages/core/src/presentation/webview/hooks/useWorkshopAppMessageRouter.ts
+++ b/packages/core/src/presentation/webview/hooks/useWorkshopAppMessageRouter.ts
@@ -8,7 +8,6 @@ import type {
   SaveResultSuccessMessage,
   StatusMessage
 } from '@messages';
-import type { WorkshopToastState } from '@components/workshop/WorkshopToast';
 import type { UseAccountBalanceReturn } from '@hooks/domain/useAccountBalance';
 import type { UseModelsSettingsReturn } from '@hooks/domain/useModelsSettings';
 import type { UseStartupNoticeReturn } from '@hooks/domain/useStartupNotice';
@@ -26,6 +25,9 @@ import type {
 import type {
   UseLexicalGravityReturn
 } from '@hooks/domain/workshop/widgets/useLexicalGravity';
+import type {
+  UseWorkshopStandingDirectivesReturn
+} from '@hooks/domain/workshop/useWorkshopStandingDirectives';
 import {
   dispatchWorkshopWidgetActionResult
 } from '@hooks/domain/workshop/dispatchWorkshopWidgetActionResult';
@@ -36,12 +38,12 @@ export interface WorkshopAppMessageRouterDeps {
   widgetHost: UseWorkshopWidgetHostReturn;
   gesturePlayground: UseGesturePlaygroundReturn;
   lexicalGravity: UseLexicalGravityReturn;
+  standingDirectives: UseWorkshopStandingDirectivesReturn;
   excerptVerify: UseWorkshopExcerptVerifyReturn;
   modelsSettings: UseModelsSettingsReturn;
   tokenTracking: UseTokenTrackingReturn;
   accountBalance: UseAccountBalanceReturn;
   startupNotice: UseStartupNoticeReturn;
-  showToast: (toast: WorkshopToastState) => void;
   handleApiKeyStatus: (message: ApiKeyStatusMessage) => void;
   handleStatusMessage: (message: StatusMessage) => void;
   handleErrorMessage: (message: ErrorMessage) => void;
@@ -57,12 +59,12 @@ export function buildWorkshopAppMessageRoutes(
     widgetHost,
     gesturePlayground,
     lexicalGravity,
+    standingDirectives,
     excerptVerify,
     modelsSettings,
     tokenTracking,
     accountBalance,
     startupNotice,
-    showToast,
     handleApiKeyStatus,
     handleStatusMessage,
     handleErrorMessage,
@@ -80,15 +82,16 @@ export function buildWorkshopAppMessageRoutes(
     [MessageType.WORKSHOP_CONTEXT_CATALOG]: workshop.handleContextCatalog,
     [MessageType.WORKSHOP_CONTEXT_ATTACHMENT_CONTENT]: workshop.handleContextAttachmentContent,
     [MessageType.WORKSHOP_CONTEXT_SEARCH_RESULTS]: workshop.handleContextSearchResults,
-    [MessageType.WORKSHOP_WIDGET_MENU_RESULT]: gesturePlayground.handleWidgetMenuResult,
+    [MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT]:
+      gesturePlayground.handleWidgetMenuResult,
     [MessageType.WORKSHOP_WIDGET_CONFIG_DATA]: widgetHost.handleWidgetConfigData,
-    [MessageType.WORKSHOP_WIDGET_GENERATION_PROGRESS]:
+    [MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS]:
       gesturePlayground.handleWidgetGenerationProgress,
     [MessageType.WORKSHOP_WIDGET_ACTION_RESULT]: (message) => {
       dispatchWorkshopWidgetActionResult(message, {
         handleGestureActionResult: gesturePlayground.handleWidgetActionResult,
         handleLexicalActionResult: lexicalGravity.handleActionResult,
-        showToast
+        handleStandingDirectiveActionResult: standingDirectives.handleActionResult
       });
     },
     [MessageType.WORKSHOP_LEXICAL_GRAVITY_LENSES_DATA]: lexicalGravity.handleLensesData,

--- a/packages/core/src/shared/streamingCancelMessages.ts
+++ b/packages/core/src/shared/streamingCancelMessages.ts
@@ -3,7 +3,7 @@ import {
   CancelCategorySearchRequestMessage,
   CancelContextRequestMessage,
   CancelDictionaryRequestMessage,
-  CancelWidgetGenerateRequestMessage,
+  CancelGesturePlaygroundGenerateRequestMessage,
   CancelWorkshopRequestMessage,
   MessageType,
   StreamingDomain
@@ -14,7 +14,7 @@ export type CancelRequestMessage =
   | CancelDictionaryRequestMessage
   | CancelContextRequestMessage
   | CancelCategorySearchRequestMessage
-  | CancelWidgetGenerateRequestMessage
+  | CancelGesturePlaygroundGenerateRequestMessage
   | CancelWorkshopRequestMessage;
 
 /**
@@ -31,7 +31,7 @@ const cancelMessageTypes: Record<CancellableStreamingDomain, CancelRequestMessag
   search: MessageType.CANCEL_CATEGORY_SEARCH_REQUEST,
   workshop: MessageType.CANCEL_WORKSHOP_REQUEST,
   'workshop-context': MessageType.CANCEL_WORKSHOP_REQUEST,
-  'workshop-widget': MessageType.CANCEL_WIDGET_GENERATE_REQUEST
+  'workshop-gesture-playground': MessageType.CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST
 };
 
 export function createCancelRequestMessage(

--- a/packages/core/src/shared/types/messages/base.ts
+++ b/packages/core/src/shared/types/messages/base.ts
@@ -156,9 +156,9 @@ export enum MessageType {
   WORKSHOP_SESSION_SAVE_STATUS = 'workshop_session_save_status',
 
   // Conversation Widgets (ADR 2026-07-22; Sprint 01 widget host + Gesture Playground)
-  WORKSHOP_WIDGET_GENERATE = 'workshop_widget_generate',
-  WORKSHOP_WIDGET_GENERATION_PROGRESS = 'workshop_widget_generation_progress',
-  WORKSHOP_WIDGET_MENU_RESULT = 'workshop_widget_menu_result',
+  WORKSHOP_GESTURE_PLAYGROUND_GENERATE = 'workshop_gesture_playground_generate',
+  WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS = 'workshop_gesture_playground_generation_progress',
+  WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT = 'workshop_gesture_playground_menu_result',
   WORKSHOP_REQUEST_LEXICAL_GRAVITY_LENSES = 'workshop_request_lexical_gravity_lenses',
   WORKSHOP_LEXICAL_GRAVITY_LENSES_DATA = 'workshop_lexical_gravity_lenses_data',
   WORKSHOP_PREVIEW_LEXICAL_GRAVITY = 'workshop_preview_lexical_gravity',
@@ -173,7 +173,7 @@ export enum MessageType {
   WORKSHOP_APPLY_STANDING_WIDGET = 'workshop_apply_standing_widget',
   WORKSHOP_REMOVE_STANDING_WIDGET = 'workshop_remove_standing_widget',
   WORKSHOP_WIDGET_ACTION_RESULT = 'workshop_widget_action_result',
-  CANCEL_WIDGET_GENERATE_REQUEST = 'cancel_widget_generate_request'
+  CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST = 'cancel_gesture_playground_generate_request'
 }
 
 export interface BaseMessage {

--- a/packages/core/src/shared/types/messages/index.ts
+++ b/packages/core/src/shared/types/messages/index.ts
@@ -172,10 +172,10 @@ import {
   WorkshopSessionsDataMessage,
   WorkshopSessionActionResultMessage,
   WorkshopSessionSaveStatusMessage,
-  WorkshopWidgetGenerateMessage,
-  CancelWidgetGenerateRequestMessage,
-  WorkshopWidgetGenerationProgressMessage,
-  WorkshopWidgetMenuResultMessage,
+  WorkshopGesturePlaygroundGenerateMessage,
+  CancelGesturePlaygroundGenerateRequestMessage,
+  WorkshopGesturePlaygroundGenerationProgressMessage,
+  WorkshopGesturePlaygroundMenuResultMessage,
   WorkshopRequestLexicalGravityLensesMessage,
   WorkshopLexicalGravityLensesDataMessage,
   WorkshopPreviewLexicalGravityMessage,
@@ -274,8 +274,8 @@ export type WebviewToExtensionMessage =
   | WorkshopDuplicateSessionMessage
   | WorkshopRevealSessionMessage
   | WorkshopDeleteSessionMessage
-  | WorkshopWidgetGenerateMessage
-  | CancelWidgetGenerateRequestMessage
+  | WorkshopGesturePlaygroundGenerateMessage
+  | CancelGesturePlaygroundGenerateRequestMessage
   | WorkshopRequestLexicalGravityLensesMessage
   | WorkshopPreviewLexicalGravityMessage
   | WorkshopBuildLexicalGravityLensMessage
@@ -324,8 +324,8 @@ export type ExtensionToWebviewMessage =
   | WorkshopContextCatalogMessage
   | WorkshopContextSearchResultsMessage
   | WorkshopContextAttachmentContentMessage
-  | WorkshopWidgetGenerationProgressMessage
-  | WorkshopWidgetMenuResultMessage
+  | WorkshopGesturePlaygroundGenerationProgressMessage
+  | WorkshopGesturePlaygroundMenuResultMessage
   | WorkshopLexicalGravityLensesDataMessage
   | WorkshopLexicalGravityPreviewResultMessage
   | WorkshopLexicalGravityLensCandidatesMessage

--- a/packages/core/src/shared/types/messages/streaming.ts
+++ b/packages/core/src/shared/types/messages/streaming.ts
@@ -16,7 +16,7 @@ export type StreamingDomain =
   | 'search'
   | 'workshop'
   | 'workshop-context'
-  | 'workshop-widget';
+  | 'workshop-gesture-playground';
 
 /**
  * Payload for STREAM_CHUNK messages

--- a/packages/core/src/shared/types/messages/workshop.ts
+++ b/packages/core/src/shared/types/messages/workshop.ts
@@ -1765,8 +1765,8 @@ export interface WorkshopSessionSaveStatusMessage extends MessageEnvelope<{
  * so a regenerate race resolves to the latest request (stale results are
  * dropped).
  */
-interface WorkshopWidgetGenerateBasePayload {
-  widgetId: WorkshopWidgetId;
+interface WorkshopGesturePlaygroundGenerateBasePayload {
+  widgetId: 'gesture-playground';
   token: string;
   targetPhrase: string;
   writerInstructions: string;
@@ -1775,25 +1775,27 @@ interface WorkshopWidgetGenerateBasePayload {
   sourceReferences: WorkshopWidgetSourceReference[];
 }
 
-export type WorkshopWidgetGeneratePayload =
-  | (WorkshopWidgetGenerateBasePayload & { mode: 'full' })
-  | (WorkshopWidgetGenerateBasePayload & {
+export type WorkshopGesturePlaygroundGeneratePayload =
+  | (WorkshopGesturePlaygroundGenerateBasePayload & { mode: 'full' })
+  | (WorkshopGesturePlaygroundGenerateBasePayload & {
       mode: 'more';
       dictionaryMarkdown: string;
       menu: WorkshopGestureMenuGroup[];
     });
 
-export interface WorkshopWidgetGenerateMessage extends MessageEnvelope<WorkshopWidgetGeneratePayload> {
-  type: MessageType.WORKSHOP_WIDGET_GENERATE;
+export interface WorkshopGesturePlaygroundGenerateMessage
+  extends MessageEnvelope<WorkshopGesturePlaygroundGeneratePayload> {
+  type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATE;
 }
 
 /** Abandon the in-flight generate call (modal closed, or superseded). */
-export interface CancelWidgetGenerateRequestMessage extends MessageEnvelope<CancelRequestPayload> {
-  type: MessageType.CANCEL_WIDGET_GENERATE_REQUEST;
+export interface CancelGesturePlaygroundGenerateRequestMessage
+  extends MessageEnvelope<CancelRequestPayload> {
+  type: MessageType.CANCEL_GESTURE_PLAYGROUND_GENERATE_REQUEST;
 }
 
-export interface WorkshopWidgetGenerationProgressPayload {
-  widgetId: WorkshopWidgetId;
+export interface WorkshopGesturePlaygroundGenerationProgressPayload {
+  widgetId: 'gesture-playground';
   token: string;
   phase: 'started' | 'streaming' | 'completed' | 'cancelled';
   stage: 'requesting' | 'dictionary' | 'menu' | 'validating';
@@ -1805,13 +1807,13 @@ export interface WorkshopWidgetGenerationProgressPayload {
   outputTokenLimit: number;
 }
 
-export interface WorkshopWidgetGenerationProgressMessage
-  extends MessageEnvelope<WorkshopWidgetGenerationProgressPayload> {
-  type: MessageType.WORKSHOP_WIDGET_GENERATION_PROGRESS;
+export interface WorkshopGesturePlaygroundGenerationProgressMessage
+  extends MessageEnvelope<WorkshopGesturePlaygroundGenerationProgressPayload> {
+  type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_GENERATION_PROGRESS;
 }
 
-export interface WorkshopWidgetMenuResultPayload {
-  widgetId: WorkshopWidgetId;
+export interface WorkshopGesturePlaygroundMenuResultPayload {
+  widgetId: 'gesture-playground';
   token: string;
   mode: 'full' | 'more';
   ok: boolean;
@@ -1826,8 +1828,9 @@ export interface WorkshopWidgetMenuResultPayload {
   truncated?: boolean;
 }
 
-export interface WorkshopWidgetMenuResultMessage extends MessageEnvelope<WorkshopWidgetMenuResultPayload> {
-  type: MessageType.WORKSHOP_WIDGET_MENU_RESULT;
+export interface WorkshopGesturePlaygroundMenuResultMessage
+  extends MessageEnvelope<WorkshopGesturePlaygroundMenuResultPayload> {
+  type: MessageType.WORKSHOP_GESTURE_PLAYGROUND_MENU_RESULT;
 }
 
 export interface WorkshopRequestLexicalGravityLensesMessage
@@ -1937,44 +1940,73 @@ export interface WorkshopWidgetConfigDataMessage extends MessageEnvelope<{
  * exploration cloud in `draft.menu` is persisted for chip re-hydration but
  * never enters the prompt.
  */
-export interface WorkshopCommitWidgetPayload {
-  widgetId: WorkshopWidgetId;
+export interface WorkshopGesturePlaygroundCommitPayload {
+  widgetId: 'gesture-playground';
+  requestToken: string;
   draft: WorkshopGestureDraft;
   /** Present on clone-and-recommit: the config this Draft was re-opened from. */
   clonedFromConfigId?: string;
 }
 
+/** Family rail contract; each supported one-shot widget contributes one exact arm. */
+export type WorkshopCommitWidgetPayload = WorkshopGesturePlaygroundCommitPayload;
+
 export interface WorkshopCommitWidgetMessage extends MessageEnvelope<WorkshopCommitWidgetPayload> {
   type: MessageType.WORKSHOP_COMMIT_WIDGET;
 }
 
+export interface WorkshopLexicalGravityApplyStandingWidgetPayload {
+  requestToken: string;
+  widgetId: 'lexical-gravity';
+  draft: WorkshopLexicalGravityDraft;
+  /** Present for edit-in-place; omitted for a first install. */
+  widgetConfigId?: string;
+}
+
+/** Each live standing feature contributes one exact widget/draft arm. */
+export type WorkshopApplyStandingWidgetPayload =
+  WorkshopLexicalGravityApplyStandingWidgetPayload;
+
 export interface WorkshopApplyStandingWidgetMessage
-  extends MessageEnvelope<{
-    widgetId: 'lexical-gravity';
-    draft: WorkshopLexicalGravityDraft;
-    /** Present for edit-in-place; omitted for a first install. */
-    widgetConfigId?: string;
-  }> {
+  extends MessageEnvelope<WorkshopApplyStandingWidgetPayload> {
   type: MessageType.WORKSHOP_APPLY_STANDING_WIDGET;
 }
 
+export interface WorkshopRemoveStandingWidgetPayload {
+  requestToken: string;
+  family: WorkshopStandingDirectiveFamily;
+}
+
 export interface WorkshopRemoveStandingWidgetMessage
-  extends MessageEnvelope<{ family: WorkshopStandingDirectiveFamily }> {
+  extends MessageEnvelope<WorkshopRemoveStandingWidgetPayload> {
   type: MessageType.WORKSHOP_REMOVE_STANDING_WIDGET;
 }
 
-export interface WorkshopWidgetActionResultPayload {
-  action: 'commit' | 'apply-standing' | 'remove-standing';
-  widgetId: WorkshopWidgetId;
+interface WorkshopWidgetActionResultBase {
+  requestToken: string;
   ok: boolean;
   widgetConfigId?: string;
   directiveId?: string;
   turnId?: string;
-  /** Distinguishes a real removal from an idempotent no-op. */
-  removed?: boolean;
   /** User-facing failure text when ok is false. */
   message?: string;
 }
+
+export type WorkshopWidgetActionResultPayload =
+  | (WorkshopWidgetActionResultBase & {
+      action: 'commit';
+      widgetId: 'gesture-playground';
+    })
+  | (WorkshopWidgetActionResultBase & {
+      action: 'apply-standing';
+      widgetId: 'lexical-gravity';
+    })
+  | (WorkshopWidgetActionResultBase & {
+      action: 'remove-standing';
+      widgetId: 'lexical-gravity' | 'prose-controller';
+      /** Distinguishes a real removal from an idempotent no-op. */
+      removed?: boolean;
+    });
 
 export interface WorkshopWidgetActionResultMessage
   extends MessageEnvelope<WorkshopWidgetActionResultPayload> {


### PR DESCRIPTION
## Summary

- move generic standing apply/remove routes from Lexical Gravity into `WorkshopStandingDirectiveHandler`
- add a closed standing-operations registry while keeping feature semantics in the Lexical slice
- make Gesture message names and widget payload identities exact
- correlate commit/apply/remove acknowledgements by request token and widget identity
- add the generic standing presentation hook, architecture witnesses, and a test-only second-family lifecycle fixture

## Architecture notes

- preserves the standing transaction kernel: serialization, between-run guard, frame replacement before commit, and aggregate atomicity
- keeps `WORKSHOP_COMMIT_WIDGET` as the generic one-shot rail
- does not change persisted checkpoint shapes or `extension.ts`
- records the accepted D4/D5 ADR clarifications and closes all Phase-2 migration exceptions
- documents the analysis, decisions, implementation outcome, and verification in the Sprint 02 runway

## Review resolution

- resolve token-correlation races with token-keyed removals, duplicate guards, per-row pending state, diagnostics, and a visible timeout
- keep application operations and host validation out of the standing rail's webview dependency graph
- replace the apply registry cast with explicit union plus exhaustive `switch`/`never` dispatch
- catch runtime family misses inside the acknowledgement boundary and resync state before post-commit guard failures
- add regressions for concurrent removals, stale/foreign acknowledgements, timeouts, runtime registry misses, and cross-widget results
- record F-01 through F-11 as addressed in the PR review; defer only the historical single-commit shape rather than force-rewrite published history

## Verification

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`
- `npm test -- --runInBand` — 168 suites, 1,818 tests, 1 snapshot passed
- emitted webview bundle inspection — host-only Lexical validation and standing-registry error strings absent
